### PR TITLE
fix(frontend): nginx-unprivileged 1.27 호환 — templates 패턴 + 8080 포트 매핑

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,8 +93,9 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     container_name: mond-frontend
+    # nginx-unprivileged는 컨테이너 안에서 8080을 listen. host 3000 → container 8080.
     ports:
-      - "3000:3000"
+      - "3000:8080"
     environment:
       VITE_API_URL: http://localhost:8000
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -28,12 +28,16 @@ RUN npm run build
 # ── 2) 런타임 스테이지 (nginx unprivileged) ────────────────────
 FROM nginxinc/nginx-unprivileged:${NGINX_VERSION} AS runtime
 
-# nginx-unprivileged는 기본 8080 포트 + nginx user
+# nginx-unprivileged는 기본 8080 포트 + nginx user.
+# nginx.conf는 templates/로 두면 표준 entrypoint(20-envsubst-on-templates.sh)가
+# ${MOND_API_UPSTREAM} 등을 ENV로 치환해 /etc/nginx/conf.d/default.conf로 작성한다.
 USER root
 RUN rm -f /etc/nginx/conf.d/default.conf
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
 USER nginx
+
+ENV MOND_API_UPSTREAM=http://backend:8000
 
 EXPOSE 8080
 

--- a/frontend/docker-entrypoint.d/10-render-conf.sh
+++ b/frontend/docker-entrypoint.d/10-render-conf.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-# 🌙 nginx.conf의 ${MOND_API_UPSTREAM}을 런타임 ENV로 치환한다.
-# nginx-unprivileged 이미지가 /docker-entrypoint.d/*.sh를 자동 실행한다.
-set -eu
-: "${MOND_API_UPSTREAM:=http://backend:8000}"
-envsubst '${MOND_API_UPSTREAM}' \
-  < /etc/nginx/conf.d/default.conf \
-  > /tmp/default.conf \
-  && cat /tmp/default.conf > /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## 증상
rebuild 후 nginx가 `unknown "mond_api_upstream" variable` 로 기동 실패. 컨테이너 안에서는 8080 listen인데 docker-compose는 `3000:3000` 매핑이라 HTTP 000.

## 원인
nginx-unprivileged 1.27이 `/etc/nginx/conf.d`를 read-only로 만듦. 기존 entrypoint(`10-render-conf.sh`)가 envsubst 결과를 conf.d로 덮어쓰려다 실패 → 미치환 \`\${MOND_API_UPSTREAM}\` 으로 기동.

## 수정
- `frontend/Dockerfile` — `nginx.conf` → `/etc/nginx/templates/default.conf.template` 표준 패턴. nginx-unprivileged 표준 entrypoint(`20-envsubst-on-templates.sh`)가 자동 치환.
- `ENV MOND_API_UPSTREAM=http://backend:8000` 기본값.
- `frontend/docker-entrypoint.d/10-render-conf.sh` — 표준 entrypoint와 중복이라 삭제.
- `docker-compose.yml` — ports `3000:3000` → `3000:8080`.

## 검증
- [x] `docker compose build frontend && up -d` → HTTP 200
- [x] 로그인 + Dashboard / Admin Connections / Security / IAM Explorer 정상 렌더
- [x] console 에러 0건
- [x] `/api/v1/iam/capabilities` → 6 providers 정상