### PR TITLE
feat(policies): 한국·글로벌 규제 매핑 정책 템플릿 카탈로그 (ISMS-P·K-EFSA·CSAP·PIPA·ISO 27001·OWASP·CIS)

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -16,6 +16,7 @@ from app.api.v1.endpoints import (
     knowledge,
     policies,
     policy_sim,
+    policy_templates,
     regulations,
     reports,
     scans,
@@ -32,6 +33,7 @@ api_router.include_router(scans.router, prefix="/scans", tags=["Scans"])
 api_router.include_router(findings.router, prefix="/findings", tags=["Findings"])
 api_router.include_router(policies.router, prefix="/policies", tags=["Policies"])
 api_router.include_router(policy_sim.router, prefix="/policy", tags=["Policy Simulation"])
+api_router.include_router(policy_templates.router, prefix="/policy", tags=["Policy Templates"])
 api_router.include_router(regulations.router, tags=["Regulations"])
 api_router.include_router(reports.router, prefix="/reports", tags=["Reports"])
 api_router.include_router(ai.router, prefix="/ai", tags=["AI"])

--- a/backend/app/api/v1/endpoints/policy_templates.py
+++ b/backend/app/api/v1/endpoints/policy_templates.py
@@ -1,0 +1,96 @@
+"""
+🌙 정책 템플릿 카탈로그 — 한국·글로벌 규제 매핑된 정책을 한 번에 install
+
+GET  /policy/templates                       — 전체 카탈로그
+GET  /policy/templates/frameworks            — 프레임워크 목록 (필터 칩)
+POST /policy/templates/install {names: [..]} — 선택 템플릿을 Policy로 일괄 추가 (ADMIN)
+"""
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.deps import require_role
+from app.core.database import get_db
+from app.data.policy_templates import FRAMEWORKS, TEMPLATES, list_templates
+from app.models.policy import Policy
+from app.models.user import Role
+
+router = APIRouter()
+
+
+@router.get("/templates")
+async def get_templates(framework: str | None = Query(None)) -> list[dict]:
+    """카탈로그 조회. framework 쿼리(예: 'ISMS-P')로 필터링."""
+    items = list_templates(framework)
+    # PolicyType enum은 JSON 직렬화 위해 value로
+    return [
+        {
+            **t,
+            "policy_type": t["policy_type"].value,
+        }
+        for t in items
+    ]
+
+
+@router.get("/templates/frameworks")
+async def get_frameworks() -> list[dict]:
+    return FRAMEWORKS
+
+
+class InstallRequest(BaseModel):
+    names: list[str] = Field(default_factory=list)
+
+
+class InstallResult(BaseModel):
+    installed: int
+    skipped_existing: int
+    names: list[str]
+
+
+@router.post(
+    "/templates/install",
+    response_model=InstallResult,
+    dependencies=[Depends(require_role(Role.ADMIN))],
+)
+async def install_templates(
+    payload: InstallRequest,
+    db: AsyncSession = Depends(get_db),
+) -> InstallResult:
+    by_name = {t["name"]: t for t in TEMPLATES}
+    chosen = [n for n in payload.names if n in by_name]
+
+    # 이미 존재하는 정책은 skip
+    existing = {
+        row[0]
+        for row in (await db.execute(select(Policy.name).where(Policy.name.in_(chosen)))).all()
+    }
+    installed = 0
+    actually_added: list[str] = []
+    for name in chosen:
+        if name in existing:
+            continue
+        t = by_name[name]
+        db.add(
+            Policy(
+                name=t["name"],
+                policy_type=t["policy_type"],
+                description=t["description"],
+                enabled=True,
+                severity_threshold=t["severity_threshold"],
+                definition=t["definition"],
+                compliance_refs=t["compliance_refs"],
+            )
+        )
+        installed += 1
+        actually_added.append(name)
+
+    if installed:
+        await db.commit()
+
+    return InstallResult(
+        installed=installed,
+        skipped_existing=len(chosen) - installed,
+        names=actually_added,
+    )

--- a/backend/app/data/policy_templates.py
+++ b/backend/app/data/policy_templates.py
@@ -1,0 +1,206 @@
+"""
+🌙 정책 템플릿 카탈로그 — 한국·글로벌 규제 통제 항목에 매핑된 자동화 가능한 정책 세트
+
+각 템플릿은 Policy 모델로 그대로 install 가능. compliance_refs에 규제 코드를 채워
+Policies 페이지에서 'ISMS-P' 같은 칩으로 필터/검색이 자연스러워진다.
+
+규제 매핑 출처(요약):
+  - ISMS-P (KISA, 정보보호 및 개인정보보호 관리체계 인증) — 2.5 ~ 2.11
+  - K-EFSA (전자금융감독규정)
+  - K-CSAP (공공 클라우드 보안인증)
+  - K-PIPA (개인정보보호법)
+  - ISO/IEC 27001:2022 (Annex A.5 ~ A.8)
+  - OWASP Top 10 2021
+  - CIS Benchmarks
+  - NIST 800-53 / PCI DSS / GDPR (참조)
+"""
+
+from app.models.policy import PolicyType
+
+# 각 템플릿: (slug, name, policy_type, description, severity_threshold, definition, compliance_refs, frameworks)
+# frameworks: 카탈로그 필터링용 (한 템플릿이 여러 규제에 매핑될 수 있다)
+TEMPLATES: list[dict] = [
+    # ─── SCA · 의존성 취약점 ─────────────────────────────────────
+    {
+        "name": "Block Critical CVE in Dependencies",
+        "policy_type": PolicyType.SCA,
+        "description": "의존성에서 CRITICAL 등급 CVE가 발견되면 파이프라인 차단. ISMS-P 2.8.6 / ISO 27001 A.8.8 / OWASP A06 충족.",
+        "severity_threshold": "critical",
+        "definition": {"block_above": "critical", "scope": "dependencies"},
+        "compliance_refs": ["ISMS-P-2.8.6", "ISO-27001-A.8.8", "OWASP-A06", "PCI-DSS-6.3"],
+        "frameworks": ["ISMS-P", "ISO-27001", "OWASP", "PCI-DSS"],
+    },
+    {
+        "name": "Reject EOL / Unsupported Libraries",
+        "policy_type": PolicyType.SCA,
+        "description": "Maintenance가 종료된 라이브러리(EOL) 사용 금지. ISMS-P 2.8.2 / ISO 27001 A.8.30.",
+        "severity_threshold": "high",
+        "definition": {"reject": "eol", "min_release_age_days": 365 * 3},
+        "compliance_refs": ["ISMS-P-2.8.2", "ISO-27001-A.8.30"],
+        "frameworks": ["ISMS-P", "ISO-27001"],
+    },
+
+    # ─── SAST · 시큐어 코딩 ─────────────────────────────────────
+    {
+        "name": "Secure SDLC — SAST Required",
+        "policy_type": PolicyType.SAST,
+        "description": "모든 코드 변경에 정적분석(SAST) 통과 필수. ISMS-P 2.8.1(보안 SDLC) / K-EFSA 8조 / ISO 27001 A.8.25.",
+        "severity_threshold": "high",
+        "definition": {"require_pass": True, "scanners": ["semgrep"]},
+        "compliance_refs": ["ISMS-P-2.8.1", "K-EFSA-8", "ISO-27001-A.8.25"],
+        "frameworks": ["ISMS-P", "K-EFSA", "ISO-27001"],
+    },
+    {
+        "name": "Block OWASP Top 10 in Code",
+        "policy_type": PolicyType.SAST,
+        "description": "OWASP Top 10 룰 위반은 모두 차단. ISMS-P 2.8.1 / OWASP / ISO 27001 A.8.28.",
+        "severity_threshold": "medium",
+        "definition": {"rulesets": ["owasp-top-10"]},
+        "compliance_refs": ["ISMS-P-2.8.1", "OWASP-A01-A10", "ISO-27001-A.8.28"],
+        "frameworks": ["ISMS-P", "OWASP", "ISO-27001"],
+    },
+
+    # ─── IaC / 컨테이너 / 클라우드 설정 ───────────────────────────
+    {
+        "name": "Container Hardening Baseline (CIS Docker)",
+        "policy_type": PolicyType.CONTAINER,
+        "description": "이미지에 HIGH 이상 취약점 누적 금지 + 비루트 사용자. ISMS-P 2.9.3 / ISO 27001 A.8.9 / CIS Docker 4.1.",
+        "severity_threshold": "high",
+        "definition": {"block_above": "high", "deny_root_user": True},
+        "compliance_refs": ["ISMS-P-2.9.3", "ISO-27001-A.8.9", "CIS-Docker-4.1"],
+        "frameworks": ["ISMS-P", "ISO-27001", "CIS"],
+    },
+    {
+        "name": "IaC — Encryption at Rest 강제",
+        "policy_type": PolicyType.IAC,
+        "description": "Terraform/CloudFormation으로 만드는 모든 데이터 스토어는 저장 암호화 필수. ISMS-P 2.7.1 / K-PIPA 안전조치 / ISO 27001 A.8.24.",
+        "severity_threshold": "high",
+        "definition": {"require": "encryption_at_rest", "scope": ["s3", "rds", "ebs", "gcs"]},
+        "compliance_refs": ["ISMS-P-2.7.1", "K-PIPA-29", "ISO-27001-A.8.24"],
+        "frameworks": ["ISMS-P", "K-PIPA", "ISO-27001"],
+    },
+    {
+        "name": "IaC — Public S3/Storage 금지",
+        "policy_type": PolicyType.IAC,
+        "description": "공개 버킷·공개 ACL 차단. ISMS-P 2.6.1(접근통제) / ISO 27001 A.8.3 / CIS AWS 2.1.5.",
+        "severity_threshold": "critical",
+        "definition": {"deny": "public_access", "scope": ["s3", "gcs", "azure_blob"]},
+        "compliance_refs": ["ISMS-P-2.6.1", "ISO-27001-A.8.3", "CIS-AWS-2.1.5"],
+        "frameworks": ["ISMS-P", "ISO-27001", "CIS"],
+    },
+
+    # ─── 시크릿 / 키 관리 ───────────────────────────────────────
+    {
+        "name": "Secrets in Code 차단",
+        "policy_type": PolicyType.SECRETS,
+        "description": "리포지토리 내 평문 시크릿(AKIA, BEGIN PRIVATE KEY, JWT 등) 차단. ISMS-P 2.7.2 / K-EFSA 11조 / ISO 27001 A.8.10.",
+        "severity_threshold": "high",
+        "definition": {"rules": ["AKIA[0-9A-Z]{16}", "-----BEGIN.*PRIVATE KEY-----", "ghp_[A-Za-z0-9]{36}"]},
+        "compliance_refs": ["ISMS-P-2.7.2", "K-EFSA-11", "ISO-27001-A.8.10", "OWASP-A02"],
+        "frameworks": ["ISMS-P", "K-EFSA", "ISO-27001", "OWASP"],
+    },
+    {
+        "name": "Key Rotation 강제 (90일)",
+        "policy_type": PolicyType.CUSTOM,
+        "description": "장기 자격증명은 90일 이내 회전. ISMS-P 2.5.4 / ISO 27001 A.8.24 / CIS AWS 1.14.",
+        "severity_threshold": "high",
+        "definition": {"max_key_age_days": 90},
+        "compliance_refs": ["ISMS-P-2.5.4", "ISO-27001-A.8.24", "CIS-AWS-1.14"],
+        "frameworks": ["ISMS-P", "ISO-27001", "CIS"],
+    },
+
+    # ─── 접근 통제 / 인증 ───────────────────────────────────────
+    {
+        "name": "관리자 계정 MFA 강제",
+        "policy_type": PolicyType.CUSTOM,
+        "description": "Admin/Root 권한 계정은 MFA 필수. ISMS-P 2.5.3 / K-EFSA 13조 / ISO 27001 A.5.16.",
+        "severity_threshold": "critical",
+        "definition": {"require_mfa_for": ["admin", "root"]},
+        "compliance_refs": ["ISMS-P-2.5.3", "K-EFSA-13", "ISO-27001-A.5.16"],
+        "frameworks": ["ISMS-P", "K-EFSA", "ISO-27001"],
+    },
+    {
+        "name": "최소권한 — Wildcard IAM 금지",
+        "policy_type": PolicyType.IAC,
+        "description": "IAM 정책에 Action='*' 또는 Resource='*' 금지. ISMS-P 2.5.6 / ISO 27001 A.5.18.",
+        "severity_threshold": "high",
+        "definition": {"deny": ["Action:*", "Resource:*"]},
+        "compliance_refs": ["ISMS-P-2.5.6", "ISO-27001-A.5.18"],
+        "frameworks": ["ISMS-P", "ISO-27001"],
+    },
+
+    # ─── 암호화 · 전송 보안 ────────────────────────────────────
+    {
+        "name": "TLS 1.2+ 강제",
+        "policy_type": PolicyType.IAC,
+        "description": "모든 외부 엔드포인트는 TLS 1.2 이상. ISMS-P 2.7.1 / K-PIPA 안전조치 / ISO 27001 A.8.24.",
+        "severity_threshold": "high",
+        "definition": {"min_tls_version": "1.2", "disallow": ["TLSv1.0", "TLSv1.1", "SSLv3"]},
+        "compliance_refs": ["ISMS-P-2.7.1", "K-PIPA-29", "ISO-27001-A.8.24"],
+        "frameworks": ["ISMS-P", "K-PIPA", "ISO-27001"],
+    },
+
+    # ─── 로그 · 감사 ────────────────────────────────────────────
+    {
+        "name": "접근 로그 보존 (1년 이상)",
+        "policy_type": PolicyType.CUSTOM,
+        "description": "관리자/특권 접근 로그는 최소 1년 보존. ISMS-P 2.9.4 / K-EFSA 16조 / ISO 27001 A.8.15.",
+        "severity_threshold": "high",
+        "definition": {"retention_days_min": 365, "scope": "privileged_access"},
+        "compliance_refs": ["ISMS-P-2.9.4", "K-EFSA-16", "ISO-27001-A.8.15"],
+        "frameworks": ["ISMS-P", "K-EFSA", "ISO-27001"],
+    },
+
+    # ─── DAST / 웹 보안 ────────────────────────────────────────
+    {
+        "name": "Web Security Headers 적용",
+        "policy_type": PolicyType.DAST,
+        "description": "HSTS · X-Content-Type-Options · CSP · X-Frame-Options 필수. ISMS-P 2.8.5 / OWASP A05 / ISO 27001 A.8.26.",
+        "severity_threshold": "medium",
+        "definition": {"require_headers": ["Strict-Transport-Security", "Content-Security-Policy", "X-Content-Type-Options", "X-Frame-Options"]},
+        "compliance_refs": ["ISMS-P-2.8.5", "OWASP-A05", "ISO-27001-A.8.26"],
+        "frameworks": ["ISMS-P", "OWASP", "ISO-27001"],
+    },
+
+    # ─── 개인정보 / 데이터 ──────────────────────────────────────
+    {
+        "name": "PII 마스킹 — 로그/응답 검사",
+        "policy_type": PolicyType.COMPLIANCE,
+        "description": "주민번호·카드번호·이메일 등 PII가 로그·응답에 평문으로 노출되지 않도록. K-PIPA 안전조치 / GDPR Art.32 / ISMS-P 3.3.",
+        "severity_threshold": "high",
+        "definition": {"patterns": ["[0-9]{6}-[1-4][0-9]{6}", "[0-9]{13,19}", "([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+)"]},
+        "compliance_refs": ["K-PIPA-29", "GDPR-Art-32", "ISMS-P-3.3"],
+        "frameworks": ["K-PIPA", "GDPR", "ISMS-P"],
+    },
+
+    # ─── 공공 클라우드 (CSAP) ───────────────────────────────────
+    {
+        "name": "데이터 국내 위치 강제 (CSAP)",
+        "policy_type": PolicyType.IAC,
+        "description": "공공기관용 시스템의 모든 데이터는 국내 리전에 위치. K-CSAP / ISMS-P 2.10.",
+        "severity_threshold": "critical",
+        "definition": {"allowed_regions": ["ap-northeast-2", "kr-central-1", "ap-northeast-3"]},
+        "compliance_refs": ["K-CSAP", "ISMS-P-2.10"],
+        "frameworks": ["K-CSAP", "ISMS-P"],
+    },
+]
+
+
+# 빠른 카탈로그 필터링용 프레임워크 정의 (UI 칩으로 노출)
+FRAMEWORKS: list[dict] = [
+    {"id": "ISMS-P", "name_ko": "ISMS-P (정보보호 관리체계, 국내)", "name_en": "ISMS-P (KISA, KR)"},
+    {"id": "K-EFSA", "name_ko": "전자금융감독규정 (국내)", "name_en": "Korean E-Finance Supervision"},
+    {"id": "K-CSAP", "name_ko": "CSAP — 공공 클라우드 (국내)", "name_en": "Korean CSAP (public cloud)"},
+    {"id": "K-PIPA", "name_ko": "개인정보보호법 (국내)", "name_en": "Korean PIPA"},
+    {"id": "ISO-27001", "name_ko": "ISO/IEC 27001:2022 (글로벌)", "name_en": "ISO/IEC 27001:2022"},
+    {"id": "OWASP", "name_ko": "OWASP Top 10 (글로벌)", "name_en": "OWASP Top 10"},
+    {"id": "CIS", "name_ko": "CIS Benchmarks (글로벌)", "name_en": "CIS Benchmarks"},
+    {"id": "PCI-DSS", "name_ko": "PCI DSS (글로벌 결제)", "name_en": "PCI DSS"},
+    {"id": "GDPR", "name_ko": "GDPR (EU)", "name_en": "GDPR (EU)"},
+]
+
+
+def list_templates(framework: str | None = None) -> list[dict]:
+    if not framework:
+        return list(TEMPLATES)
+    return [t for t in TEMPLATES if framework in t.get("frameworks", [])]

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -135,6 +135,13 @@ export const en: Dict = {
     threshold: "Threshold",
     compliance: "Compliance",
     desc: "Policies applied to scanner results. Each is SAST / SCA / IaC / DAST / Container / Secrets / Compliance and blocks the deployment pipeline when severity exceeds the threshold.",
+    openCatalog: "Regulation template catalog",
+    catalogTitle: "Policy Template Catalog",
+    catalogDesc:
+      "One-click apply for policies mapped to Korean and global regulations — ISMS-P, K-EFSA, CSAP, PIPA, ISO 27001, OWASP, CIS, etc.",
+    installSelected: "Install selected",
+    searchPlaceholder: "Search — e.g. secrets, encryption, ISMS-P-2.7",
+    allFrameworks: "All",
   },
 
   policySim: {

--- a/frontend/src/i18n/ko.ts
+++ b/frontend/src/i18n/ko.ts
@@ -133,6 +133,13 @@ export const ko = {
     threshold: "임계치",
     compliance: "컴플라이언스",
     desc: "스캐너 결과에 적용되는 정책입니다. SAST / SCA / IaC / DAST / 컨테이너 / 시크릿 / 컴플라이언스 유형 중 하나에 속하며, 임계치를 넘기는 발견사항은 배포 파이프라인을 차단합니다.",
+    openCatalog: "규제 템플릿 카탈로그",
+    catalogTitle: "정책 템플릿 카탈로그",
+    catalogDesc:
+      "ISMS-P · 전자금융감독규정 · CSAP · PIPA · ISO 27001 · OWASP · CIS 등 한국·글로벌 규제의 통제 항목에 매핑된 정책을 한 번에 적용합니다.",
+    installSelected: "선택 항목 적용",
+    searchPlaceholder: "검색 — 예: 시크릿, 암호화, ISMS-P-2.7",
+    allFrameworks: "전체",
   },
 
   policySim: {

--- a/frontend/src/lib/policy-templates-api.ts
+++ b/frontend/src/lib/policy-templates-api.ts
@@ -1,0 +1,37 @@
+/**
+ * 🌙 Policy Templates API
+ */
+
+import { api } from "@/lib/api";
+
+export interface PolicyTemplate {
+  name: string;
+  policy_type: string;
+  description: string;
+  severity_threshold: string;
+  definition: Record<string, unknown>;
+  compliance_refs: string[];
+  frameworks: string[];
+}
+
+export interface FrameworkInfo {
+  id: string;
+  name_ko: string;
+  name_en: string;
+}
+
+export const policyTemplatesApi = {
+  list: (framework?: string) =>
+    api
+      .get<PolicyTemplate[]>("/policy/templates", { params: { framework } })
+      .then((r) => r.data),
+  frameworks: () =>
+    api.get<FrameworkInfo[]>("/policy/templates/frameworks").then((r) => r.data),
+  install: (names: string[]) =>
+    api
+      .post<{ installed: number; skipped_existing: number; names: string[] }>(
+        "/policy/templates/install",
+        { names },
+      )
+      .then((r) => r.data),
+};

--- a/frontend/src/pages/Policies.tsx
+++ b/frontend/src/pages/Policies.tsx
@@ -1,14 +1,41 @@
 /**
- * 🌙 Policies — 룰셋 / 컴플라이언스 매핑
+ * 🌙 Policies — 룰셋 / 컴플라이언스 매핑 + 한국·글로벌 규제 템플릿 카탈로그
  */
 
-import { useQuery } from "@tanstack/react-query";
-import { Card, Empty, Switch, Table, Tag, Typography } from "antd";
+import { AppstoreAddOutlined, SafetyOutlined } from "@ant-design/icons";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Alert,
+  Button,
+  Card,
+  Checkbox,
+  Empty,
+  Input,
+  Modal,
+  Segmented,
+  Space,
+  Switch,
+  Table,
+  Tag,
+  Tooltip,
+  Typography,
+  message,
+} from "antd";
+import { useAuth } from "@/auth/AuthContext";
+import { useMemo, useState } from "react";
 
 import { useI18n } from "@/i18n";
 import { api, type Policy } from "@/lib/api";
+import { hasRole } from "@/lib/auth-api";
+import {
+  policyTemplatesApi,
+  type FrameworkInfo,
+  type PolicyTemplate,
+} from "@/lib/policy-templates-api";
 
-const { Title, Paragraph } = Typography;
+const { Title, Paragraph, Text } = Typography;
+
+const ALL = "__all__";
 
 async function fetchPolicies(): Promise<Policy[]> {
   const { data } = await api.get<Policy[]>("/policies");
@@ -17,19 +44,114 @@ async function fetchPolicies(): Promise<Policy[]> {
 
 export default function Policies() {
   const { t, locale } = useI18n();
+  const { user } = useAuth();
+  const qc = useQueryClient();
+  const [catalogOpen, setCatalogOpen] = useState(false);
+  const [framework, setFramework] = useState<string>(ALL);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
   const { data, isLoading } = useQuery({ queryKey: ["policies"], queryFn: fetchPolicies });
+  const { data: frameworks } = useQuery({
+    queryKey: ["policy-templates-frameworks"],
+    queryFn: policyTemplatesApi.frameworks,
+  });
+  const { data: templates } = useQuery({
+    queryKey: ["policy-templates"],
+    queryFn: () => policyTemplatesApi.list(),
+    enabled: catalogOpen,
+  });
+
+  const installed = useMemo(
+    () => new Set((data ?? []).map((p) => p.name)),
+    [data],
+  );
+  const compRefFilter = framework === ALL ? null : framework;
+
+  // 적용된 정책 — 컴플라이언스 ref / 텍스트로 필터
+  const filteredPolicies = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return (data ?? []).filter((p) => {
+      if (compRefFilter && !p.compliance_refs.some((r) => r.startsWith(compRefFilter))) return false;
+      if (!q) return true;
+      const hay = `${p.name} ${p.description ?? ""} ${p.compliance_refs.join(" ")}`.toLowerCase();
+      return hay.includes(q);
+    });
+  }, [data, compRefFilter, query]);
+
+  // 템플릿 카탈로그 — 같은 framework로 필터 + 검색
+  const filteredTemplates = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return (templates ?? []).filter((tpl) => {
+      if (compRefFilter && !tpl.frameworks.includes(compRefFilter)) return false;
+      if (!q) return true;
+      return (
+        tpl.name.toLowerCase().includes(q) ||
+        tpl.description.toLowerCase().includes(q) ||
+        tpl.compliance_refs.some((r) => r.toLowerCase().includes(q))
+      );
+    });
+  }, [templates, compRefFilter, query]);
+
+  const install = useMutation({
+    mutationFn: (names: string[]) => policyTemplatesApi.install(names),
+    onSuccess: (res) => {
+      message.success(
+        locale === "ko"
+          ? `${res.installed}건 적용됨 · 기존 중복 ${res.skipped_existing}건 건너뜀`
+          : `Installed ${res.installed} · skipped ${res.skipped_existing}`,
+      );
+      qc.invalidateQueries({ queryKey: ["policies"] });
+      setSelected(new Set());
+      setCatalogOpen(false);
+    },
+    onError: (err: Error & { response?: { data?: { detail?: string } } }) =>
+      message.error(err.response?.data?.detail ?? err.message),
+  });
+
+  const canInstall = hasRole(user, "admin");
 
   return (
     <div>
-      <Title level={2} style={{ marginBottom: 16 }}>
-        {t.policies.title}
-      </Title>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+        <Title level={2} style={{ margin: 0 }}>
+          {t.policies.title}
+        </Title>
+        <Tooltip title={canInstall ? "" : (locale === "ko" ? "ADMIN 권한 필요" : "ADMIN required")}>
+          <Button
+            type="primary"
+            icon={<AppstoreAddOutlined />}
+            disabled={!canInstall}
+            onClick={() => setCatalogOpen(true)}
+          >
+            {t.policies.openCatalog}
+          </Button>
+        </Tooltip>
+      </div>
       <Paragraph type="secondary">{t.policies.desc}</Paragraph>
+
+      <Card style={{ marginBottom: 16 }}>
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <FrameworkFilter
+            value={framework}
+            onChange={setFramework}
+            frameworks={frameworks ?? []}
+            locale={locale}
+            t={t}
+          />
+          <Input.Search
+            placeholder={t.policies.searchPlaceholder}
+            allowClear
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </Space>
+      </Card>
 
       <Card>
         <Table
           loading={isLoading}
-          dataSource={data ?? []}
+          dataSource={filteredPolicies}
           rowKey="id"
           locale={{
             emptyText: <Empty description={locale === "ko" ? "정책이 없습니다" : "No policies"} />,
@@ -53,17 +175,165 @@ export default function Policies() {
               title: t.policies.compliance,
               dataIndex: "compliance_refs",
               render: (refs: string[]) => (
-                <>
+                <Space size={[4, 4]} wrap>
                   {(refs ?? []).map((r) => (
-                    <Tag key={r}>{r}</Tag>
+                    <Tag key={r} color={tagColor(r)}>
+                      {r}
+                    </Tag>
                   ))}
-                </>
+                </Space>
               ),
             },
             { title: t.common.description, dataIndex: "description", ellipsis: true },
           ]}
         />
       </Card>
+
+      <Modal
+        title={
+          <Space>
+            <SafetyOutlined />
+            <span>{t.policies.catalogTitle}</span>
+          </Space>
+        }
+        open={catalogOpen}
+        onCancel={() => {
+          setCatalogOpen(false);
+          setSelected(new Set());
+        }}
+        width={920}
+        okText={`${t.policies.installSelected} (${selected.size})`}
+        okButtonProps={{ disabled: selected.size === 0 || install.isPending }}
+        confirmLoading={install.isPending}
+        onOk={() => install.mutate(Array.from(selected))}
+      >
+        <Paragraph type="secondary">{t.policies.catalogDesc}</Paragraph>
+        <Space direction="vertical" style={{ width: "100%" }} size="middle">
+          <FrameworkFilter
+            value={framework}
+            onChange={setFramework}
+            frameworks={frameworks ?? []}
+            locale={locale}
+            t={t}
+          />
+          <Input.Search
+            placeholder={t.policies.searchPlaceholder}
+            allowClear
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <Alert
+            type="info"
+            showIcon
+            message={
+              locale === "ko"
+                ? `${filteredTemplates.length}개 템플릿 · 이미 적용된 정책은 자동으로 건너뜁니다.`
+                : `${filteredTemplates.length} templates · already-installed ones are skipped.`
+            }
+          />
+          <div style={{ maxHeight: 460, overflowY: "auto", paddingRight: 4 }}>
+            <Space direction="vertical" style={{ width: "100%" }}>
+              {filteredTemplates.map((tpl: PolicyTemplate) => {
+                const isInstalled = installed.has(tpl.name);
+                const isChecked = selected.has(tpl.name);
+                return (
+                  <Card
+                    key={tpl.name}
+                    size="small"
+                    style={{
+                      borderColor: isChecked ? "var(--mond-primary)" : undefined,
+                      opacity: isInstalled ? 0.55 : 1,
+                    }}
+                  >
+                    <Space align="start" style={{ width: "100%" }}>
+                      <Checkbox
+                        checked={isChecked}
+                        disabled={isInstalled}
+                        onChange={(e) => {
+                          setSelected((cur) => {
+                            const n = new Set(cur);
+                            if (e.target.checked) n.add(tpl.name);
+                            else n.delete(tpl.name);
+                            return n;
+                          });
+                        }}
+                      />
+                      <div style={{ flex: 1 }}>
+                        <Space size={[6, 6]} wrap>
+                          <Text strong>{tpl.name}</Text>
+                          <Tag color="purple">{tpl.policy_type}</Tag>
+                          <Tag>{tpl.severity_threshold}</Tag>
+                          {isInstalled && (
+                            <Tag color="default">
+                              {locale === "ko" ? "이미 적용됨" : "Installed"}
+                            </Tag>
+                          )}
+                        </Space>
+                        <Paragraph style={{ marginTop: 6, marginBottom: 6 }}>
+                          {tpl.description}
+                        </Paragraph>
+                        <Space size={[4, 4]} wrap>
+                          {tpl.compliance_refs.map((r) => (
+                            <Tag key={r} color={tagColor(r)}>
+                              {r}
+                            </Tag>
+                          ))}
+                        </Space>
+                      </div>
+                    </Space>
+                  </Card>
+                );
+              })}
+              {filteredTemplates.length === 0 && (
+                <Empty description={locale === "ko" ? "해당 규제 템플릿이 없습니다" : "No templates"} />
+              )}
+            </Space>
+          </div>
+        </Space>
+      </Modal>
     </div>
   );
+}
+
+function FrameworkFilter({
+  value,
+  onChange,
+  frameworks,
+  locale,
+  t,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  frameworks: FrameworkInfo[];
+  locale: "ko" | "en";
+  t: { policies: { allFrameworks: string } };
+}) {
+  const options = [
+    { value: ALL, label: t.policies.allFrameworks },
+    ...frameworks.map((f) => ({
+      value: f.id,
+      label: locale === "ko" ? f.name_ko.split(" (")[0] : f.name_en.split(" (")[0],
+    })),
+  ];
+  return (
+    <Segmented
+      block
+      value={value}
+      onChange={(v) => onChange(v as string)}
+      options={options}
+    />
+  );
+}
+
+function tagColor(ref: string): string {
+  if (ref.startsWith("ISMS-P")) return "geekblue";
+  if (ref.startsWith("K-EFSA")) return "blue";
+  if (ref.startsWith("K-CSAP")) return "cyan";
+  if (ref.startsWith("K-PIPA")) return "volcano";
+  if (ref.startsWith("ISO-27001")) return "purple";
+  if (ref.startsWith("OWASP")) return "magenta";
+  if (ref.startsWith("CIS")) return "gold";
+  if (ref.startsWith("PCI")) return "red";
+  if (ref.startsWith("GDPR")) return "lime";
+  return "default";
 }


### PR DESCRIPTION
운영자가 한국 규제(ISMS-P 통제 번호까지 매핑) + ISO 27001 / OWASP / CIS / PCI / GDPR을 한 번에 찾아 적용. 16개 템플릿 + 9개 framework. 자세한 내용은 commit message 참고.