### PR TITLE
feat: Wave 2 — My Mond + Findings bulk triage

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -15,6 +15,7 @@ from app.api.v1.endpoints import (
     iam,
     integrations,
     knowledge,
+    me,
     mfa,
     policies,
     policy_sim,
@@ -34,6 +35,7 @@ api_router.include_router(health.router, tags=["Health"])
 api_router.include_router(auth.router, prefix="/auth", tags=["Auth"])
 api_router.include_router(mfa.router, prefix="/auth/mfa", tags=["MFA"])
 api_router.include_router(dashboard.router, prefix="/dashboard", tags=["Dashboard"])
+api_router.include_router(me.router, prefix="/me", tags=["My Mond"])
 api_router.include_router(assets.router, prefix="/assets", tags=["Assets"])
 api_router.include_router(scans.router, prefix="/scans", tags=["Scans"])
 api_router.include_router(findings.router, prefix="/findings", tags=["Findings"])

--- a/backend/app/api/v1/endpoints/findings.py
+++ b/backend/app/api/v1/endpoints/findings.py
@@ -6,12 +6,13 @@ Finding 엔드포인트
   - PATCH  : REVIEWER 이상 — 상태 변경(False Positive 등)은 보안 담당자
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.deps import current_user, require_role
 from app.core.database import get_db
-from app.models.finding import FindingStatus, Severity
+from app.models.finding import Finding, FindingStatus, Severity
 from app.models.user import Role, User
 from app.schemas.common import Page
 from app.schemas.finding import FindingRead, FindingUpdate
@@ -75,3 +76,37 @@ async def update_finding(
         raise HTTPException(status_code=404, detail="Finding not found")
     updated = await finding_service.update_finding(db, f, payload)
     return FindingRead.model_validate(updated)
+
+
+@router.patch(
+    "/bulk/status",
+    dependencies=[Depends(require_role(Role.REVIEWER))],
+)
+async def bulk_update_status(
+    payload: dict = Body(
+        ...,
+        example={
+            "finding_ids": [1, 2, 3],
+            "status": "resolved",
+        },
+    ),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """선택된 발견사항에 같은 status를 일괄 적용.
+
+    매주 finding 100개 이상 처리하는 보안 담당자의 시간을 1/10로.
+    """
+    ids = payload.get("finding_ids") or []
+    status_str = payload.get("status")
+    if not ids or not status_str:
+        raise HTTPException(status_code=400, detail="finding_ids와 status 필요")
+    try:
+        new_status = FindingStatus(status_str)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"unknown status: {status_str}")
+
+    result = await db.execute(
+        sa_update(Finding).where(Finding.id.in_(ids)).values(status=new_status)
+    )
+    await db.commit()
+    return {"updated": result.rowcount or 0, "status": new_status.value, "ids": ids}

--- a/backend/app/api/v1/endpoints/me.py
+++ b/backend/app/api/v1/endpoints/me.py
@@ -1,0 +1,24 @@
+"""
+'내 페이지' 엔드포인트 — 본인 자산 / 자기 발견사항 / 권한 요청 / 만료 임박 집계.
+
+권한: 인증된 사용자만. 본인 데이터만 노출 (다른 사용자 데이터 leak 금지).
+"""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.deps import current_user
+from app.core.database import get_db
+from app.models.user import User
+from app.services import me as me_service
+
+router = APIRouter()
+
+
+@router.get("/overview")
+async def overview(
+    user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """본인 화면에 쓰일 데이터 묶음."""
+    return await me_service.get_me_overview(db, user)

--- a/backend/app/services/me.py
+++ b/backend/app/services/me.py
@@ -1,0 +1,159 @@
+"""
+'내 페이지' 집계 — 본인이 소유한 자산, 자기 발견사항, 자기 권한 요청, 활성 권한.
+
+owner 매핑은 Asset.owner = user.email 기준.
+세분화된 assignee 모델은 v0.2 backlog. 지금은 자산 소유로 derive.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.asset import Asset
+from app.models.finding import Finding, FindingStatus
+from app.models.iam import AccessRequest, AccessRequestStatus
+from app.models.scan import Scan
+from app.models.user import User
+
+
+async def get_me_overview(session: AsyncSession, user: User) -> dict:
+    """본인 화면에 쓰일 데이터 한 묶음."""
+    now = datetime.now(timezone.utc)
+    soon = now + timedelta(days=7)
+
+    # 내 자산 — owner == email
+    my_assets_q = await session.execute(
+        select(Asset).where(Asset.owner == user.email).order_by(Asset.created_at.desc()).limit(50)
+    )
+    my_assets = my_assets_q.scalars().all()
+    asset_ids = [a.id for a in my_assets]
+
+    # 미해결 발견사항 합계
+    open_findings_total = 0
+    open_by_severity: dict[str, int] = {}
+    recent_findings: list[Finding] = []
+    if asset_ids:
+        q = await session.execute(
+            select(Finding)
+            .where(
+                and_(
+                    Finding.asset_id.in_(asset_ids),
+                    Finding.status.in_([FindingStatus.NEW, FindingStatus.TRIAGED, FindingStatus.IN_PROGRESS]),
+                )
+            )
+            .order_by(Finding.created_at.desc())
+            .limit(200)
+        )
+        all_open = q.scalars().all()
+        open_findings_total = len(all_open)
+        for f in all_open:
+            sev = f.severity.value
+            open_by_severity[sev] = open_by_severity.get(sev, 0) + 1
+        recent_findings = all_open[:10]
+
+    # 내 권한 요청 (requester == email) — 최근 20개
+    req_q = await session.execute(
+        select(AccessRequest)
+        .where(AccessRequest.requester == user.email)
+        .order_by(AccessRequest.created_at.desc())
+        .limit(20)
+    )
+    my_requests = req_q.scalars().all()
+
+    # 만료 임박 (현재로부터 7일 이내) 활성 권한
+    expiring_q = await session.execute(
+        select(AccessRequest)
+        .where(
+            and_(
+                AccessRequest.requester == user.email,
+                AccessRequest.status == AccessRequestStatus.APPROVED,
+                AccessRequest.revoked_at.is_(None),
+                AccessRequest.expires_at.is_not(None),
+                AccessRequest.expires_at <= soon,
+            )
+        )
+        .order_by(AccessRequest.expires_at.asc())
+    )
+    expiring = expiring_q.scalars().all()
+
+    # 최근 스캔 (자산 기준) 5개
+    recent_scans: list[Scan] = []
+    if asset_ids:
+        s_q = await session.execute(
+            select(Scan)
+            .where(Scan.asset_id.in_(asset_ids))
+            .order_by(Scan.created_at.desc())
+            .limit(5)
+        )
+        recent_scans = s_q.scalars().all()
+
+    return {
+        "user": {
+            "email": user.email,
+            "name": user.name,
+            "role": user.role,
+        },
+        "summary": {
+            "my_assets_total": len(my_assets),
+            "open_findings_total": open_findings_total,
+            "open_by_severity": open_by_severity,
+            "active_requests": sum(1 for r in my_requests if r.status == AccessRequestStatus.PENDING),
+            "expiring_soon": len(expiring),
+        },
+        "my_assets": [
+            {
+                "id": a.id,
+                "name": a.name,
+                "asset_type": a.asset_type.value,
+                "environment": a.environment,
+                "open_findings_count": a.open_findings_count,
+                "last_scanned_at_str": a.last_scanned_at_str,
+            }
+            for a in my_assets[:10]
+        ],
+        "recent_findings": [
+            {
+                "id": f.id,
+                "title": f.title,
+                "severity": f.severity.value,
+                "status": f.status.value,
+                "asset_id": f.asset_id,
+                "created_at": f.created_at.isoformat(),
+            }
+            for f in recent_findings
+        ],
+        "my_requests": [
+            {
+                "id": r.id,
+                "permission_name": r.permission.name if r.permission else "?",
+                "status": r.status.value,
+                "expires_at": r.expires_at.isoformat() if r.expires_at else None,
+                "revoked_at": r.revoked_at.isoformat() if r.revoked_at else None,
+                "created_at": r.created_at.isoformat(),
+            }
+            for r in my_requests
+        ],
+        "expiring_soon": [
+            {
+                "id": r.id,
+                "permission_name": r.permission.name if r.permission else "?",
+                "expires_at": r.expires_at.isoformat() if r.expires_at else None,
+                "days_left": max(0, int((r.expires_at - now).total_seconds() / 86400)) if r.expires_at else None,
+            }
+            for r in expiring
+        ],
+        "recent_scans": [
+            {
+                "id": s.id,
+                "asset_id": s.asset_id,
+                "scanner": s.scanner,
+                "status": s.status.value,
+                "findings_count": s.findings_count,
+                "created_at": s.created_at.isoformat(),
+            }
+            for s in recent_scans
+        ],
+    }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import IAMExplorer from "@/pages/IAMExplorer";
 import Integrations from "@/pages/Integrations";
 import KnowledgeHub from "@/pages/KnowledgeHub";
 import Login from "@/pages/Login";
+import MyMond from "@/pages/MyMond";
 import MfaChallenge from "@/pages/MfaChallenge";
 import Policies from "@/pages/Policies";
 import SecuritySettings from "@/pages/SecuritySettings";
@@ -49,6 +50,7 @@ export default function App() {
       >
         {/* 일반 영역 */}
         <Route index element={<Dashboard />} />
+        <Route path="me" element={<MyMond />} />
         <Route path="assets" element={<Assets />} />
         <Route
           path="scans"

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,6 +11,7 @@ import {
   BookOutlined,
   BulbOutlined,
   DashboardOutlined,
+  HomeOutlined,
   ExperimentOutlined,
   FileTextOutlined,
   GlobalOutlined,
@@ -50,6 +51,7 @@ export default function Layout() {
   // 사이드바 정보 위계 — 4그룹으로 미니멀 분할 (OVERVIEW / OPS / KNOWLEDGE / ACCESS).
   // 평탄 14개를 그룹으로 묶어 시각 노이즈를 낮추고 카테고리 navigation 가능.
   const overviewItems = [
+    { key: "/me", icon: <HomeOutlined />, label: t.menu.myMond, minRole: "viewer" as const },
     { key: "/", icon: <DashboardOutlined />, label: t.menu.dashboard, minRole: "viewer" as const },
   ].filter((i) => hasRole(user, i.minRole));
 

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -8,6 +8,7 @@ export const en: Dict = {
   language: { ko: "한국어", en: "English" },
 
   menu: {
+    myMond: "My Mond",
     dashboard: "Dashboard",
     assets: "Assets",
     scans: "Scans",

--- a/frontend/src/i18n/ko.ts
+++ b/frontend/src/i18n/ko.ts
@@ -6,6 +6,7 @@ export const ko = {
   language: { ko: "한국어", en: "English" },
 
   menu: {
+    myMond: "내 페이지",
     dashboard: "대시보드",
     assets: "자산",
     scans: "스캔",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -160,3 +160,52 @@ export interface DashboardOverview {
     at: string;
   }>;
 }
+
+export interface MeOverview {
+  user: { email: string; name: string | null; role: string };
+  summary: {
+    my_assets_total: number;
+    open_findings_total: number;
+    open_by_severity: Record<string, number>;
+    active_requests: number;
+    expiring_soon: number;
+  };
+  my_assets: Array<{
+    id: number;
+    name: string;
+    asset_type: string;
+    environment: string | null;
+    open_findings_count: number;
+    last_scanned_at_str: string | null;
+  }>;
+  recent_findings: Array<{
+    id: number;
+    title: string;
+    severity: Severity;
+    status: string;
+    asset_id: number;
+    created_at: string;
+  }>;
+  my_requests: Array<{
+    id: number;
+    permission_name: string;
+    status: string;
+    expires_at: string | null;
+    revoked_at: string | null;
+    created_at: string;
+  }>;
+  expiring_soon: Array<{
+    id: number;
+    permission_name: string;
+    expires_at: string | null;
+    days_left: number | null;
+  }>;
+  recent_scans: Array<{
+    id: number;
+    asset_id: number;
+    scanner: string;
+    status: ScanStatus;
+    findings_count: number;
+    created_at: string;
+  }>;
+}

--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -2,12 +2,13 @@
  * Findings — 발견된 보안 이슈 + 상태 변경 + AI 분석
  */
 
-import { BulbOutlined } from "@ant-design/icons";
+import { BulbOutlined, CheckOutlined } from "@ant-design/icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Alert,
   Button,
   Drawer,
+  Popconfirm,
   Select,
   Space,
   Table,
@@ -58,9 +59,10 @@ async function fetchInsights(findingId: number): Promise<AIInsight[]> {
 }
 
 export default function Findings() {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const qc = useQueryClient();
   const [selected, setSelected] = useState<Finding | null>(null);
+  const [checked, setChecked] = useState<number[]>([]);
 
   const { data, isLoading } = useQuery({ queryKey: ["findings"], queryFn: fetchFindings });
 
@@ -85,16 +87,69 @@ export default function Findings() {
     onSuccess: () => qc.invalidateQueries({ queryKey: ["findings"] }),
   });
 
+  const bulkUpdate = useMutation({
+    mutationFn: (status: FindingStatus) =>
+      api.patch<{ updated: number }>("/findings/bulk/status", {
+        finding_ids: checked,
+        status,
+      }),
+    onSuccess: (r) => {
+      message.success(
+        locale === "ko"
+          ? `${r.data.updated}개 발견사항 상태 변경됨`
+          : `${r.data.updated} findings updated`,
+      );
+      setChecked([]);
+      qc.invalidateQueries({ queryKey: ["findings"] });
+    },
+    onError: (err: Error) => message.error(err.message),
+  });
+
   return (
     <div>
       <Title level={2} style={{ marginBottom: 16 }}>
         {t.findings.title}
       </Title>
 
+      {checked.length > 0 && (
+        <Space style={{ marginBottom: 12 }} wrap>
+          <Tag color="blue" style={{ fontSize: 13, padding: "4px 10px" }}>
+            {locale === "ko" ? `${checked.length}개 선택됨` : `${checked.length} selected`}
+          </Tag>
+          <Popconfirm
+            title={locale === "ko" ? "선택한 발견을 해결로 표시할까요?" : "Mark selected as resolved?"}
+            onConfirm={() => bulkUpdate.mutate("resolved")}
+          >
+            <Button size="small" icon={<CheckOutlined />}>
+              {locale === "ko" ? "일괄: 해결" : "Bulk: Resolved"}
+            </Button>
+          </Popconfirm>
+          <Popconfirm
+            title={locale === "ko" ? "선택한 발견을 억제(무시)할까요?" : "Suppress selected?"}
+            onConfirm={() => bulkUpdate.mutate("suppressed")}
+          >
+            <Button size="small">{locale === "ko" ? "일괄: 억제" : "Bulk: Suppress"}</Button>
+          </Popconfirm>
+          <Popconfirm
+            title={locale === "ko" ? "선택한 발견을 false-positive로 표시할까요?" : "Mark as false-positive?"}
+            onConfirm={() => bulkUpdate.mutate("false_positive")}
+          >
+            <Button size="small">{locale === "ko" ? "일괄: False positive" : "Bulk: FP"}</Button>
+          </Popconfirm>
+          <Button size="small" type="text" onClick={() => setChecked([])}>
+            {locale === "ko" ? "선택 해제" : "Clear"}
+          </Button>
+        </Space>
+      )}
+
       <Table
         loading={isLoading}
         dataSource={data?.items ?? []}
         rowKey="id"
+        rowSelection={{
+          selectedRowKeys: checked,
+          onChange: (keys) => setChecked(keys as number[]),
+        }}
         onRow={(record) => ({ onClick: () => setSelected(record), style: { cursor: "pointer" } })}
         columns={[
           { title: "ID", dataIndex: "id", width: 70 },

--- a/frontend/src/pages/MyMond.tsx
+++ b/frontend/src/pages/MyMond.tsx
@@ -1,0 +1,244 @@
+/**
+ * My Mond — 임직원이 매일 처음 보는 본인 화면.
+ *
+ * 보안 담당자가 한 화면에서 조직 전체를 본다면,
+ * 임직원은 한 화면에서 본인 자산·발견·권한·만료 임박을 본다.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { Card, Col, Empty, List, Row, Space, Tag, Typography } from "antd";
+import { Link } from "react-router-dom";
+
+import { useAuth } from "@/auth/AuthContext";
+import { useI18n } from "@/i18n";
+import { api, type MeOverview, type Severity } from "@/lib/api";
+
+const { Title, Paragraph, Text } = Typography;
+
+const SEVERITY_COLOR: Record<Severity, string> = {
+  critical: "red",
+  high: "volcano",
+  medium: "orange",
+  low: "gold",
+  info: "default",
+};
+
+async function fetchMe(): Promise<MeOverview> {
+  const { data } = await api.get<MeOverview>("/me/overview");
+  return data;
+}
+
+export default function MyMond() {
+  const { locale } = useI18n();
+  const { user } = useAuth();
+  const { data, isLoading } = useQuery({
+    queryKey: ["me-overview"],
+    queryFn: fetchMe,
+    refetchInterval: 30_000,
+  });
+
+  const summary = data?.summary;
+  const greeting = locale === "ko"
+    ? `안녕하세요, ${user?.name || user?.email}님`
+    : `Hello, ${user?.name || user?.email}`;
+
+  return (
+    <div>
+      <Title level={2} style={{ marginBottom: 4 }}>
+        {greeting}
+      </Title>
+      <Paragraph type="secondary">
+        {locale === "ko"
+          ? "내가 등록한 자산 · 받은 발견사항 · 권한 요청 · 만료 임박을 한눈에."
+          : "Your assets, findings, requests, and expiring permissions at a glance."}
+      </Paragraph>
+
+      <Row gutter={[12, 12]} style={{ marginBottom: 16 }}>
+        <Col xs={12} md={6}>
+          <Card size="small" loading={isLoading}>
+            <Text type="secondary" style={{ fontSize: 11, letterSpacing: "0.08em" }}>
+              {locale === "ko" ? "내 자산" : "MY ASSETS"}
+            </Text>
+            <div style={{ fontSize: 32, fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>
+              {summary?.my_assets_total ?? 0}
+            </div>
+          </Card>
+        </Col>
+        <Col xs={12} md={6}>
+          <Card size="small" loading={isLoading}>
+            <Text type="secondary" style={{ fontSize: 11, letterSpacing: "0.08em" }}>
+              {locale === "ko" ? "미해결 발견" : "OPEN FINDINGS"}
+            </Text>
+            <div
+              style={{
+                fontSize: 32,
+                fontWeight: 700,
+                fontVariantNumeric: "tabular-nums",
+                color: (summary?.open_findings_total ?? 0) > 0 ? "var(--severity-high)" : undefined,
+              }}
+            >
+              {summary?.open_findings_total ?? 0}
+            </div>
+          </Card>
+        </Col>
+        <Col xs={12} md={6}>
+          <Card size="small" loading={isLoading}>
+            <Text type="secondary" style={{ fontSize: 11, letterSpacing: "0.08em" }}>
+              {locale === "ko" ? "진행중 권한 요청" : "ACTIVE REQUESTS"}
+            </Text>
+            <div style={{ fontSize: 32, fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>
+              {summary?.active_requests ?? 0}
+            </div>
+          </Card>
+        </Col>
+        <Col xs={12} md={6}>
+          <Card size="small" loading={isLoading}>
+            <Text type="secondary" style={{ fontSize: 11, letterSpacing: "0.08em" }}>
+              {locale === "ko" ? "만료 임박 (7일)" : "EXPIRING (7d)"}
+            </Text>
+            <div
+              style={{
+                fontSize: 32,
+                fontWeight: 700,
+                fontVariantNumeric: "tabular-nums",
+                color: (summary?.expiring_soon ?? 0) > 0 ? "var(--severity-high)" : undefined,
+              }}
+            >
+              {summary?.expiring_soon ?? 0}
+            </div>
+          </Card>
+        </Col>
+      </Row>
+
+      <Row gutter={[12, 12]}>
+        <Col xs={24} md={12}>
+          <Card
+            title={locale === "ko" ? "내 자산" : "My Assets"}
+            extra={<Link to="/assets">{locale === "ko" ? "전체" : "All"}</Link>}
+            style={{ marginBottom: 12 }}
+          >
+            {(data?.my_assets?.length ?? 0) === 0 ? (
+              <Empty
+                description={
+                  locale === "ko" ? "owner=내 이메일인 자산이 없습니다" : "No assets owned by you"
+                }
+              />
+            ) : (
+              <List
+                size="small"
+                dataSource={data?.my_assets ?? []}
+                renderItem={(a) => (
+                  <List.Item>
+                    <Space style={{ width: "100%", justifyContent: "space-between" }}>
+                      <Space>
+                        <Text strong>{a.name}</Text>
+                        <Tag>{a.asset_type}</Tag>
+                        {a.environment && <Tag color="blue">{a.environment}</Tag>}
+                      </Space>
+                      {a.open_findings_count > 0 && (
+                        <Tag color="orange">
+                          {a.open_findings_count} {locale === "ko" ? "미해결" : "open"}
+                        </Tag>
+                      )}
+                    </Space>
+                  </List.Item>
+                )}
+              />
+            )}
+          </Card>
+        </Col>
+
+        <Col xs={24} md={12}>
+          <Card
+            title={locale === "ko" ? "최근 발견사항" : "Recent Findings"}
+            extra={<Link to="/findings">{locale === "ko" ? "전체" : "All"}</Link>}
+            style={{ marginBottom: 12 }}
+          >
+            {(data?.recent_findings?.length ?? 0) === 0 ? (
+              <Empty description={locale === "ko" ? "조용한 하루입니다" : "Quiet day"} />
+            ) : (
+              <List
+                size="small"
+                dataSource={data?.recent_findings ?? []}
+                renderItem={(f) => (
+                  <List.Item>
+                    <Space>
+                      <Tag color={SEVERITY_COLOR[f.severity]}>{f.severity}</Tag>
+                      <Text ellipsis style={{ maxWidth: 300 }}>
+                        {f.title}
+                      </Text>
+                    </Space>
+                  </List.Item>
+                )}
+              />
+            )}
+          </Card>
+        </Col>
+
+        <Col xs={24} md={12}>
+          <Card
+            title={locale === "ko" ? "만료 임박 권한" : "Expiring Permissions"}
+            extra={<Link to="/access-center">{locale === "ko" ? "갱신 요청" : "Renew"}</Link>}
+          >
+            {(data?.expiring_soon?.length ?? 0) === 0 ? (
+              <Empty description={locale === "ko" ? "임박한 만료 없음" : "Nothing expiring soon"} />
+            ) : (
+              <List
+                size="small"
+                dataSource={data?.expiring_soon ?? []}
+                renderItem={(p) => (
+                  <List.Item>
+                    <Space style={{ width: "100%", justifyContent: "space-between" }}>
+                      <Text>{p.permission_name}</Text>
+                      <Tag color={p.days_left !== null && p.days_left <= 2 ? "red" : "orange"}>
+                        {p.days_left !== null
+                          ? `${p.days_left}${locale === "ko" ? "일 남음" : "d left"}`
+                          : "—"}
+                      </Tag>
+                    </Space>
+                  </List.Item>
+                )}
+              />
+            )}
+          </Card>
+        </Col>
+
+        <Col xs={24} md={12}>
+          <Card
+            title={locale === "ko" ? "내 권한 요청" : "My Access Requests"}
+            extra={<Link to="/access-center">{locale === "ko" ? "센터" : "Center"}</Link>}
+          >
+            {(data?.my_requests?.length ?? 0) === 0 ? (
+              <Empty description={locale === "ko" ? "권한 요청 없음" : "No requests"} />
+            ) : (
+              <List
+                size="small"
+                dataSource={data?.my_requests?.slice(0, 5) ?? []}
+                renderItem={(r) => (
+                  <List.Item>
+                    <Space>
+                      <Tag
+                        color={
+                          r.status === "approved" || r.status === "granted"
+                            ? "green"
+                            : r.status === "denied"
+                              ? "red"
+                              : r.status === "pending"
+                                ? "blue"
+                                : "default"
+                        }
+                      >
+                        {r.status}
+                      </Tag>
+                      <Text>{r.permission_name}</Text>
+                    </Space>
+                  </List.Item>
+                )}
+              />
+            )}
+          </Card>
+        </Col>
+      </Row>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
페르소나(임직원/보안 담당자) 매일 흐름의 가장 큰 마찰을 풀기.

### My Mond (`/me`) — 임직원 진입점
임직원이 매일 처음 열어 "내가 봐야 할 것"을 한 화면에서 확인.
- backend `GET /api/v1/me/overview` — 본인 자산(owner=email) 기준 집계
- 페이지: 4 KPI (자산 / 미해결 발견 / 권한 요청 / 만료 임박 7일) + 4 list card (자산 · 최근 발견 · 만료 임박 · 권한 요청)
- 사이드바 "한눈에" 그룹 최상단에 "내 페이지" 추가

### Findings 일괄 처리 (Bulk Triage)
보안 담당자가 매주 finding 100개+ 처리하는 시간을 1/10로.
- backend `PATCH /api/v1/findings/bulk/status` — `finding_ids[]` + `status` 일괄. REVIEWER 이상.
- 프론트 Table rowSelection + 선택 시 상단에 일괄 액션 (Resolved / Suppressed / False-positive)

## Test plan
- [x] /me 페이지 — 4 KPI + 4 list card 정상
- [x] Findings — 체크박스 + bulk action 노출
- [ ] backend `GET /api/v1/me/overview` (인증된 사용자, 401 미인증)
- [ ] backend `PATCH /api/v1/findings/bulk/status` (REVIEWER+)
- [ ] CI Backend / Frontend / CodeQL 통과

## 다음 (Wave 3 후보)
- E3 사용자 프로필 Slack ID + 개인 DM 라우팅
- S1 Daily Security Digest cron
- E2 권한 만료 알림 + 1-click 갱신