### PR TITLE
feat: Daily Security Digest — 어제 일어난 일 Slack 카드

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,9 @@ SLACK_WEBHOOK_URL=
 GENERIC_WEBHOOK_URL=
 # 알림 임계치: critical / high / medium / low / info
 NOTIFY_MIN_SEVERITY=high
+# Daily Security Digest 전용 채널 — 비우면 SLACK_WEBHOOK_URL을 fallback으로 사용.
+# 보안팀 채널을 finding 알림과 분리하고 싶을 때.
+DIGEST_SLACK_WEBHOOK_URL=
 
 # ─── GitHub Webhook 검증 ─────────────────────────────
 # GitHub Webhook 설정 시 Secret과 동일하게 맞추세요.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [Unreleased]
 
 ### Added
+- **Daily Security Digest** — 어제 일어난 일(신규 finding severity별 · 스캔 실행/실패 · 권한 요청 흐름)을 Slack 카드 한 장으로. Admin → Connections에 카드 + `지금 전송` 버튼. 자동 실행은 외부 cron(k8s CronJob 예시 포함)이 `POST /api/v1/admin/digest/send` 호출. 미리보기 `GET /api/v1/admin/digest/preview` (Reviewer+). 전용 채널 ENV `DIGEST_SLACK_WEBHOOK_URL` (없으면 `SLACK_WEBHOOK_URL` fallback).
 - **My Mond** (`/me`) — 임직원 진입 페이지. 본인 자산 · 받은 발견사항 · 진행중 권한 요청 · 만료 임박(7일) 4 KPI + 4 list card. 사이드바 "한눈에" 그룹 최상단에 노출. 백엔드 `GET /api/v1/me/overview` 신설.
 - **Findings 일괄 처리(Bulk Triage)** — Findings 테이블 row 체크박스 + 일괄 액션(Resolved / Suppressed / False-positive). 매주 발견사항 100개+ 처리하는 보안 담당자 시간을 1/10로. 백엔드 `PATCH /api/v1/findings/bulk/status` 신설 (REVIEWER+).
 - **AI provider 추상화** — Anthropic · OpenAI / Azure OpenAI · AWS Bedrock · Ollama(로컬) 4종을 `AI_PROVIDER` 한 줄로 전환. 폐쇄망/데이터 외부 유출 금지 조직도 사용 가능.

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -10,6 +10,7 @@ from app.api.v1.endpoints import (
     assets,
     auth,
     dashboard,
+    digest,
     findings,
     health,
     iam,
@@ -46,6 +47,7 @@ api_router.include_router(regulations.router, tags=["Regulations"])
 api_router.include_router(reports.router, prefix="/reports", tags=["Reports"])
 api_router.include_router(ai.router, prefix="/ai", tags=["AI"])
 api_router.include_router(ai_providers.router, prefix="/admin/ai-providers", tags=["AI Providers (Admin)"])
+api_router.include_router(digest.router, prefix="/admin/digest", tags=["Daily Digest (Admin)"])
 api_router.include_router(integrations.router, prefix="/integrations", tags=["Integrations"])
 api_router.include_router(webhooks.router, prefix="/webhooks", tags=["Webhooks"])
 api_router.include_router(webhook_tokens.router, prefix="/webhook-tokens", tags=["Webhook Tokens"])

--- a/backend/app/api/v1/endpoints/digest.py
+++ b/backend/app/api/v1/endpoints/digest.py
@@ -1,0 +1,22 @@
+"""Daily Digest endpoint — 미리보기(Reviewer)와 발송(Admin) 두 개."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.deps import require_role
+from app.core.database import get_db
+from app.models.user import Role
+from app.services import digest as digest_service
+
+router = APIRouter()
+
+
+@router.get("/preview", dependencies=[Depends(require_role(Role.REVIEWER))])
+async def preview(db: AsyncSession = Depends(get_db)) -> dict:
+    d = await digest_service.build_daily_digest(db)
+    return {"digest": d, "slack_message": digest_service.format_slack_message(d)}
+
+
+@router.post("/send", dependencies=[Depends(require_role(Role.ADMIN))])
+async def send(db: AsyncSession = Depends(get_db)) -> dict:
+    return await digest_service.send_daily_digest(db)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -98,6 +98,8 @@ class Settings(BaseSettings):
     SLACK_WEBHOOK_URL: Optional[str] = None
     GENERIC_WEBHOOK_URL: Optional[str] = None
     NOTIFY_MIN_SEVERITY: str = "high"  # critical / high / medium / low / info
+    # Daily Digest 전용 채널. 비우면 SLACK_WEBHOOK_URL을 fallback.
+    DIGEST_SLACK_WEBHOOK_URL: Optional[str] = None
 
     # 외부 통합 — GitHub Webhook 검증용 (없으면 검증 생략, 개발 편의)
     GITHUB_WEBHOOK_SECRET: Optional[str] = None

--- a/backend/app/services/digest.py
+++ b/backend/app/services/digest.py
@@ -1,0 +1,143 @@
+"""
+어제 일어난 일을 Slack에 한 카드로 묶어 전송.
+보통 외부 cron(k8s CronJob 등)이 매일 한 번 endpoint를 호출한다.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import httpx
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.models.finding import Finding, Severity
+from app.models.iam import AccessRequest, AccessRequestStatus
+from app.models.scan import Scan, ScanStatus
+
+logger = get_logger(__name__)
+
+
+async def build_daily_digest(
+    session: AsyncSession,
+    since: datetime | None = None,
+    until: datetime | None = None,
+) -> dict:
+    now = datetime.now(timezone.utc)
+    if until is None:
+        until = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    if since is None:
+        since = until - timedelta(days=1)
+
+    sev_rows = (await session.execute(
+        select(Finding.severity, func.count(Finding.id))
+        .where(Finding.created_at >= since, Finding.created_at < until)
+        .group_by(Finding.severity)
+    )).all()
+    by_sev = {s.value: 0 for s in Severity}
+    for sev, cnt in sev_rows:
+        by_sev[sev.value] = int(cnt)
+    findings_total = sum(by_sev.values())
+
+    scans_total = int((await session.execute(
+        select(func.count(Scan.id)).where(Scan.created_at >= since, Scan.created_at < until)
+    )).scalar_one() or 0)
+    scans_failed = int((await session.execute(
+        select(func.count(Scan.id)).where(
+            Scan.created_at >= since,
+            Scan.created_at < until,
+            Scan.status == ScanStatus.FAILED,
+        )
+    )).scalar_one() or 0)
+
+    req_rows = (await session.execute(
+        select(AccessRequest.status, func.count(AccessRequest.id))
+        .where(AccessRequest.created_at >= since, AccessRequest.created_at < until)
+        .group_by(AccessRequest.status)
+    )).all()
+    req_count = {status.value: int(cnt) for status, cnt in req_rows}
+    req_total = sum(req_count.values())
+    # 승인 흐름은 단계가 여러 개라 사용자가 보는 "승인"은 셋을 합친 값.
+    req_granted = (
+        req_count.get(AccessRequestStatus.GRANTED.value, 0)
+        + req_count.get(AccessRequestStatus.HUMAN_APPROVED.value, 0)
+        + req_count.get(AccessRequestStatus.AI_AUTO_APPROVED.value, 0)
+    )
+    req_denied = req_count.get(AccessRequestStatus.HUMAN_DENIED.value, 0)
+    req_pending = (
+        req_count.get(AccessRequestStatus.PENDING_AI_REVIEW.value, 0)
+        + req_count.get(AccessRequestStatus.NEEDS_HUMAN_REVIEW.value, 0)
+    )
+
+    return {
+        "period": {"since": since.isoformat(), "until": until.isoformat()},
+        "findings": {"total": findings_total, "by_severity": by_sev},
+        "scans": {"total": scans_total, "failed": scans_failed},
+        "access_requests": {
+            "total": req_total,
+            "granted": req_granted,
+            "denied": req_denied,
+            "pending": req_pending,
+        },
+    }
+
+
+def format_slack_message(digest: dict) -> dict:
+    f = digest["findings"]
+    s = digest["scans"]
+    a = digest["access_requests"]
+    sev = f["by_severity"]
+    day = digest["period"]["since"][:10]
+
+    sev_line = (
+        f"critical {sev.get('critical', 0)} · "
+        f"high {sev.get('high', 0)} · "
+        f"medium {sev.get('medium', 0)} · "
+        f"low {sev.get('low', 0)} · "
+        f"info {sev.get('info', 0)}"
+    )
+
+    lines = [
+        f"*Mond Daily Digest* — {day}",
+        "",
+        f"*Findings* — 신규 {f['total']}건",
+        sev_line,
+        "",
+        f"*Scans* — 실행 {s['total']}건, 실패 {s['failed']}건",
+        f"*Access Requests* — 신규 {a['total']}건, 승인 {a['granted']}, 거부 {a['denied']}, 대기 {a['pending']}",
+    ]
+    return {"text": "\n".join(lines)}
+
+
+async def send_daily_digest(
+    session: AsyncSession,
+    slack_webhook_url: str | None = None,
+    generic_webhook_url: str | None = None,
+) -> dict:
+    digest = await build_daily_digest(session)
+
+    slack_url = slack_webhook_url or settings.DIGEST_SLACK_WEBHOOK_URL or settings.SLACK_WEBHOOK_URL
+    generic_url = generic_webhook_url or settings.GENERIC_WEBHOOK_URL
+
+    sent: list[str] = []
+    errors: list[str] = []
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        if slack_url:
+            try:
+                await client.post(slack_url, json=format_slack_message(digest))
+                sent.append("slack")
+            except Exception as exc:
+                logger.warning("digest_slack_failed", error=str(exc))
+                errors.append(f"slack: {exc}")
+        if generic_url:
+            try:
+                await client.post(generic_url, json={"source": "mond", "kind": "daily_digest", **digest})
+                sent.append("generic")
+            except Exception as exc:
+                logger.warning("digest_generic_failed", error=str(exc))
+                errors.append(f"generic: {exc}")
+
+    return {"digest": digest, "sent": sent, "errors": errors}

--- a/backend/app/services/me.py
+++ b/backend/app/services/me.py
@@ -69,7 +69,7 @@ async def get_me_overview(session: AsyncSession, user: User) -> dict:
         .where(
             and_(
                 AccessRequest.requester == user.email,
-                AccessRequest.status == AccessRequestStatus.APPROVED,
+                AccessRequest.status == AccessRequestStatus.GRANTED,
                 AccessRequest.revoked_at.is_(None),
                 AccessRequest.expires_at.is_not(None),
                 AccessRequest.expires_at <= soon,
@@ -100,7 +100,12 @@ async def get_me_overview(session: AsyncSession, user: User) -> dict:
             "my_assets_total": len(my_assets),
             "open_findings_total": open_findings_total,
             "open_by_severity": open_by_severity,
-            "active_requests": sum(1 for r in my_requests if r.status == AccessRequestStatus.PENDING),
+            "active_requests": sum(
+                1
+                for r in my_requests
+                if r.status
+                in {AccessRequestStatus.PENDING_AI_REVIEW, AccessRequestStatus.NEEDS_HUMAN_REVIEW}
+            ),
             "expiring_soon": len(expiring),
         },
         "my_assets": [

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -613,6 +613,61 @@ NOTIFY_MIN_SEVERITY=high   # critical / high / medium / low / info (threshold)
 - 보안팀 전담 채널 — `medium`
 - 데모 — `critical`만
 
+<a id="daily-digest"></a>
+#### 7-1) Daily Security Digest — 매일 아침 어제 일어난 일 요약
+
+화면 5개 돌아다닐 필요 없이 Slack 카드 한 장으로 어제를 본다.
+
+**ENV:**
+```bash
+# Daily Digest 전용 채널 (없으면 SLACK_WEBHOOK_URL fallback).
+# 보안팀 채널을 finding 알림과 분리하고 싶을 때.
+DIGEST_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/.../digest
+```
+
+**수동 발송:** Admin → Connections 페이지의 "Daily Security Digest" 카드에서 `지금 전송` 클릭.
+
+**자동 발송 (운영):** 외부 cron이 매일 한 번 다음 endpoint를 호출.
+```
+POST /api/v1/admin/digest/send
+```
+인증은 admin webhook token 또는 admin 세션 cookie 필요.
+
+**Kubernetes CronJob 예시 (매일 09:00 KST):**
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mond-daily-digest
+  namespace: mond
+spec:
+  schedule: "0 0 * * *"   # 00:00 UTC = 09:00 KST
+  timeZone: UTC
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: caller
+              image: curlimages/curl:8.10.1
+              command:
+                - sh
+                - -c
+                - |
+                  curl -fsS -X POST \
+                    -H "Authorization: Bearer $MOND_ADMIN_TOKEN" \
+                    http://mond-backend.mond.svc.cluster.local:8000/api/v1/admin/digest/send
+              env:
+                - name: MOND_ADMIN_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: mond-secrets
+                      key: ADMIN_DIGEST_TOKEN
+```
+
+**미리보기 (Reviewer+):** `GET /api/v1/admin/digest/preview` — 전송 없이 집계와 Slack 메시지 포맷 확인.
+
 ### 8) GitHub Webhook 자동 스캔 (선택)
 
 push마다 자동 스캔하려면:

--- a/frontend/src/pages/admin/AdminConnections.tsx
+++ b/frontend/src/pages/admin/AdminConnections.tsx
@@ -15,6 +15,7 @@ import { useState } from "react";
 import { useI18n } from "@/i18n";
 
 import AIProvidersCard from "./connections/AIProvidersCard";
+import DailyDigestCard from "./connections/DailyDigestCard";
 import IAMSourceCard from "./connections/IAMSourceCard";
 import IAMSourceModal from "./connections/IAMSourceModal";
 import SSOCard from "./connections/SSOCard";
@@ -36,6 +37,7 @@ export default function AdminConnections() {
       <IAMSourceCard onAdd={() => setModalOpen(true)} />
       <SSOCard />
       <AIProvidersCard />
+      <DailyDigestCard />
       <WebhookCard />
 
       <IAMSourceModal open={modalOpen} onClose={() => setModalOpen(false)} />

--- a/frontend/src/pages/admin/connections/DailyDigestCard.tsx
+++ b/frontend/src/pages/admin/connections/DailyDigestCard.tsx
@@ -1,0 +1,135 @@
+import { ClockCircleOutlined, SendOutlined } from "@ant-design/icons";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Alert, Button, Card, Space, Tag, Typography, message } from "antd";
+
+import { useI18n } from "@/i18n";
+import { api } from "@/lib/api";
+
+const { Paragraph, Text } = Typography;
+
+interface DigestData {
+  period: { since: string; until: string };
+  findings: { total: number; by_severity: Record<string, number> };
+  scans: { total: number; failed: number };
+  access_requests: { total: number; granted: number; denied: number; pending: number };
+}
+
+interface PreviewResp {
+  digest: DigestData;
+  slack_message: { text: string };
+}
+
+interface SendResp {
+  digest: DigestData;
+  sent: string[];
+  errors: string[];
+}
+
+export default function DailyDigestCard() {
+  const { locale } = useI18n();
+
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ["digest-preview"],
+    queryFn: async () => (await api.get<PreviewResp>("/admin/digest/preview")).data,
+  });
+
+  const send = useMutation({
+    mutationFn: async () => (await api.post<SendResp>("/admin/digest/send")).data,
+    onSuccess: (r) => {
+      if (r.sent.length > 0) {
+        message.success(
+          locale === "ko" ? `전송됨 — ${r.sent.join(", ")}` : `Sent — ${r.sent.join(", ")}`,
+        );
+      } else if (r.errors.length > 0) {
+        message.error(r.errors.join(" / "));
+      } else {
+        message.warning(
+          locale === "ko"
+            ? "Slack URL이 비어 있습니다. DIGEST_SLACK_WEBHOOK_URL 또는 SLACK_WEBHOOK_URL을 채워주세요."
+            : "No Slack URL configured (DIGEST_SLACK_WEBHOOK_URL or SLACK_WEBHOOK_URL).",
+        );
+      }
+      refetch();
+    },
+    onError: (e: Error) => message.error(e.message),
+  });
+
+  const d = data?.digest;
+  const sev = d?.findings.by_severity ?? {};
+  const day = d?.period.since.slice(0, 10);
+
+  return (
+    <Card
+      title={
+        <Space>
+          <ClockCircleOutlined />
+          <span>Daily Security Digest</span>
+        </Space>
+      }
+      extra={
+        <Button
+          type="primary"
+          icon={<SendOutlined />}
+          loading={send.isPending}
+          onClick={() => send.mutate()}
+        >
+          {locale === "ko" ? "지금 전송" : "Send now"}
+        </Button>
+      }
+      style={{ marginBottom: 16 }}
+      loading={isLoading}
+    >
+      <Paragraph type="secondary" style={{ marginBottom: 8 }}>
+        {locale === "ko"
+          ? "어제 일어난 일을 Slack 한 카드로 요약합니다. 자동 발송은 외부 cron(k8s CronJob 등)이 POST /api/v1/admin/digest/send를 호출하는 패턴을 권장합니다."
+          : "Yesterday in one Slack card. For automation, schedule an external cron to POST /api/v1/admin/digest/send."}
+      </Paragraph>
+
+      {d && (
+        <>
+          <Text type="secondary" style={{ fontSize: 12 }}>
+            {locale === "ko" ? "집계 기간: " : "Period: "}
+            {day}
+          </Text>
+          <Space wrap style={{ marginTop: 8, marginBottom: 8 }}>
+            <Tag>
+              {locale === "ko" ? "신규" : "New"} {d.findings.total}
+            </Tag>
+            {sev.critical > 0 && <Tag color="red">critical {sev.critical}</Tag>}
+            {sev.high > 0 && <Tag color="volcano">high {sev.high}</Tag>}
+            {sev.medium > 0 && <Tag color="orange">medium {sev.medium}</Tag>}
+            <Tag>
+              {locale === "ko" ? "스캔" : "Scans"} {d.scans.total}
+              {d.scans.failed > 0 ? ` (fail ${d.scans.failed})` : ""}
+            </Tag>
+            <Tag>
+              {locale === "ko" ? "권한 요청" : "Access"} {d.access_requests.total}
+              {d.access_requests.granted > 0 ? ` · ${d.access_requests.granted} granted` : ""}
+            </Tag>
+          </Space>
+        </>
+      )}
+
+      <Alert
+        type="info"
+        showIcon
+        style={{ marginTop: 8 }}
+        message={
+          <Text style={{ fontSize: 12 }}>
+            <code>DIGEST_SLACK_WEBHOOK_URL</code>
+            {locale === "ko" ? " (없으면 " : " (falls back to "}
+            <code>SLACK_WEBHOOK_URL</code>
+            {locale === "ko" ? ") · 자동 발송 가이드는 " : ") · CronJob example: "}
+            <a
+              href="https://github.com/jland-93/mond/blob/main/docs/SETUP.md#daily-digest"
+              target="_blank"
+              rel="noreferrer"
+            >
+              SETUP.md
+            </a>
+          </Text>
+        }
+      />
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
v0.2 Wave 3 첫 기능. 보안팀이 매일 아침 화면 5개 돌아다닐 필요 없게 어제 일어난 일을 Slack 카드 한 장으로.

### Backend
- `services/digest.py` — `build_daily_digest` / `format_slack_message` / `send_daily_digest`
- `endpoints/digest.py` — GET `/api/v1/admin/digest/preview` (Reviewer+) · POST `/api/v1/admin/digest/send` (Admin)
- `config.py` — `DIGEST_SLACK_WEBHOOK_URL` (없으면 `SLACK_WEBHOOK_URL` fallback)

### Frontend
- `connections/DailyDigestCard.tsx` — AdminConnections 페이지 카드 + `지금 전송` 버튼

### 자동 실행
외부 cron이 `/api/v1/admin/digest/send` 호출 권장. `docs/SETUP.md` Part 5 7-1)에 k8s CronJob 예시.

## Test plan
- [x] GET preview → 200, severity별 집계 + Slack 메시지 포맷 정상
- [x] POST send → 200, Slack URL 미설정 시 `sent=[] errors=[]` no-op
- [x] AdminConnections 카드 시각 노출 (신규 1 / high 1 / 스캔 2 / 권한 2)
- [x] `ruff check` 통과
- [ ] CI Backend / Frontend / CodeQL 통과

## 문서
- `CHANGELOG.md` [Unreleased] Added
- `docs/SETUP.md` Part 5 7-1) Daily Security Digest (k8s CronJob 예시 포함)
- `.env.example` `DIGEST_SLACK_WEBHOOK_URL` 추가