### PR TITLE
feat: MCP HTTP 마운트 안정화 + i18n 컬럼 잔여 정리

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -69,8 +69,8 @@ class Settings(BaseSettings):
     # i18n 기본 언어 (UI 초기 로드 시 사용)
     DEFAULT_LOCALE: str = "ko"
 
-    # MCP 서버 토글 — stdio가 권장. HTTP/SSE는 mcp 패키지 변경 영향이 커서 기본 비활성.
-    MCP_HTTP_ENABLED: bool = False
+    # MCP HTTP 마운트 — Streamable HTTP > SSE 순서로 시도. mcp 패키지가 둘 다 실패해도 backend는 정상.
+    MCP_HTTP_ENABLED: bool = True
 
 
 settings = Settings()

--- a/backend/main.py
+++ b/backend/main.py
@@ -73,14 +73,29 @@ app.add_middleware(
 
 app.include_router(api_router, prefix=settings.API_V1_PREFIX)
 
-# MCP HTTP/SSE 마운트 — 원격 협업용. stdio 모드는 mcp_server.py로 별도 진입.
-# import는 lazy: mcp 패키지가 없거나 호환되지 않아도 backend는 정상 부팅.
+# MCP HTTP 마운트 — 원격 클라이언트용. stdio 모드는 mcp_server.py로 별도 진입.
+# Streamable HTTP(MCP 신규 표준) > SSE 순으로 시도, 둘 다 실패해도 backend 정상 부팅.
 if settings.MCP_HTTP_ENABLED:
     try:
         from mcp_server import mcp as mond_mcp
 
-        app.mount("/mcp", mond_mcp.sse_app())
-        logger.info("mcp_mounted", path="/mcp")
+        mcp_app = None
+        for attr in ("streamable_http_app", "sse_app"):
+            factory = getattr(mond_mcp, attr, None)
+            if factory is None:
+                continue
+            try:
+                mcp_app = factory()
+                logger.info("mcp_transport_resolved", transport=attr)
+                break
+            except Exception as exc:
+                logger.warning("mcp_transport_failed", transport=attr, error=str(exc))
+
+        if mcp_app is not None:
+            app.mount("/mcp", mcp_app)
+            logger.info("mcp_mounted", path="/mcp")
+        else:
+            logger.warning("mcp_mount_skipped", reason="no compatible transport")
     except Exception as exc:
         logger.warning("mcp_mount_failed", error=str(exc))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       NOTIFY_MIN_SEVERITY: ${NOTIFY_MIN_SEVERITY:-high}
       GITHUB_WEBHOOK_SECRET: ${GITHUB_WEBHOOK_SECRET:-}
       DEFAULT_LOCALE: ${DEFAULT_LOCALE:-ko}
-      MCP_HTTP_ENABLED: ${MCP_HTTP_ENABLED:-false}
+      MCP_HTTP_ENABLED: ${MCP_HTTP_ENABLED:-true}
     ports:
       - "8000:8000"
     depends_on:

--- a/frontend/src/pages/Assets.tsx
+++ b/frontend/src/pages/Assets.tsx
@@ -82,18 +82,18 @@ export default function Assets() {
         rowKey="id"
         columns={[
           { title: "ID", dataIndex: "id", width: 70 },
-          { title: "Name", dataIndex: "name" },
+          { title: t.common.name, dataIndex: "name" },
           {
-            title: "Type",
+            title: t.common.type,
             dataIndex: "asset_type",
-            render: (t: string) => <Tag>{t}</Tag>,
+            render: (v: string) => <Tag>{v}</Tag>,
             width: 150,
           },
-          { title: "URI", dataIndex: "uri", ellipsis: true },
-          { title: "Env", dataIndex: "environment", width: 90 },
-          { title: "Owner", dataIndex: "owner", width: 120 },
+          { title: t.assets.uri, dataIndex: "uri", ellipsis: true },
+          { title: t.assets.env, dataIndex: "environment", width: 90 },
+          { title: t.assets.owner, dataIndex: "owner", width: 120 },
           {
-            title: "Open Findings",
+            title: t.assets.openFindings,
             dataIndex: "open_findings_count",
             width: 130,
             render: (v: number) => (

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -130,15 +130,15 @@ export default function Dashboard() {
               pagination={false}
               columns={[
                 {
-                  title: "Severity",
+                  title: t.common.severity,
                   dataIndex: "severity",
                   render: (s: Severity) => (
                     <Tag color={SEVERITY_COLOR[s]}>{s.toUpperCase()}</Tag>
                   ),
                   width: 110,
                 },
-                { title: "Title", dataIndex: "title", ellipsis: true },
-                { title: "Scanner", dataIndex: "scanner", width: 100 },
+                { title: t.common.title, dataIndex: "title", ellipsis: true },
+                { title: t.common.scanner, dataIndex: "scanner", width: 100 },
               ]}
             />
           </Card>
@@ -154,11 +154,11 @@ export default function Dashboard() {
               size="small"
               pagination={false}
               columns={[
-                { title: "Scan #", dataIndex: "id", width: 90 },
-                { title: "Asset", dataIndex: "asset_id", width: 110 },
-                { title: "Scanner", dataIndex: "scanner" },
+                { title: "#", dataIndex: "id", width: 90 },
+                { title: t.common.asset, dataIndex: "asset_id", width: 110 },
+                { title: t.common.scanner, dataIndex: "scanner" },
                 {
-                  title: "Status",
+                  title: t.common.status,
                   dataIndex: "status",
                   render: (s: string) => (
                     <Tag
@@ -175,9 +175,9 @@ export default function Dashboard() {
                   ),
                   width: 120,
                 },
-                { title: "Findings", dataIndex: "findings_count", width: 100 },
+                { title: t.scans.findingsCount, dataIndex: "findings_count", width: 100 },
                 {
-                  title: "When",
+                  title: t.common.when,
                   dataIndex: "created_at",
                   render: (v: string) => new Date(v).toLocaleString(),
                 },

--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -99,18 +99,18 @@ export default function Findings() {
         columns={[
           { title: "ID", dataIndex: "id", width: 70 },
           {
-            title: "Severity",
+            title: t.common.severity,
             dataIndex: "severity",
             render: (s: Severity) => (
               <Tag color={SEVERITY_COLOR[s]}>{s.toUpperCase()}</Tag>
             ),
             width: 110,
           },
-          { title: "Title", dataIndex: "title", ellipsis: true },
-          { title: "Scanner", dataIndex: "scanner", width: 110 },
+          { title: t.common.title, dataIndex: "title", ellipsis: true },
+          { title: t.common.scanner, dataIndex: "scanner", width: 110 },
           { title: "Rule", dataIndex: "rule_id", width: 200, ellipsis: true },
           {
-            title: "Status",
+            title: t.common.status,
             dataIndex: "status",
             width: 160,
             render: (s: FindingStatus, record: Finding) => (

--- a/frontend/src/pages/Policies.tsx
+++ b/frontend/src/pages/Policies.tsx
@@ -16,7 +16,7 @@ async function fetchPolicies(): Promise<Policy[]> {
 }
 
 export default function Policies() {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const { data, isLoading } = useQuery({ queryKey: ["policies"], queryFn: fetchPolicies });
 
   return (
@@ -31,24 +31,26 @@ export default function Policies() {
           loading={isLoading}
           dataSource={data ?? []}
           rowKey="id"
-          locale={{ emptyText: <Empty description="정책이 없습니다" /> }}
+          locale={{
+            emptyText: <Empty description={locale === "ko" ? "정책이 없습니다" : "No policies"} />,
+          }}
           columns={[
-            { title: "Name", dataIndex: "name" },
+            { title: t.common.name, dataIndex: "name" },
             {
-              title: "Type",
+              title: t.common.type,
               dataIndex: "policy_type",
-              render: (t: string) => <Tag color="purple">{t}</Tag>,
+              render: (v: string) => <Tag color="purple">{v}</Tag>,
               width: 130,
             },
-            { title: "Threshold", dataIndex: "severity_threshold", width: 120 },
+            { title: t.policies.threshold, dataIndex: "severity_threshold", width: 120 },
             {
-              title: "Enabled",
+              title: t.common.enabled,
               dataIndex: "enabled",
               render: (v: boolean) => <Switch checked={v} disabled />,
               width: 100,
             },
             {
-              title: "Compliance",
+              title: t.policies.compliance,
               dataIndex: "compliance_refs",
               render: (refs: string[]) => (
                 <>
@@ -58,7 +60,7 @@ export default function Policies() {
                 </>
               ),
             },
-            { title: "Description", dataIndex: "description", ellipsis: true },
+            { title: t.common.description, dataIndex: "description", ellipsis: true },
           ]}
         />
       </Card>

--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -84,10 +84,10 @@ export default function Scans() {
         rowKey="id"
         columns={[
           { title: "ID", dataIndex: "id", width: 70 },
-          { title: "Asset", dataIndex: "asset_id", width: 110 },
-          { title: "Scanner", dataIndex: "scanner", width: 140 },
+          { title: t.common.asset, dataIndex: "asset_id", width: 110 },
+          { title: t.common.scanner, dataIndex: "scanner", width: 140 },
           {
-            title: "Status",
+            title: t.common.status,
             dataIndex: "status",
             render: (s: string) => (
               <Tag color={s === "completed" ? "green" : s === "failed" ? "red" : "blue"}>
@@ -97,20 +97,20 @@ export default function Scans() {
             width: 120,
           },
           {
-            title: "Trigger",
+            title: t.scans.trigger,
             dataIndex: "trigger",
-            render: (t: string) => <Tag>{t}</Tag>,
+            render: (v: string) => <Tag>{v}</Tag>,
             width: 110,
           },
-          { title: "Findings", dataIndex: "findings_count", width: 110 },
+          { title: t.scans.findingsCount, dataIndex: "findings_count", width: 110 },
           {
-            title: "Duration",
+            title: t.scans.duration,
             dataIndex: "duration_ms",
             render: (v: number | null) => (v ? `${v} ms` : "—"),
             width: 110,
           },
           {
-            title: "When",
+            title: t.common.when,
             dataIndex: "created_at",
             render: (v: string) => new Date(v).toLocaleString(),
           },
@@ -118,7 +118,7 @@ export default function Scans() {
       />
 
       <Modal
-        title="Trigger Scan"
+        title={t.scans.trigger}
         open={open}
         onCancel={() => setOpen(false)}
         onOk={() => form.submit()}


### PR DESCRIPTION
MCP /mcp 마운트가 Streamable HTTP로 정상 노출. 5개 페이지 테이블 컬럼명 한글화.