### PR TITLE
feat(admin): 관리자 영역 확장 — 연동·정책·사용자 변경은 관리자 모드에서만

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -20,6 +20,7 @@ from app.api.v1.endpoints import (
     regulations,
     reports,
     scans,
+    users,
     webhooks,
 )
 
@@ -41,3 +42,4 @@ api_router.include_router(integrations.router, prefix="/integrations", tags=["In
 api_router.include_router(webhooks.router, prefix="/webhooks", tags=["Webhooks"])
 api_router.include_router(iam.router, prefix="/iam", tags=["IAM Self-Service"])
 api_router.include_router(knowledge.router, prefix="/knowledge", tags=["Knowledge Hub"])
+api_router.include_router(users.router, prefix="/users", tags=["Users (Admin)"])

--- a/backend/app/api/v1/endpoints/policies.py
+++ b/backend/app/api/v1/endpoints/policies.py
@@ -1,11 +1,13 @@
 """
-🌙 Policy 엔드포인트
+🌙 Policy 엔드포인트 — 조회는 모두에게, 변경은 REVIEWER+에게.
 """
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth.deps import require_role
 from app.core.database import get_db
+from app.models.user import Role
 from app.schemas.policy import PolicyCreate, PolicyRead, PolicyUpdate
 from app.services import policy as policy_service
 
@@ -21,7 +23,12 @@ async def list_policies(
     return [PolicyRead.model_validate(i) for i in items]
 
 
-@router.post("", response_model=PolicyRead, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=PolicyRead,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_role(Role.REVIEWER))],
+)
 async def create_policy(payload: PolicyCreate, db: AsyncSession = Depends(get_db)) -> PolicyRead:
     policy = await policy_service.create_policy(db, payload)
     return PolicyRead.model_validate(policy)
@@ -35,7 +42,11 @@ async def get_policy(policy_id: int, db: AsyncSession = Depends(get_db)) -> Poli
     return PolicyRead.model_validate(policy)
 
 
-@router.patch("/{policy_id}", response_model=PolicyRead)
+@router.patch(
+    "/{policy_id}",
+    response_model=PolicyRead,
+    dependencies=[Depends(require_role(Role.REVIEWER))],
+)
 async def update_policy(
     policy_id: int,
     payload: PolicyUpdate,
@@ -48,7 +59,11 @@ async def update_policy(
     return PolicyRead.model_validate(updated)
 
 
-@router.delete("/{policy_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{policy_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_role(Role.REVIEWER))],
+)
 async def delete_policy(policy_id: int, db: AsyncSession = Depends(get_db)) -> None:
     policy = await policy_service.get_policy(db, policy_id)
     if not policy:

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -1,0 +1,106 @@
+"""
+🌙 Users 관리 엔드포인트 — ADMIN 전용 (사용자 목록 + role 변경)
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.deps import current_user, require_role
+from app.core.database import get_db
+from app.models.user import Role, User
+from app.schemas.common import Timestamped
+
+router = APIRouter()
+
+
+class UserRead(Timestamped):
+    id: int
+    email: str
+    name: str | None = None
+    picture_url: str | None = None
+    role: Role
+    sso_provider: str | None = None
+    last_login_at_iso: str | None = None
+
+
+class UpdateRoleIn(BaseModel):
+    role: Role
+
+
+@router.get(
+    "",
+    response_model=list[UserRead],
+    dependencies=[Depends(require_role(Role.ADMIN))],
+)
+async def list_users(db: AsyncSession = Depends(get_db)) -> list[UserRead]:
+    items = list((await db.execute(select(User).order_by(User.id))).scalars().all())
+    out: list[UserRead] = []
+    for u in items:
+        out.append(
+            UserRead(
+                id=u.id,
+                email=u.email,
+                name=u.name,
+                picture_url=u.picture_url,
+                role=u.role,
+                sso_provider=u.sso_provider,
+                last_login_at_iso=u.last_login_at.isoformat() if u.last_login_at else None,
+                created_at=u.created_at,
+                updated_at=u.updated_at,
+            )
+        )
+    return out
+
+
+@router.patch(
+    "/{user_id}/role",
+    response_model=UserRead,
+)
+async def update_role(
+    user_id: int,
+    payload: UpdateRoleIn,
+    actor: User = Depends(require_role(Role.ADMIN)),
+    db: AsyncSession = Depends(get_db),
+) -> UserRead:
+    target = (await db.execute(select(User).where(User.id == user_id))).scalar_one_or_none()
+    if not target:
+        raise HTTPException(status_code=404, detail="user not found")
+    if target.id == actor.id and payload.role != Role.ADMIN:
+        raise HTTPException(
+            status_code=400,
+            detail="자신의 role을 ADMIN 미만으로 낮출 수 없습니다 (계정 잠금 방지).",
+        )
+    target.role = payload.role
+    await db.commit()
+    await db.refresh(target)
+    return UserRead(
+        id=target.id,
+        email=target.email,
+        name=target.name,
+        picture_url=target.picture_url,
+        role=target.role,
+        sso_provider=target.sso_provider,
+        last_login_at_iso=target.last_login_at.isoformat() if target.last_login_at else None,
+        created_at=target.created_at,
+        updated_at=target.updated_at,
+    )
+
+
+@router.get("/me/refresh", response_model=UserRead)
+async def me_refresh(
+    user: User = Depends(current_user),
+) -> UserRead:
+    """최신 role/메타 재조회용."""
+    return UserRead(
+        id=user.id,
+        email=user.email,
+        name=user.name,
+        picture_url=user.picture_url,
+        role=user.role,
+        sso_provider=user.sso_provider,
+        last_login_at_iso=user.last_login_at.isoformat() if user.last_login_at else None,
+        created_at=user.created_at,
+        updated_at=user.updated_at,
+    )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,8 @@
 /**
- * 🌙 Mond — 라우팅 (인증 가드 포함)
+ * 🌙 Mond — 라우팅 (인증 가드 + 관리자 영역 포함)
  */
 
-import { Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 
 import RequireAuth from "@/auth/RequireAuth";
 import Layout from "@/components/Layout";
@@ -22,6 +22,9 @@ import Regulations from "@/pages/Regulations";
 import Reports from "@/pages/Reports";
 import Scans from "@/pages/Scans";
 import Settings from "@/pages/Settings";
+import AdminConnections from "@/pages/admin/AdminConnections";
+import AdminPolicies from "@/pages/admin/AdminPolicies";
+import AdminUsers from "@/pages/admin/AdminUsers";
 
 export default function App() {
   return (
@@ -34,6 +37,7 @@ export default function App() {
           </RequireAuth>
         }
       >
+        {/* 일반 영역 */}
         <Route index element={<Dashboard />} />
         <Route path="assets" element={<Assets />} />
         <Route
@@ -75,15 +79,45 @@ export default function App() {
             </RequireAuth>
           }
         />
+        <Route path="settings" element={<Settings />} />
+
+        {/* 관리자 영역 */}
+        <Route path="admin" element={<Navigate to="/admin/access-review" replace />} />
         <Route
-          path="access-review"
+          path="admin/access-review"
           element={
             <RequireAuth minRole="reviewer">
               <AccessReview />
             </RequireAuth>
           }
         />
-        <Route path="settings" element={<Settings />} />
+        <Route
+          path="admin/policies"
+          element={
+            <RequireAuth minRole="reviewer">
+              <AdminPolicies />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="admin/connections"
+          element={
+            <RequireAuth minRole="admin">
+              <AdminConnections />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="admin/users"
+          element={
+            <RequireAuth minRole="admin">
+              <AdminUsers />
+            </RequireAuth>
+          }
+        />
+
+        {/* 구 경로 호환 */}
+        <Route path="access-review" element={<Navigate to="/admin/access-review" replace />} />
       </Route>
     </Routes>
   );

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,7 @@
 /**
  * 🌙 Mond — 사이드바 + 헤더 레이아웃 + 언어 스위처 + 사용자 메뉴
+ *
+ * 일반 모드와 관리자 모드(/admin/*)에서 사이드바 메뉴가 전환된다.
  */
 
 import {
@@ -14,10 +16,12 @@ import {
   GlobalOutlined,
   KeyOutlined,
   LogoutOutlined,
+  RollbackOutlined,
   SafetyCertificateOutlined,
   SafetyOutlined,
   ScanOutlined,
   SettingOutlined,
+  SolutionOutlined,
   TeamOutlined,
   ThunderboltOutlined,
   UserOutlined,
@@ -40,8 +44,9 @@ export default function Layout() {
   const { t, locale, setLocale } = useI18n();
   const { user, logout } = useAuth();
 
-  // role에 따라 메뉴를 필터링한다.
-  const items = [
+  const isAdminRoute = location.pathname.startsWith("/admin");
+
+  const userItems = [
     { key: "/", icon: <DashboardOutlined />, label: t.menu.dashboard, minRole: "viewer" as const },
     { key: "/assets", icon: <AppstoreOutlined />, label: t.menu.assets, minRole: "viewer" as const },
     { key: "/scans", icon: <ScanOutlined />, label: t.menu.scans, minRole: "employee" as const },
@@ -58,10 +63,16 @@ export default function Layout() {
     { key: "/settings", icon: <SettingOutlined />, label: t.menu.settings, minRole: "viewer" as const },
   ].filter((i) => hasRole(user, i.minRole));
 
-  const isAdminRoute = location.pathname.startsWith("/access-review");
-  const selectedKey = isAdminRoute
-    ? ""
-    : items.find((i) => i.key !== "/" && location.pathname.startsWith(i.key))?.key ?? "/";
+  const adminItems = [
+    { key: "/admin/access-review", icon: <SolutionOutlined />, label: t.adminArea.menuAccessReview, minRole: "reviewer" as const },
+    { key: "/admin/policies", icon: <ExperimentOutlined />, label: t.adminArea.menuPolicies, minRole: "reviewer" as const },
+    { key: "/admin/connections", icon: <ApiOutlined />, label: t.adminArea.menuConnections, minRole: "admin" as const },
+    { key: "/admin/users", icon: <TeamOutlined />, label: t.adminArea.menuUsers, minRole: "admin" as const },
+  ].filter((i) => hasRole(user, i.minRole));
+
+  const items = isAdminRoute ? adminItems : userItems;
+  const selectedKey =
+    items.find((i) => location.pathname.startsWith(i.key))?.key ?? items[0]?.key ?? "";
 
   const canEnterAdmin = hasRole(user, "reviewer");
 
@@ -86,6 +97,11 @@ export default function Layout() {
         style={{ borderRight: "1px solid var(--mond-border)" }}
       >
         <Logo collapsed={collapsed} />
+        {isAdminRoute && !collapsed && (
+          <div style={{ padding: "6px 18px" }}>
+            <Tag color="red">{t.admin.badge}</Tag>
+          </div>
+        )}
         <Menu
           theme="dark"
           mode="inline"
@@ -114,10 +130,10 @@ export default function Layout() {
               <Button
                 type={isAdminRoute ? "primary" : "default"}
                 danger={isAdminRoute}
-                icon={<SafetyCertificateOutlined />}
-                onClick={() => navigate(isAdminRoute ? "/" : "/access-review")}
+                icon={isAdminRoute ? <RollbackOutlined /> : <SafetyCertificateOutlined />}
+                onClick={() => navigate(isAdminRoute ? "/" : "/admin/access-review")}
               >
-                {isAdminRoute ? "←" : t.admin.enter}
+                {isAdminRoute ? t.adminArea.backToApp : t.admin.enter}
               </Button>
             )}
             <Dropdown

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -30,6 +30,38 @@ export const en: Dict = {
     badge: "ADMIN",
   },
 
+  adminArea: {
+    home: "Admin Home",
+    backToApp: "Back to app",
+    menuAccessReview: "Access Review",
+    menuConnections: "Connections",
+    menuPolicies: "Policy Management",
+    menuUsers: "Users & Roles",
+    connectionsTitle: "Connections",
+    connectionsDesc:
+      "Manage external integrations in one place — cloud IAM sources, SSO IdPs, and external webhooks. ADMIN role required.",
+    iamSources: "IAM Sources (cloud)",
+    ssoTitle: "SSO / IdP",
+    ssoDesc:
+      "Check current OIDC SSO status. Enable additional IdPs via runtime ENV. Default is Dev Login.",
+    ssoMode: "Current mode",
+    ssoActive: "Active IdPs",
+    ssoEnvHint: "Production ENV example (.env)",
+    webhookTitle: "GitHub Webhook",
+    webhookDesc:
+      "Receives GitHub push events and auto-scans matching repository assets. Set the same secret in ENV as GITHUB_WEBHOOK_SECRET.",
+    policyMgmtTitle: "Policy Management",
+    policyMgmtDesc:
+      "Only security reviewers can change policies that gate scanner results. Toggle/threshold/delete + bulk-install regulation templates.",
+    usersTitle: "Users & Roles",
+    usersDesc:
+      "See all users with their roles and change them as ADMIN. Self-lockout prevention: you can't demote yourself from ADMIN.",
+    user: "User",
+    role: "Role",
+    ssoProvider: "SSO source",
+    lastLogin: "Last login",
+  },
+
   auth: {
     loginTitle: "Sign in",
     ssoLogin: "Sign in with your company account (SSO)",

--- a/frontend/src/i18n/ko.ts
+++ b/frontend/src/i18n/ko.ts
@@ -28,6 +28,38 @@ export const ko = {
     badge: "ADMIN",
   },
 
+  adminArea: {
+    home: "관리자 홈",
+    backToApp: "일반 모드로 복귀",
+    menuAccessReview: "권한 검토",
+    menuConnections: "연동 관리",
+    menuPolicies: "정책 관리",
+    menuUsers: "사용자·역할",
+    connectionsTitle: "연동 관리",
+    connectionsDesc:
+      "클라우드 IAM 소스, SSO IdP, 외부 Webhook 같은 외부 시스템 연동을 한 곳에서 관리합니다. ADMIN 권한이 필요합니다.",
+    iamSources: "IAM 소스 (클라우드 연동)",
+    ssoTitle: "SSO / IdP 연동",
+    ssoDesc:
+      "OIDC 기반 SSO 상태를 확인하고, 운영 환경 변수로 추가 활성화할 수 있습니다. 기본값은 Dev Login.",
+    ssoMode: "현재 모드",
+    ssoActive: "활성 IdP",
+    ssoEnvHint: "운영 환경 ENV 예시 (.env)",
+    webhookTitle: "GitHub Webhook",
+    webhookDesc:
+      "GitHub push 이벤트를 받아 매칭되는 레포 자산을 자동 스캔합니다. 운영 secret을 ENV의 GITHUB_WEBHOOK_SECRET과 동일하게 맞추세요.",
+    policyMgmtTitle: "정책 관리",
+    policyMgmtDesc:
+      "스캐너 결과 게이트가 되는 정책을 보안 담당자만 수정할 수 있습니다. 활성화/임계치 조정/삭제 + 규제 템플릿 일괄 적용을 지원합니다.",
+    usersTitle: "사용자·역할",
+    usersDesc:
+      "전체 사용자 목록과 역할을 한눈에 보고 ADMIN이 직접 변경할 수 있습니다. 본인의 ADMIN 권한은 잠금 방지를 위해 직접 낮출 수 없습니다.",
+    user: "사용자",
+    role: "역할",
+    ssoProvider: "SSO 출처",
+    lastLogin: "최근 로그인",
+  },
+
   auth: {
     loginTitle: "로그인",
     ssoLogin: "회사 계정으로 로그인 (SSO)",

--- a/frontend/src/lib/users-api.ts
+++ b/frontend/src/lib/users-api.ts
@@ -1,0 +1,24 @@
+/**
+ * 🌙 Users 관리 API (ADMIN 전용)
+ */
+
+import { api } from "@/lib/api";
+import type { Role } from "@/lib/auth-api";
+
+export interface AdminUser {
+  id: number;
+  email: string;
+  name?: string | null;
+  picture_url?: string | null;
+  role: Role;
+  sso_provider?: string | null;
+  last_login_at_iso?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export const usersApi = {
+  list: () => api.get<AdminUser[]>("/users").then((r) => r.data),
+  updateRole: (id: number, role: Role) =>
+    api.patch<AdminUser>(`/users/${id}/role`, { role }).then((r) => r.data),
+};

--- a/frontend/src/pages/IAMExplorer.tsx
+++ b/frontend/src/pages/IAMExplorer.tsx
@@ -1,32 +1,16 @@
 /**
- * 🌙 IAM Explorer — Identities / Permissions 조회 + Source 동기화
+ * 🌙 IAM Explorer — Identities / Permissions 조회 (read-only).
+ * 연동(Source) 추가/동기화는 관리자 모드 → 연동 관리로 분리.
  */
 
-import { CloudDownloadOutlined, PlusOutlined, SyncOutlined } from "@ant-design/icons";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  Button,
-  Card,
-  Col,
-  Form,
-  Input,
-  Modal,
-  Row,
-  Select,
-  Space,
-  Table,
-  Tag,
-  Typography,
-  message,
-} from "antd";
-import { useState } from "react";
+import { CloudDownloadOutlined } from "@ant-design/icons";
+import { useQuery } from "@tanstack/react-query";
+import { Card, Col, Row, Table, Tag, Typography } from "antd";
 
 import { useI18n } from "@/i18n";
 import {
   iamApi,
   type IAMIdentity,
-  type IAMSource,
-  type IAMSourceKind,
   type PermissionRow,
 } from "@/lib/iam-api";
 
@@ -38,53 +22,18 @@ const RISK_COLOR: Record<string, string> = {
   read: "green",
 };
 
-const KIND_OPTIONS: IAMSourceKind[] = ["aws", "gcp", "azure", "k8s", "custom"];
-
 export default function IAMExplorer() {
   const { t } = useI18n();
-  const qc = useQueryClient();
-  const [open, setOpen] = useState(false);
-  const [form] = Form.useForm();
 
   const { data: sources } = useQuery({ queryKey: ["iam-sources"], queryFn: iamApi.listSources });
   const { data: identities } = useQuery({ queryKey: ["iam-identities"], queryFn: () => iamApi.listIdentities() });
   const { data: permissions } = useQuery({ queryKey: ["iam-permissions"], queryFn: () => iamApi.listPermissions() });
 
-  const sync = useMutation({
-    mutationFn: (id: number) => iamApi.syncSource(id),
-    onSuccess: (data) => {
-      message.success(
-        `${data.imported_identities ?? 0} identities · ${data.imported_permissions ?? 0} permissions`,
-      );
-      qc.invalidateQueries({ queryKey: ["iam-sources"] });
-      qc.invalidateQueries({ queryKey: ["iam-identities"] });
-      qc.invalidateQueries({ queryKey: ["iam-permissions"] });
-    },
-  });
-
-  const create = useMutation({
-    mutationFn: (body: { name: string; kind: IAMSourceKind; config: Record<string, unknown>; credentials_env_ref: Record<string, string> }) =>
-      iamApi.createSource(body),
-    onSuccess: () => {
-      message.success(t.iam.sourceCreated);
-      qc.invalidateQueries({ queryKey: ["iam-sources"] });
-      setOpen(false);
-      form.resetFields();
-    },
-  });
-
   return (
     <div>
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
-        <Title level={2} style={{ margin: 0 }}>
-          {t.iam.iamExplorerTitle}
-        </Title>
-        <Space>
-          <Button icon={<PlusOutlined />} onClick={() => setOpen(true)}>
-            {t.iam.addSource}
-          </Button>
-        </Space>
-      </div>
+      <Title level={2} style={{ marginBottom: 8 }}>
+        {t.iam.iamExplorerTitle}
+      </Title>
       <Paragraph type="secondary">{t.iam.iamExplorerDesc}</Paragraph>
 
       <Card title="Sources" style={{ marginTop: 12 }}>
@@ -98,15 +47,6 @@ export default function IAMExplorer() {
             { title: t.iam.fields.source, dataIndex: "name" },
             { title: t.iam.fields.type, dataIndex: "kind", render: (k: string) => <Tag>{k.toUpperCase()}</Tag>, width: 100 },
             { title: "last sync", dataIndex: "last_synced_at_str", render: (v: string | null) => v || "—" },
-            {
-              title: t.iam.sync,
-              render: (_: unknown, r: IAMSource) => (
-                <Button size="small" icon={<SyncOutlined />} onClick={() => sync.mutate(r.id)}>
-                  {t.iam.syncSource}
-                </Button>
-              ),
-              width: 140,
-            },
           ]}
         />
       </Card>
@@ -154,46 +94,6 @@ export default function IAMExplorer() {
           </Card>
         </Col>
       </Row>
-
-      <Modal
-        title={t.iam.addSource}
-        open={open}
-        onOk={() => form.submit()}
-        onCancel={() => setOpen(false)}
-        confirmLoading={create.isPending}
-      >
-        <Form
-          form={form}
-          layout="vertical"
-          onFinish={(values) =>
-            create.mutate({
-              name: values.name,
-              kind: values.kind,
-              config: { region: values.region },
-              credentials_env_ref: {
-                access_key_id: values.access_key_env || "AWS_ACCESS_KEY_ID",
-                secret_access_key: values.secret_key_env || "AWS_SECRET_ACCESS_KEY",
-              },
-            })
-          }
-        >
-          <Form.Item label={t.iam.fields.source} name="name" rules={[{ required: true }]}>
-            <Input placeholder="aws-prod" />
-          </Form.Item>
-          <Form.Item label={t.iam.fields.type} name="kind" rules={[{ required: true }]}>
-            <Select options={KIND_OPTIONS.map((k) => ({ value: k, label: k.toUpperCase() }))} />
-          </Form.Item>
-          <Form.Item label="region" name="region">
-            <Input placeholder="us-east-1" />
-          </Form.Item>
-          <Form.Item label="ENV name for access key" name="access_key_env">
-            <Input placeholder="AWS_ACCESS_KEY_ID" />
-          </Form.Item>
-          <Form.Item label="ENV name for secret key" name="secret_key_env">
-            <Input placeholder="AWS_SECRET_ACCESS_KEY" />
-          </Form.Item>
-        </Form>
-      </Modal>
     </div>
   );
 }

--- a/frontend/src/pages/Policies.tsx
+++ b/frontend/src/pages/Policies.tsx
@@ -1,39 +1,21 @@
 /**
- * 🌙 Policies — 룰셋 / 컴플라이언스 매핑 + 한국·글로벌 규제 템플릿 카탈로그
+ * 🌙 Policies — 룰셋 / 컴플라이언스 매핑 (read-only)
+ *
+ * 정책 수정·삭제·템플릿 적용은 관리자 모드 → '정책 관리'에서만 가능.
  */
 
-import { AppstoreAddOutlined, SafetyOutlined } from "@ant-design/icons";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  Alert,
-  Button,
-  Card,
-  Checkbox,
-  Empty,
-  Input,
-  Modal,
-  Segmented,
-  Space,
-  Switch,
-  Table,
-  Tag,
-  Tooltip,
-  Typography,
-  message,
-} from "antd";
-import { useAuth } from "@/auth/AuthContext";
+import { useQuery } from "@tanstack/react-query";
+import { Card, Empty, Input, Segmented, Space, Switch, Table, Tag, Typography } from "antd";
 import { useMemo, useState } from "react";
 
 import { useI18n } from "@/i18n";
 import { api, type Policy } from "@/lib/api";
-import { hasRole } from "@/lib/auth-api";
 import {
   policyTemplatesApi,
   type FrameworkInfo,
-  type PolicyTemplate,
 } from "@/lib/policy-templates-api";
 
-const { Title, Paragraph, Text } = Typography;
+const { Title, Paragraph } = Typography;
 
 const ALL = "__all__";
 
@@ -44,31 +26,17 @@ async function fetchPolicies(): Promise<Policy[]> {
 
 export default function Policies() {
   const { t, locale } = useI18n();
-  const { user } = useAuth();
-  const qc = useQueryClient();
-  const [catalogOpen, setCatalogOpen] = useState(false);
   const [framework, setFramework] = useState<string>(ALL);
   const [query, setQuery] = useState("");
-  const [selected, setSelected] = useState<Set<string>>(new Set());
 
   const { data, isLoading } = useQuery({ queryKey: ["policies"], queryFn: fetchPolicies });
   const { data: frameworks } = useQuery({
     queryKey: ["policy-templates-frameworks"],
     queryFn: policyTemplatesApi.frameworks,
   });
-  const { data: templates } = useQuery({
-    queryKey: ["policy-templates"],
-    queryFn: () => policyTemplatesApi.list(),
-    enabled: catalogOpen,
-  });
 
-  const installed = useMemo(
-    () => new Set((data ?? []).map((p) => p.name)),
-    [data],
-  );
   const compRefFilter = framework === ALL ? null : framework;
 
-  // 적용된 정책 — 컴플라이언스 ref / 텍스트로 필터
   const filteredPolicies = useMemo(() => {
     const q = query.trim().toLowerCase();
     return (data ?? []).filter((p) => {
@@ -79,55 +47,11 @@ export default function Policies() {
     });
   }, [data, compRefFilter, query]);
 
-  // 템플릿 카탈로그 — 같은 framework로 필터 + 검색
-  const filteredTemplates = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return (templates ?? []).filter((tpl) => {
-      if (compRefFilter && !tpl.frameworks.includes(compRefFilter)) return false;
-      if (!q) return true;
-      return (
-        tpl.name.toLowerCase().includes(q) ||
-        tpl.description.toLowerCase().includes(q) ||
-        tpl.compliance_refs.some((r) => r.toLowerCase().includes(q))
-      );
-    });
-  }, [templates, compRefFilter, query]);
-
-  const install = useMutation({
-    mutationFn: (names: string[]) => policyTemplatesApi.install(names),
-    onSuccess: (res) => {
-      message.success(
-        locale === "ko"
-          ? `${res.installed}건 적용됨 · 기존 중복 ${res.skipped_existing}건 건너뜀`
-          : `Installed ${res.installed} · skipped ${res.skipped_existing}`,
-      );
-      qc.invalidateQueries({ queryKey: ["policies"] });
-      setSelected(new Set());
-      setCatalogOpen(false);
-    },
-    onError: (err: Error & { response?: { data?: { detail?: string } } }) =>
-      message.error(err.response?.data?.detail ?? err.message),
-  });
-
-  const canInstall = hasRole(user, "admin");
-
   return (
     <div>
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
-        <Title level={2} style={{ margin: 0 }}>
-          {t.policies.title}
-        </Title>
-        <Tooltip title={canInstall ? "" : (locale === "ko" ? "ADMIN 권한 필요" : "ADMIN required")}>
-          <Button
-            type="primary"
-            icon={<AppstoreAddOutlined />}
-            disabled={!canInstall}
-            onClick={() => setCatalogOpen(true)}
-          >
-            {t.policies.openCatalog}
-          </Button>
-        </Tooltip>
-      </div>
+      <Title level={2} style={{ marginBottom: 8 }}>
+        {t.policies.title}
+      </Title>
       <Paragraph type="secondary">{t.policies.desc}</Paragraph>
 
       <Card style={{ marginBottom: 16 }}>
@@ -188,109 +112,6 @@ export default function Policies() {
           ]}
         />
       </Card>
-
-      <Modal
-        title={
-          <Space>
-            <SafetyOutlined />
-            <span>{t.policies.catalogTitle}</span>
-          </Space>
-        }
-        open={catalogOpen}
-        onCancel={() => {
-          setCatalogOpen(false);
-          setSelected(new Set());
-        }}
-        width={920}
-        okText={`${t.policies.installSelected} (${selected.size})`}
-        okButtonProps={{ disabled: selected.size === 0 || install.isPending }}
-        confirmLoading={install.isPending}
-        onOk={() => install.mutate(Array.from(selected))}
-      >
-        <Paragraph type="secondary">{t.policies.catalogDesc}</Paragraph>
-        <Space direction="vertical" style={{ width: "100%" }} size="middle">
-          <FrameworkFilter
-            value={framework}
-            onChange={setFramework}
-            frameworks={frameworks ?? []}
-            locale={locale}
-            t={t}
-          />
-          <Input.Search
-            placeholder={t.policies.searchPlaceholder}
-            allowClear
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-          />
-          <Alert
-            type="info"
-            showIcon
-            message={
-              locale === "ko"
-                ? `${filteredTemplates.length}개 템플릿 · 이미 적용된 정책은 자동으로 건너뜁니다.`
-                : `${filteredTemplates.length} templates · already-installed ones are skipped.`
-            }
-          />
-          <div style={{ maxHeight: 460, overflowY: "auto", paddingRight: 4 }}>
-            <Space direction="vertical" style={{ width: "100%" }}>
-              {filteredTemplates.map((tpl: PolicyTemplate) => {
-                const isInstalled = installed.has(tpl.name);
-                const isChecked = selected.has(tpl.name);
-                return (
-                  <Card
-                    key={tpl.name}
-                    size="small"
-                    style={{
-                      borderColor: isChecked ? "var(--mond-primary)" : undefined,
-                      opacity: isInstalled ? 0.55 : 1,
-                    }}
-                  >
-                    <Space align="start" style={{ width: "100%" }}>
-                      <Checkbox
-                        checked={isChecked}
-                        disabled={isInstalled}
-                        onChange={(e) => {
-                          setSelected((cur) => {
-                            const n = new Set(cur);
-                            if (e.target.checked) n.add(tpl.name);
-                            else n.delete(tpl.name);
-                            return n;
-                          });
-                        }}
-                      />
-                      <div style={{ flex: 1 }}>
-                        <Space size={[6, 6]} wrap>
-                          <Text strong>{tpl.name}</Text>
-                          <Tag color="purple">{tpl.policy_type}</Tag>
-                          <Tag>{tpl.severity_threshold}</Tag>
-                          {isInstalled && (
-                            <Tag color="default">
-                              {locale === "ko" ? "이미 적용됨" : "Installed"}
-                            </Tag>
-                          )}
-                        </Space>
-                        <Paragraph style={{ marginTop: 6, marginBottom: 6 }}>
-                          {tpl.description}
-                        </Paragraph>
-                        <Space size={[4, 4]} wrap>
-                          {tpl.compliance_refs.map((r) => (
-                            <Tag key={r} color={tagColor(r)}>
-                              {r}
-                            </Tag>
-                          ))}
-                        </Space>
-                      </div>
-                    </Space>
-                  </Card>
-                );
-              })}
-              {filteredTemplates.length === 0 && (
-                <Empty description={locale === "ko" ? "해당 규제 템플릿이 없습니다" : "No templates"} />
-              )}
-            </Space>
-          </div>
-        </Space>
-      </Modal>
     </div>
   );
 }
@@ -316,12 +137,7 @@ function FrameworkFilter({
     })),
   ];
   return (
-    <Segmented
-      block
-      value={value}
-      onChange={(v) => onChange(v as string)}
-      options={options}
-    />
+    <Segmented block value={value} onChange={(v) => onChange(v as string)} options={options} />
   );
 }
 

--- a/frontend/src/pages/admin/AdminConnections.tsx
+++ b/frontend/src/pages/admin/AdminConnections.tsx
@@ -1,0 +1,250 @@
+/**
+ * 🌙 Admin · Connections — 외부 시스템 연동 통합 관리 (IAM Source · SSO · Webhook)
+ */
+
+import { ApiOutlined, CloudOutlined, PlusOutlined, SafetyOutlined, SyncOutlined } from "@ant-design/icons";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Form,
+  Input,
+  Modal,
+  Row,
+  Select,
+  Space,
+  Table,
+  Tag,
+  Typography,
+  message,
+} from "antd";
+import { useState } from "react";
+
+import { useI18n } from "@/i18n";
+import { authApi } from "@/lib/auth-api";
+import { iamApi, type IAMSource, type IAMSourceKind } from "@/lib/iam-api";
+
+const { Title, Paragraph, Text } = Typography;
+
+const KIND_OPTIONS: IAMSourceKind[] = ["aws", "gcp", "azure", "k8s", "custom"];
+
+export default function AdminConnections() {
+  const { t, locale } = useI18n();
+  const qc = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [form] = Form.useForm();
+
+  const { data: sources } = useQuery({ queryKey: ["admin-iam-sources"], queryFn: iamApi.listSources });
+  const { data: providers } = useQuery({ queryKey: ["auth-providers"], queryFn: authApi.providers });
+
+  const sync = useMutation({
+    mutationFn: (id: number) => iamApi.syncSource(id),
+    onSuccess: (data) => {
+      message.success(
+        `${(data.imported_identities as number) ?? 0} identities · ${
+          (data.imported_permissions as number) ?? 0
+        } permissions`,
+      );
+      qc.invalidateQueries({ queryKey: ["admin-iam-sources"] });
+      qc.invalidateQueries({ queryKey: ["iam-identities"] });
+      qc.invalidateQueries({ queryKey: ["iam-permissions"] });
+    },
+  });
+
+  const create = useMutation({
+    mutationFn: (body: { name: string; kind: IAMSourceKind; config: Record<string, unknown>; credentials_env_ref: Record<string, string> }) =>
+      iamApi.createSource(body),
+    onSuccess: () => {
+      message.success(t.iam.sourceCreated);
+      qc.invalidateQueries({ queryKey: ["admin-iam-sources"] });
+      setOpen(false);
+      form.resetFields();
+    },
+  });
+
+  return (
+    <div>
+      <Title level={2} style={{ marginBottom: 8 }}>
+        {t.adminArea.connectionsTitle}
+      </Title>
+      <Paragraph type="secondary">{t.adminArea.connectionsDesc}</Paragraph>
+
+      {/* ── IAM Source ─────────────────────────────────────── */}
+      <Card
+        title={
+          <Space>
+            <CloudOutlined />
+            <span>{t.adminArea.iamSources}</span>
+          </Space>
+        }
+        extra={
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setOpen(true)}>
+            {t.iam.addSource}
+          </Button>
+        }
+        style={{ marginBottom: 16 }}
+      >
+        <Table
+          dataSource={sources ?? []}
+          rowKey="id"
+          size="small"
+          pagination={false}
+          columns={[
+            { title: "ID", dataIndex: "id", width: 60 },
+            { title: t.common.name, dataIndex: "name" },
+            {
+              title: t.common.type,
+              dataIndex: "kind",
+              render: (k: string) => <Tag color="purple">{k.toUpperCase()}</Tag>,
+              width: 100,
+            },
+            { title: "last sync", dataIndex: "last_synced_at_str", render: (v: string | null) => v || "—" },
+            {
+              title: t.iam.sync,
+              render: (_: unknown, r: IAMSource) => (
+                <Button size="small" icon={<SyncOutlined />} onClick={() => sync.mutate(r.id)}>
+                  {t.iam.syncSource}
+                </Button>
+              ),
+              width: 140,
+            },
+          ]}
+        />
+      </Card>
+
+      {/* ── SSO Providers ─────────────────────────────────── */}
+      <Card
+        title={
+          <Space>
+            <SafetyOutlined />
+            <span>{t.adminArea.ssoTitle}</span>
+          </Space>
+        }
+        style={{ marginBottom: 16 }}
+      >
+        <Paragraph type="secondary">{t.adminArea.ssoDesc}</Paragraph>
+        <Row gutter={[12, 12]}>
+          <Col xs={24} md={12}>
+            <Card type="inner" title={t.adminArea.ssoMode}>
+              <Tag color={providers?.mode === "sso" ? "green" : "orange"}>{providers?.mode ?? "—"}</Tag>
+              <Text type="secondary" style={{ marginLeft: 8 }}>
+                {providers?.dev_login_enabled
+                  ? locale === "ko"
+                    ? "Dev Login 활성"
+                    : "Dev login enabled"
+                  : locale === "ko"
+                    ? "Dev Login 비활성"
+                    : "Dev login disabled"}
+              </Text>
+            </Card>
+          </Col>
+          <Col xs={24} md={12}>
+            <Card type="inner" title={t.adminArea.ssoActive}>
+              {(providers?.providers ?? []).length === 0 ? (
+                <Text type="secondary">
+                  {locale === "ko"
+                    ? "활성 IdP 없음 — .env에 SSO_PROVIDERS와 해당 ENV를 설정하고 백엔드를 재시작하세요."
+                    : "No IdP configured — set SSO_PROVIDERS in .env and restart the backend."}
+                </Text>
+              ) : (
+                <Space wrap>
+                  {providers!.providers.map((p) => (
+                    <Tag key={p.name} color="geekblue">
+                      {p.display}
+                    </Tag>
+                  ))}
+                </Space>
+              )}
+            </Card>
+          </Col>
+        </Row>
+        <Alert
+          style={{ marginTop: 12 }}
+          type="info"
+          showIcon
+          message={t.adminArea.ssoEnvHint}
+          description={
+            <pre style={{ marginBottom: 0, fontSize: 12 }}>
+{`AUTH_MODE=sso
+SSO_PROVIDERS=keycloak,okta
+SSO_KEYCLOAK_ISSUER=https://kc.example.com/realms/main
+SSO_KEYCLOAK_CLIENT_ID=mond
+SSO_KEYCLOAK_CLIENT_SECRET=...
+SSO_ADMIN_EMAILS=security-lead@example.com`}
+            </pre>
+          }
+        />
+      </Card>
+
+      {/* ── Webhook ─────────────────────────────────────── */}
+      <Card
+        title={
+          <Space>
+            <ApiOutlined />
+            <span>{t.adminArea.webhookTitle}</span>
+          </Space>
+        }
+      >
+        <Paragraph type="secondary">{t.adminArea.webhookDesc}</Paragraph>
+        <Alert
+          type="info"
+          showIcon
+          message={
+            <>
+              GitHub Settings → Webhooks →{" "}
+              <code>https://&lt;your-mond&gt;/api/v1/webhooks/github</code>
+            </>
+          }
+          description={
+            <>
+              Content type: <code>application/json</code>. Secret 설정 시 ENV의{" "}
+              <code>GITHUB_WEBHOOK_SECRET</code>과 동일하게 맞추세요.
+            </>
+          }
+        />
+      </Card>
+
+      <Modal
+        title={t.iam.addSource}
+        open={open}
+        onOk={() => form.submit()}
+        onCancel={() => setOpen(false)}
+        confirmLoading={create.isPending}
+      >
+        <Form
+          form={form}
+          layout="vertical"
+          onFinish={(values) =>
+            create.mutate({
+              name: values.name,
+              kind: values.kind,
+              config: { region: values.region },
+              credentials_env_ref: {
+                access_key_id: values.access_key_env || "AWS_ACCESS_KEY_ID",
+                secret_access_key: values.secret_key_env || "AWS_SECRET_ACCESS_KEY",
+              },
+            })
+          }
+        >
+          <Form.Item label={t.iam.fields.source} name="name" rules={[{ required: true }]}>
+            <Input placeholder="aws-prod" />
+          </Form.Item>
+          <Form.Item label={t.iam.fields.type} name="kind" rules={[{ required: true }]}>
+            <Select options={KIND_OPTIONS.map((k) => ({ value: k, label: k.toUpperCase() }))} />
+          </Form.Item>
+          <Form.Item label="region" name="region">
+            <Input placeholder="us-east-1" />
+          </Form.Item>
+          <Form.Item label="ENV name for access key" name="access_key_env">
+            <Input placeholder="AWS_ACCESS_KEY_ID" />
+          </Form.Item>
+          <Form.Item label="ENV name for secret key" name="secret_key_env">
+            <Input placeholder="AWS_SECRET_ACCESS_KEY" />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminPolicies.tsx
+++ b/frontend/src/pages/admin/AdminPolicies.tsx
@@ -1,0 +1,362 @@
+/**
+ * 🌙 Admin · Policy Management — 정책 enable/disable, threshold 조정, 삭제 + 템플릿 카탈로그
+ */
+
+import { AppstoreAddOutlined, DeleteOutlined, SafetyOutlined } from "@ant-design/icons";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Alert,
+  Button,
+  Card,
+  Checkbox,
+  Empty,
+  Input,
+  Modal,
+  Popconfirm,
+  Segmented,
+  Select,
+  Space,
+  Switch,
+  Table,
+  Tag,
+  Typography,
+  message,
+} from "antd";
+import { useMemo, useState } from "react";
+
+import { useI18n } from "@/i18n";
+import { api, type Policy } from "@/lib/api";
+import {
+  policyTemplatesApi,
+  type FrameworkInfo,
+  type PolicyTemplate,
+} from "@/lib/policy-templates-api";
+
+const { Title, Paragraph, Text } = Typography;
+
+const ALL = "__all__";
+const SEVERITIES = ["critical", "high", "medium", "low", "info"];
+
+async function fetchPolicies(): Promise<Policy[]> {
+  const { data } = await api.get<Policy[]>("/policies");
+  return data;
+}
+
+export default function AdminPolicies() {
+  const { t, locale } = useI18n();
+  const qc = useQueryClient();
+  const [catalogOpen, setCatalogOpen] = useState(false);
+  const [framework, setFramework] = useState<string>(ALL);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const { data: policies, isLoading } = useQuery({ queryKey: ["policies"], queryFn: fetchPolicies });
+  const { data: frameworks } = useQuery({
+    queryKey: ["policy-templates-frameworks"],
+    queryFn: policyTemplatesApi.frameworks,
+  });
+  const { data: templates } = useQuery({
+    queryKey: ["policy-templates"],
+    queryFn: () => policyTemplatesApi.list(),
+    enabled: catalogOpen,
+  });
+
+  const updatePolicy = useMutation({
+    mutationFn: ({ id, patch }: { id: number; patch: Partial<Policy> }) =>
+      api.patch<Policy>(`/policies/${id}`, patch).then((r) => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["policies"] }),
+  });
+
+  const deletePolicy = useMutation({
+    mutationFn: (id: number) => api.delete(`/policies/${id}`),
+    onSuccess: () => {
+      message.success(locale === "ko" ? "삭제됨" : "Deleted");
+      qc.invalidateQueries({ queryKey: ["policies"] });
+    },
+  });
+
+  const installed = useMemo(() => new Set((policies ?? []).map((p) => p.name)), [policies]);
+  const compRefFilter = framework === ALL ? null : framework;
+
+  const filteredPolicies = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return (policies ?? []).filter((p) => {
+      if (compRefFilter && !p.compliance_refs.some((r) => r.startsWith(compRefFilter))) return false;
+      if (!q) return true;
+      const hay = `${p.name} ${p.description ?? ""} ${p.compliance_refs.join(" ")}`.toLowerCase();
+      return hay.includes(q);
+    });
+  }, [policies, compRefFilter, query]);
+
+  const filteredTemplates = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return (templates ?? []).filter((tpl) => {
+      if (compRefFilter && !tpl.frameworks.includes(compRefFilter)) return false;
+      if (!q) return true;
+      return (
+        tpl.name.toLowerCase().includes(q) ||
+        tpl.description.toLowerCase().includes(q) ||
+        tpl.compliance_refs.some((r) => r.toLowerCase().includes(q))
+      );
+    });
+  }, [templates, compRefFilter, query]);
+
+  const install = useMutation({
+    mutationFn: (names: string[]) => policyTemplatesApi.install(names),
+    onSuccess: (res) => {
+      message.success(
+        locale === "ko"
+          ? `${res.installed}건 적용 · 중복 ${res.skipped_existing}건`
+          : `Installed ${res.installed} · skipped ${res.skipped_existing}`,
+      );
+      qc.invalidateQueries({ queryKey: ["policies"] });
+      setSelected(new Set());
+      setCatalogOpen(false);
+    },
+  });
+
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+        <Title level={2} style={{ margin: 0 }}>
+          {t.adminArea.policyMgmtTitle}
+        </Title>
+        <Button type="primary" icon={<AppstoreAddOutlined />} onClick={() => setCatalogOpen(true)}>
+          {t.policies.openCatalog}
+        </Button>
+      </div>
+      <Paragraph type="secondary">{t.adminArea.policyMgmtDesc}</Paragraph>
+
+      <Card style={{ marginBottom: 16 }}>
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <FrameworkFilter
+            value={framework}
+            onChange={setFramework}
+            frameworks={frameworks ?? []}
+            locale={locale}
+            t={t}
+          />
+          <Input.Search
+            placeholder={t.policies.searchPlaceholder}
+            allowClear
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </Space>
+      </Card>
+
+      <Card>
+        <Table
+          loading={isLoading}
+          dataSource={filteredPolicies}
+          rowKey="id"
+          locale={{
+            emptyText: <Empty description={locale === "ko" ? "정책이 없습니다" : "No policies"} />,
+          }}
+          columns={[
+            { title: t.common.name, dataIndex: "name" },
+            {
+              title: t.common.type,
+              dataIndex: "policy_type",
+              render: (v: string) => <Tag color="purple">{v}</Tag>,
+              width: 130,
+            },
+            {
+              title: t.policies.threshold,
+              dataIndex: "severity_threshold",
+              width: 130,
+              render: (v: string, r: Policy) => (
+                <Select
+                  size="small"
+                  value={v}
+                  style={{ width: "100%" }}
+                  options={SEVERITIES.map((s) => ({ value: s, label: s }))}
+                  onChange={(val) =>
+                    updatePolicy.mutate({ id: r.id, patch: { severity_threshold: val } as Partial<Policy> })
+                  }
+                />
+              ),
+            },
+            {
+              title: t.common.enabled,
+              dataIndex: "enabled",
+              render: (v: boolean, r: Policy) => (
+                <Switch
+                  checked={v}
+                  onChange={(checked) =>
+                    updatePolicy.mutate({ id: r.id, patch: { enabled: checked } as Partial<Policy> })
+                  }
+                />
+              ),
+              width: 100,
+            },
+            {
+              title: t.policies.compliance,
+              dataIndex: "compliance_refs",
+              render: (refs: string[]) => (
+                <Space size={[4, 4]} wrap>
+                  {(refs ?? []).map((rf) => (
+                    <Tag key={rf} color={tagColor(rf)}>
+                      {rf}
+                    </Tag>
+                  ))}
+                </Space>
+              ),
+            },
+            { title: t.common.description, dataIndex: "description", ellipsis: true },
+            {
+              title: "",
+              width: 60,
+              render: (_: unknown, r: Policy) => (
+                <Popconfirm
+                  title={locale === "ko" ? "이 정책을 삭제할까요?" : "Delete this policy?"}
+                  okType="danger"
+                  onConfirm={() => deletePolicy.mutate(r.id)}
+                >
+                  <Button size="small" type="text" danger icon={<DeleteOutlined />} />
+                </Popconfirm>
+              ),
+            },
+          ]}
+        />
+      </Card>
+
+      <Modal
+        title={
+          <Space>
+            <SafetyOutlined />
+            <span>{t.policies.catalogTitle}</span>
+          </Space>
+        }
+        open={catalogOpen}
+        onCancel={() => {
+          setCatalogOpen(false);
+          setSelected(new Set());
+        }}
+        width={920}
+        okText={`${t.policies.installSelected} (${selected.size})`}
+        okButtonProps={{ disabled: selected.size === 0 || install.isPending }}
+        confirmLoading={install.isPending}
+        onOk={() => install.mutate(Array.from(selected))}
+      >
+        <Paragraph type="secondary">{t.policies.catalogDesc}</Paragraph>
+        <Space direction="vertical" style={{ width: "100%" }} size="middle">
+          <FrameworkFilter
+            value={framework}
+            onChange={setFramework}
+            frameworks={frameworks ?? []}
+            locale={locale}
+            t={t}
+          />
+          <Input.Search
+            placeholder={t.policies.searchPlaceholder}
+            allowClear
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <Alert
+            type="info"
+            showIcon
+            message={
+              locale === "ko"
+                ? `${filteredTemplates.length}개 템플릿 · 이미 적용된 정책은 자동으로 건너뜁니다.`
+                : `${filteredTemplates.length} templates · already-installed ones are skipped.`
+            }
+          />
+          <div style={{ maxHeight: 460, overflowY: "auto", paddingRight: 4 }}>
+            <Space direction="vertical" style={{ width: "100%" }}>
+              {filteredTemplates.map((tpl: PolicyTemplate) => {
+                const isInstalled = installed.has(tpl.name);
+                const isChecked = selected.has(tpl.name);
+                return (
+                  <Card
+                    key={tpl.name}
+                    size="small"
+                    style={{
+                      borderColor: isChecked ? "var(--mond-primary)" : undefined,
+                      opacity: isInstalled ? 0.55 : 1,
+                    }}
+                  >
+                    <Space align="start" style={{ width: "100%" }}>
+                      <Checkbox
+                        checked={isChecked}
+                        disabled={isInstalled}
+                        onChange={(e) => {
+                          setSelected((cur) => {
+                            const n = new Set(cur);
+                            if (e.target.checked) n.add(tpl.name);
+                            else n.delete(tpl.name);
+                            return n;
+                          });
+                        }}
+                      />
+                      <div style={{ flex: 1 }}>
+                        <Space size={[6, 6]} wrap>
+                          <Text strong>{tpl.name}</Text>
+                          <Tag color="purple">{tpl.policy_type}</Tag>
+                          <Tag>{tpl.severity_threshold}</Tag>
+                          {isInstalled && (
+                            <Tag color="default">
+                              {locale === "ko" ? "이미 적용됨" : "Installed"}
+                            </Tag>
+                          )}
+                        </Space>
+                        <Paragraph style={{ marginTop: 6, marginBottom: 6 }}>{tpl.description}</Paragraph>
+                        <Space size={[4, 4]} wrap>
+                          {tpl.compliance_refs.map((rf) => (
+                            <Tag key={rf} color={tagColor(rf)}>
+                              {rf}
+                            </Tag>
+                          ))}
+                        </Space>
+                      </div>
+                    </Space>
+                  </Card>
+                );
+              })}
+              {filteredTemplates.length === 0 && (
+                <Empty description={locale === "ko" ? "해당 규제 템플릿이 없습니다" : "No templates"} />
+              )}
+            </Space>
+          </div>
+        </Space>
+      </Modal>
+    </div>
+  );
+}
+
+function FrameworkFilter({
+  value,
+  onChange,
+  frameworks,
+  locale,
+  t,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  frameworks: FrameworkInfo[];
+  locale: "ko" | "en";
+  t: { policies: { allFrameworks: string } };
+}) {
+  const options = [
+    { value: ALL, label: t.policies.allFrameworks },
+    ...frameworks.map((f) => ({
+      value: f.id,
+      label: locale === "ko" ? f.name_ko.split(" (")[0] : f.name_en.split(" (")[0],
+    })),
+  ];
+  return <Segmented block value={value} onChange={(v) => onChange(v as string)} options={options} />;
+}
+
+function tagColor(ref: string): string {
+  if (ref.startsWith("ISMS-P")) return "geekblue";
+  if (ref.startsWith("K-EFSA")) return "blue";
+  if (ref.startsWith("K-CSAP")) return "cyan";
+  if (ref.startsWith("K-PIPA")) return "volcano";
+  if (ref.startsWith("ISO-27001")) return "purple";
+  if (ref.startsWith("OWASP")) return "magenta";
+  if (ref.startsWith("CIS")) return "gold";
+  if (ref.startsWith("PCI")) return "red";
+  if (ref.startsWith("GDPR")) return "lime";
+  return "default";
+}

--- a/frontend/src/pages/admin/AdminUsers.tsx
+++ b/frontend/src/pages/admin/AdminUsers.tsx
@@ -1,0 +1,106 @@
+/**
+ * 🌙 Admin · Users — 사용자 목록 + Role 변경 (ADMIN 전용)
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Avatar, Card, Select, Space, Table, Tag, Typography, message } from "antd";
+import { UserOutlined } from "@ant-design/icons";
+
+import { useAuth } from "@/auth/AuthContext";
+import { useI18n } from "@/i18n";
+import type { Role } from "@/lib/auth-api";
+import { usersApi, type AdminUser } from "@/lib/users-api";
+
+const { Title, Paragraph } = Typography;
+
+const ROLES: Role[] = ["viewer", "employee", "reviewer", "admin"];
+
+const ROLE_COLOR: Record<Role, string> = {
+  viewer: "default",
+  employee: "blue",
+  reviewer: "purple",
+  admin: "red",
+};
+
+export default function AdminUsers() {
+  const { t, locale } = useI18n();
+  const { user: me } = useAuth();
+  const qc = useQueryClient();
+
+  const { data, isLoading } = useQuery({ queryKey: ["admin-users"], queryFn: usersApi.list });
+
+  const updateRole = useMutation({
+    mutationFn: ({ id, role }: { id: number; role: Role }) => usersApi.updateRole(id, role),
+    onSuccess: () => {
+      message.success(locale === "ko" ? "역할 변경됨" : "Role updated");
+      qc.invalidateQueries({ queryKey: ["admin-users"] });
+    },
+    onError: (err: Error & { response?: { data?: { detail?: string } } }) =>
+      message.error(err.response?.data?.detail ?? err.message),
+  });
+
+  return (
+    <div>
+      <Title level={2} style={{ marginBottom: 8 }}>
+        {t.adminArea.usersTitle}
+      </Title>
+      <Paragraph type="secondary">{t.adminArea.usersDesc}</Paragraph>
+
+      <Card>
+        <Table
+          loading={isLoading}
+          dataSource={data ?? []}
+          rowKey="id"
+          columns={[
+            {
+              title: t.adminArea.user,
+              render: (_: unknown, u: AdminUser) => (
+                <Space>
+                  <Avatar size={28} src={u.picture_url ?? undefined} icon={!u.picture_url && <UserOutlined />} />
+                  <Space direction="vertical" size={0}>
+                    <span>{u.name || u.email}</span>
+                    <span style={{ color: "var(--mond-text-dim)", fontSize: 12 }}>{u.email}</span>
+                  </Space>
+                </Space>
+              ),
+            },
+            {
+              title: t.adminArea.ssoProvider,
+              dataIndex: "sso_provider",
+              render: (v: string | null) => (v ? <Tag>{v}</Tag> : "—"),
+              width: 120,
+            },
+            {
+              title: t.adminArea.role,
+              dataIndex: "role",
+              render: (r: Role, u: AdminUser) => (
+                <Select
+                  size="small"
+                  value={r}
+                  style={{ width: 140 }}
+                  options={ROLES.map((opt) => ({
+                    value: opt,
+                    label: (
+                      <Tag color={ROLE_COLOR[opt]} style={{ marginRight: 0 }}>
+                        {opt.toUpperCase()}
+                      </Tag>
+                    ),
+                  }))}
+                  onChange={(val) => updateRole.mutate({ id: u.id, role: val })}
+                  disabled={me?.id === u.id && r === "admin"}
+                />
+              ),
+              width: 180,
+            },
+            {
+              title: t.adminArea.lastLogin,
+              dataIndex: "last_login_at_iso",
+              render: (v: string | null) => (v ? new Date(v).toLocaleString() : "—"),
+              width: 200,
+            },
+          ]}
+        />
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
외부 연동(IAM Source, SSO, Webhook), 정책 룰셋 수정, 사용자 역할 변경을 관리자 모드 안으로 분리. /admin/access-review·policies·connections·users 4개 관리자 페이지 + 기존 일반 페이지 read-only화. 자세한 내용은 commit message 참고.