### PR TITLE
fix(me): unused sqlalchemy import 제거 (ruff F401)

### DIFF
--- a/backend/app/services/me.py
+++ b/backend/app/services/me.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.asset import Asset


### PR DESCRIPTION
PR #41 머지 후 main CI Ruff lint 실패. `func` / `or_` 사용 안 함 → 제거. 한 줄 fix.