### PR TITLE
feat: 권한 만료 임박 + 1-click 갱신

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [Unreleased]
 
 ### Added
+- **권한 만료 임박 + 1-click 갱신** — My Mond (`/me`)의 "만료 임박" 카드 각 항목에 `갱신 요청` 버튼. 백엔드 `POST /api/v1/me/access-requests/{id}/renew`가 같은 identity·permission으로 새 AccessRequest를 만들어 AI 1차 검토 흐름에 태움. Daily Digest에도 3일 내 만료 권한 수가 추가됨.
 - **Daily Security Digest** — 어제 일어난 일(신규 finding severity별 · 스캔 실행/실패 · 권한 요청 흐름)을 Slack 카드 한 장으로. Admin → Connections에 카드 + `지금 전송` 버튼. 자동 실행은 외부 cron(k8s CronJob 예시 포함)이 `POST /api/v1/admin/digest/send` 호출. 미리보기 `GET /api/v1/admin/digest/preview` (Reviewer+). 전용 채널 ENV `DIGEST_SLACK_WEBHOOK_URL` (없으면 `SLACK_WEBHOOK_URL` fallback).
 - **My Mond** (`/me`) — 임직원 진입 페이지. 본인 자산 · 받은 발견사항 · 진행중 권한 요청 · 만료 임박(7일) 4 KPI + 4 list card. 사이드바 "한눈에" 그룹 최상단에 노출. 백엔드 `GET /api/v1/me/overview` 신설.
 - **Findings 일괄 처리(Bulk Triage)** — Findings 테이블 row 체크박스 + 일괄 액션(Resolved / Suppressed / False-positive). 매주 발견사항 100개+ 처리하는 보안 담당자 시간을 1/10로. 백엔드 `PATCH /api/v1/findings/bulk/status` 신설 (REVIEWER+).

--- a/backend/app/api/v1/endpoints/me.py
+++ b/backend/app/api/v1/endpoints/me.py
@@ -1,15 +1,19 @@
 """
-'내 페이지' 엔드포인트 — 본인 자산 / 자기 발견사항 / 권한 요청 / 만료 임박 집계.
+'내 페이지' 엔드포인트 — 본인 자산 / 자기 발견사항 / 권한 요청 / 만료 임박 집계 + 갱신.
 
 권한: 인증된 사용자만. 본인 데이터만 노출 (다른 사용자 데이터 leak 금지).
 """
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Body, Depends, HTTPException
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.deps import current_user
 from app.core.database import get_db
+from app.models.iam import AccessRequest
 from app.models.user import User
+from app.schemas.iam import AccessRequestCreate, AccessRequestRead
+from app.services import iam as iam_service
 from app.services import me as me_service
 
 router = APIRouter()
@@ -20,5 +24,39 @@ async def overview(
     user: User = Depends(current_user),
     db: AsyncSession = Depends(get_db),
 ) -> dict:
-    """본인 화면에 쓰일 데이터 묶음."""
     return await me_service.get_me_overview(db, user)
+
+
+@router.post("/access-requests/{request_id}/renew", response_model=AccessRequestRead)
+async def renew_access(
+    request_id: int,
+    payload: dict = Body(default={}),
+    user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_db),
+) -> AccessRequestRead:
+    """만료 임박/만료된 본인 권한을 같은 identity/permission으로 다시 요청.
+
+    이전 요청과 동일한 (identity, permission) 페어로 새 AccessRequest 생성.
+    AI 1차 + 사람 검토 흐름은 평소와 동일.
+    """
+    src = (await db.execute(select(AccessRequest).where(AccessRequest.id == request_id))).scalar_one_or_none()
+    if src is None:
+        raise HTTPException(status_code=404, detail="원본 권한 요청을 찾을 수 없습니다")
+    if src.requester != user.email:
+        raise HTTPException(status_code=403, detail="본인 권한만 갱신할 수 있습니다")
+
+    new_reason = (payload or {}).get("reason") or f"갱신 — 원본 #{src.id}: {src.reason}"
+    duration = (payload or {}).get("duration_hours", src.duration_hours)
+
+    create = AccessRequestCreate(
+        requester=user.email,
+        reason=new_reason,
+        target_identity_id=src.target_identity_id,
+        permission_id=src.permission_id,
+        duration_hours=duration,
+    )
+    try:
+        new_req = await iam_service.create_request(db, create)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return AccessRequestRead.model_validate(new_req)

--- a/backend/app/services/digest.py
+++ b/backend/app/services/digest.py
@@ -71,6 +71,18 @@ async def build_daily_digest(
         + req_count.get(AccessRequestStatus.NEEDS_HUMAN_REVIEW.value, 0)
     )
 
+    # 만료 임박 — 향후 3일 이내 expires_at, 아직 revoke 안 됨, granted 상태.
+    expiring_until = until + timedelta(days=3)
+    expiring_count = int((await session.execute(
+        select(func.count(AccessRequest.id)).where(
+            AccessRequest.status == AccessRequestStatus.GRANTED,
+            AccessRequest.revoked_at.is_(None),
+            AccessRequest.expires_at.is_not(None),
+            AccessRequest.expires_at <= expiring_until,
+            AccessRequest.expires_at >= until,
+        )
+    )).scalar_one() or 0)
+
     return {
         "period": {"since": since.isoformat(), "until": until.isoformat()},
         "findings": {"total": findings_total, "by_severity": by_sev},
@@ -80,6 +92,7 @@ async def build_daily_digest(
             "granted": req_granted,
             "denied": req_denied,
             "pending": req_pending,
+            "expiring_3d": expiring_count,
         },
     }
 
@@ -108,6 +121,8 @@ def format_slack_message(digest: dict) -> dict:
         f"*Scans* — 실행 {s['total']}건, 실패 {s['failed']}건",
         f"*Access Requests* — 신규 {a['total']}건, 승인 {a['granted']}, 거부 {a['denied']}, 대기 {a['pending']}",
     ]
+    if a.get("expiring_3d"):
+        lines.append(f"⏰ 3일 내 만료 권한 {a['expiring_3d']}건 — /me에서 갱신 가능")
     return {"text": "\n".join(lines)}
 
 

--- a/frontend/src/pages/MyMond.tsx
+++ b/frontend/src/pages/MyMond.tsx
@@ -5,8 +5,8 @@
  * 임직원은 한 화면에서 본인 자산·발견·권한·만료 임박을 본다.
  */
 
-import { useQuery } from "@tanstack/react-query";
-import { Card, Col, Empty, List, Row, Space, Tag, Typography } from "antd";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button, Card, Col, Empty, List, Row, Space, Tag, Typography, message } from "antd";
 import { Link } from "react-router-dom";
 
 import { useAuth } from "@/auth/AuthContext";
@@ -31,10 +31,21 @@ async function fetchMe(): Promise<MeOverview> {
 export default function MyMond() {
   const { locale } = useI18n();
   const { user } = useAuth();
+  const qc = useQueryClient();
   const { data, isLoading } = useQuery({
     queryKey: ["me-overview"],
     queryFn: fetchMe,
     refetchInterval: 30_000,
+  });
+
+  const renew = useMutation({
+    mutationFn: (requestId: number) => api.post(`/me/access-requests/${requestId}/renew`, {}),
+    onSuccess: () => {
+      message.success(locale === "ko" ? "갱신 요청 제출됨" : "Renewal submitted");
+      qc.invalidateQueries({ queryKey: ["me-overview"] });
+    },
+    onError: (e: Error & { response?: { data?: { detail?: string } } }) =>
+      message.error(e.response?.data?.detail ?? e.message),
   });
 
   const summary = data?.summary;
@@ -187,7 +198,19 @@ export default function MyMond() {
                 size="small"
                 dataSource={data?.expiring_soon ?? []}
                 renderItem={(p) => (
-                  <List.Item>
+                  <List.Item
+                    actions={[
+                      <Button
+                        key="renew"
+                        size="small"
+                        type="link"
+                        loading={renew.isPending && renew.variables === p.id}
+                        onClick={() => renew.mutate(p.id)}
+                      >
+                        {locale === "ko" ? "갱신 요청" : "Renew"}
+                      </Button>,
+                    ]}
+                  >
                     <Space style={{ width: "100%", justifyContent: "space-between" }}>
                       <Text>{p.permission_name}</Text>
                       <Tag color={p.days_left !== null && p.days_left <= 2 ? "red" : "orange"}>


### PR DESCRIPTION
## Summary
v0.2 Wave 3 두 번째 기능. /me의 만료 임박 카드에서 갱신 요청을 한 번에.

### Backend
- `POST /api/v1/me/access-requests/{id}/renew` — 본인 권한만 갱신. 같은 identity/permission으로 새 AccessRequest 생성 → 평소 AI 1차 검토 흐름.
- `services/digest.py` — `expiring_3d` 집계 추가 + Daily Digest 메시지에 한 줄 (있을 때만 표시).

### Frontend
- `MyMond.tsx` — 만료 임박 List item에 `갱신 요청` 버튼 + mutation.

## Test plan
- [x] ruff check 통과
- [x] /me 페이지 카드 정상 노출
- [x] /api/v1/admin/digest/preview에 expiring_3d 필드 포함 확인
- [ ] CI Backend / Frontend / CodeQL 통과
- 데모 시드에 만료 임박 데이터 없음 → 실 데이터에서 버튼 동작 확인 필요