### PR TITLE
ci(backend): re-enable pytest gate (drop continue-on-error)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,33 +46,6 @@ jobs:
       - name: Compile all
         run: python -m compileall -q app main.py mcp_server.py
 
-      - name: Pytest diagnostic
-        continue-on-error: true
-        env:
-          PYTHONPATH: ${{ github.workspace }}/backend
-        run: |
-          python -c "
-          import os, sys
-          print('cwd:', os.getcwd())
-          print('PYTHONPATH env:', os.environ.get('PYTHONPATH'))
-          print('sys.path[:5]:', sys.path[:5])
-          print('app/ exists:', os.path.isdir('app'))
-          print('app/__init__.py exists:', os.path.isfile('app/__init__.py'))
-          print('app/__init__.py size:', os.path.getsize('app/__init__.py') if os.path.isfile('app/__init__.py') else 'N/A')
-          print('app/models/__init__.py exists:', os.path.isfile('app/models/__init__.py'))
-          print('app/ entries:', sorted(os.listdir('app')) if os.path.isdir('app') else 'N/A')
-          try:
-              import app
-              print('import app OK:', app.__file__, app.__path__)
-          except Exception as e:
-              print('import app failed:', repr(e))
-          try:
-              import app.models
-              print('import app.models OK')
-          except Exception as e:
-              print('import app.models failed:', repr(e))
-          "
-
       - name: Pytest
         env:
           PYTHONPATH: ${{ github.workspace }}/backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,34 @@ jobs:
       - name: Compile all
         run: python -m compileall -q app main.py mcp_server.py
 
-      - name: Pytest
-        # TODO: GitHub-hosted runner에서 sys.path 인식 이슈 — 다음 작업에서 정리.
-        # 로컬 docker (python:3.12-slim) 환경에서는 18 tests pass 확인.
+      - name: Pytest diagnostic
         continue-on-error: true
+        env:
+          PYTHONPATH: ${{ github.workspace }}/backend
+        run: |
+          python -c "
+          import os, sys
+          print('cwd:', os.getcwd())
+          print('PYTHONPATH env:', os.environ.get('PYTHONPATH'))
+          print('sys.path[:5]:', sys.path[:5])
+          print('app/ exists:', os.path.isdir('app'))
+          print('app/__init__.py exists:', os.path.isfile('app/__init__.py'))
+          print('app/__init__.py size:', os.path.getsize('app/__init__.py') if os.path.isfile('app/__init__.py') else 'N/A')
+          print('app/models/__init__.py exists:', os.path.isfile('app/models/__init__.py'))
+          print('app/ entries:', sorted(os.listdir('app')) if os.path.isdir('app') else 'N/A')
+          try:
+              import app
+              print('import app OK:', app.__file__, app.__path__)
+          except Exception as e:
+              print('import app failed:', repr(e))
+          try:
+              import app.models
+              print('import app.models OK')
+          except Exception as e:
+              print('import app.models failed:', repr(e))
+          "
+
+      - name: Pytest
         env:
           PYTHONPATH: ${{ github.workspace }}/backend
         run: python -m pytest -q


### PR DESCRIPTION
## Summary

`feat/iam-self-service` 머지 시점에 backend pytest가 transient sys.path 이슈로
`continue-on-error: true`로 막혀 있었음. 이번 진단 푸시(commit fb6a844, run 27672999538)에서
명시적 `PYTHONPATH=\${{ github.workspace }}/backend` + `python -m pytest -q` 조합으로
**18 tests passed in 0.45s**가 안정적으로 그린.

진단 step을 제거하고 `continue-on-error`를 떼서 정식 게이트로 복원합니다.

## Changes
- `.github/workflows/ci.yml` Pytest step에서 `continue-on-error: true` 제거
- 임시 진단 step 제거 (commit fb6a844에서 추가 → df73945에서 정리)

## Verification
- 마지막 main 머지 직후 CI run 27672999538: **success** (Backend + Frontend 둘 다)
- 이 PR의 CI도 동일 워크플로 — 통과 예상

🤖 Generated with [Claude Code](https://claude.com/claude-code)