### PR TITLE
feat: Slack 연동 별도 페이지 (Admin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [Unreleased]
 
 ### Added
+- **Slack 연동 별도 페이지** — `/admin/slack` (Admin). 워크스페이스의 Incoming Webhook URL을 5종 purpose(`default` · `digest` · `finding` · `access_request` · `role_request`) 채널에 매핑하고, 카드별로 테스트 메시지 전송. DB에 저장된 채널이 ENV(`SLACK_WEBHOOK_URL` · `DIGEST_SLACK_WEBHOOK_URL`)보다 우선. `notifications` · `digest` 둘 다 `slack.resolve_webhook(purpose)`로 라우팅 일원화.
 - **권한 만료 임박 + 1-click 갱신** — My Mond (`/me`)의 "만료 임박" 카드 각 항목에 `갱신 요청` 버튼. 백엔드 `POST /api/v1/me/access-requests/{id}/renew`가 같은 identity·permission으로 새 AccessRequest를 만들어 AI 1차 검토 흐름에 태움. Daily Digest에도 3일 내 만료 권한 수가 추가됨.
 - **Daily Security Digest** — 어제 일어난 일(신규 finding severity별 · 스캔 실행/실패 · 권한 요청 흐름)을 Slack 카드 한 장으로. Admin → Connections에 카드 + `지금 전송` 버튼. 자동 실행은 외부 cron(k8s CronJob 예시 포함)이 `POST /api/v1/admin/digest/send` 호출. 미리보기 `GET /api/v1/admin/digest/preview` (Reviewer+). 전용 채널 ENV `DIGEST_SLACK_WEBHOOK_URL` (없으면 `SLACK_WEBHOOK_URL` fallback).
 - **My Mond** (`/me`) — 임직원 진입 페이지. 본인 자산 · 받은 발견사항 · 진행중 권한 요청 · 만료 임박(7일) 4 KPI + 4 list card. 사이드바 "한눈에" 그룹 최상단에 노출. 백엔드 `GET /api/v1/me/overview` 신설.

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -5,6 +5,7 @@ API v1 라우터
 from fastapi import APIRouter
 
 from app.api.v1.endpoints import (
+    admin_slack,
     ai,
     ai_providers,
     assets,
@@ -47,6 +48,7 @@ api_router.include_router(regulations.router, tags=["Regulations"])
 api_router.include_router(reports.router, prefix="/reports", tags=["Reports"])
 api_router.include_router(ai.router, prefix="/ai", tags=["AI"])
 api_router.include_router(ai_providers.router, prefix="/admin/ai-providers", tags=["AI Providers (Admin)"])
+api_router.include_router(admin_slack.router, prefix="/admin/slack", tags=["Slack Channels (Admin)"])
 api_router.include_router(digest.router, prefix="/admin/digest", tags=["Daily Digest (Admin)"])
 api_router.include_router(integrations.router, prefix="/integrations", tags=["Integrations"])
 api_router.include_router(webhooks.router, prefix="/webhooks", tags=["Webhooks"])

--- a/backend/app/api/v1/endpoints/admin_slack.py
+++ b/backend/app/api/v1/endpoints/admin_slack.py
@@ -1,0 +1,96 @@
+"""조직 Slack 채널 매핑 — Admin 전용."""
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.deps import require_role
+from app.core.database import get_db
+from app.models.slack import SlackPurpose
+from app.models.user import Role
+from app.services import slack as slack_service
+
+router = APIRouter(dependencies=[Depends(require_role(Role.ADMIN))])
+
+
+class ChannelUpsert(BaseModel):
+    purpose: SlackPurpose
+    webhook_url: str
+    label: str | None = None
+    enabled: bool = True
+
+
+@router.get("")
+async def list_channels(db: AsyncSession = Depends(get_db)) -> list[dict]:
+    rows = await slack_service.list_channels(db)
+    return [
+        {
+            "id": r.id,
+            "purpose": r.purpose.value,
+            "label": r.label,
+            "enabled": r.enabled,
+            # webhook_url은 마스킹 — UI에 raw 노출 금지
+            "webhook_masked": _mask(r.webhook_url),
+        }
+        for r in rows
+    ]
+
+
+@router.put("")
+async def upsert(payload: ChannelUpsert, db: AsyncSession = Depends(get_db)) -> dict:
+    if not payload.webhook_url.startswith("https://hooks.slack.com/"):
+        raise HTTPException(status_code=400, detail="Slack incoming webhook URL이어야 합니다")
+    ch = await slack_service.upsert_channel(
+        db,
+        payload.purpose,
+        payload.webhook_url,
+        payload.label,
+        payload.enabled,
+    )
+    return {
+        "id": ch.id,
+        "purpose": ch.purpose.value,
+        "label": ch.label,
+        "enabled": ch.enabled,
+        "webhook_masked": _mask(ch.webhook_url),
+    }
+
+
+@router.delete("/{purpose}")
+async def delete(purpose: SlackPurpose, db: AsyncSession = Depends(get_db)) -> dict:
+    ok = await slack_service.delete_channel(db, purpose)
+    if not ok:
+        raise HTTPException(status_code=404, detail="해당 purpose 채널 없음")
+    return {"deleted": purpose.value}
+
+
+@router.post("/test")
+async def test(
+    payload: dict = Body(...),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """저장된 채널(purpose)로 또는 임시 webhook_url로 테스트 메시지 전송."""
+    text = payload.get("text") or "Mond 테스트 메시지 — 채널 연결 확인용"
+    if payload.get("purpose"):
+        try:
+            purpose = SlackPurpose(payload["purpose"])
+        except ValueError:
+            raise HTTPException(status_code=400, detail="unknown purpose")
+        url = await slack_service.resolve_webhook(db, purpose)
+        if not url:
+            raise HTTPException(status_code=400, detail="해당 purpose에 등록된 채널이 없습니다")
+    elif payload.get("webhook_url"):
+        url = payload["webhook_url"]
+        if not url.startswith("https://hooks.slack.com/"):
+            raise HTTPException(status_code=400, detail="Slack incoming webhook URL이어야 합니다")
+    else:
+        raise HTTPException(status_code=400, detail="purpose 또는 webhook_url 중 하나 필요")
+
+    ok, err = await slack_service.test_send(url, text)
+    return {"ok": ok, "error": err}
+
+
+def _mask(url: str) -> str:
+    if len(url) <= 30:
+        return "…"
+    return url[:30] + "…" + url[-4:]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -25,6 +25,7 @@ from app.models.iam import (
 from app.models.knowledge import KnowledgeCard, KnowledgeCategory, KnowledgeSource
 from app.models.policy import Policy, PolicyType
 from app.models.scan import Scan, ScanStatus, ScanTrigger
+from app.models.slack import SlackChannel, SlackPurpose
 from app.models.user import (
     MfaBackupCode,
     Role,

--- a/backend/app/models/slack.py
+++ b/backend/app/models/slack.py
@@ -1,0 +1,37 @@
+"""
+조직 Slack workspace 연동 — 목적별 채널에 webhook URL 매핑.
+
+OSS 사용자는 자기 워크스페이스의 Incoming Webhook URL을 Admin UI에서 등록.
+ENV(SLACK_WEBHOOK_URL · DIGEST_SLACK_WEBHOOK_URL)는 fallback으로 남아 있다.
+"""
+
+from __future__ import annotations
+
+import enum
+
+from sqlalchemy import Boolean, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class SlackPurpose(str, enum.Enum):
+    DEFAULT = "default"            # purpose가 더 구체적으로 잡히지 않을 때 fallback
+    DIGEST = "digest"              # Daily Security Digest
+    FINDING = "finding"            # severity 임계 이상 신규 finding 알림
+    ACCESS_REQUEST = "access_request"  # 권한 요청 / 검토 알림
+    ROLE_REQUEST = "role_request"  # 역할 변경 요청
+
+
+class SlackChannel(Base, TimestampMixin):
+    __tablename__ = "slack_channels"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    purpose: Mapped[SlackPurpose] = mapped_column(
+        String(32), nullable=False, unique=True, index=True
+    )
+    label: Mapped[str | None] = mapped_column(String(255))  # 예: "#mond-alerts"
+    webhook_url: Mapped[str] = mapped_column(String(1024), nullable=False)
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
+    )

--- a/backend/app/services/digest.py
+++ b/backend/app/services/digest.py
@@ -16,6 +16,8 @@ from app.core.logging import get_logger
 from app.models.finding import Finding, Severity
 from app.models.iam import AccessRequest, AccessRequestStatus
 from app.models.scan import Scan, ScanStatus
+from app.models.slack import SlackPurpose
+from app.services import slack as slack_service
 
 logger = get_logger(__name__)
 
@@ -133,7 +135,8 @@ async def send_daily_digest(
 ) -> dict:
     digest = await build_daily_digest(session)
 
-    slack_url = slack_webhook_url or settings.DIGEST_SLACK_WEBHOOK_URL or settings.SLACK_WEBHOOK_URL
+    # 우선순위: 인자 → DB(DIGEST → DEFAULT) → ENV.
+    slack_url = slack_webhook_url or await slack_service.resolve_webhook(session, SlackPurpose.DIGEST)
     generic_url = generic_webhook_url or settings.GENERIC_WEBHOOK_URL
 
     sent: list[str] = []

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -1,7 +1,8 @@
 """
 Notifications — Slack / Generic Webhook
 
-엔드포인트가 비어 있으면 조용히 no-op. 운영자가 .env에 URL을 채우면 활성화된다.
+엔드포인트가 비어 있으면 조용히 no-op. 운영자가 .env에 URL을 채우거나
+Admin → Slack 페이지에서 등록하면 활성화된다.
 """
 
 from __future__ import annotations
@@ -9,7 +10,10 @@ from __future__ import annotations
 import httpx
 
 from app.core.config import settings
+from app.core.database import AsyncSessionLocal
 from app.core.logging import get_logger
+from app.models.slack import SlackPurpose
+from app.services import slack as slack_service
 
 logger = get_logger(__name__)
 
@@ -40,9 +44,13 @@ async def notify_finding(finding) -> None:
         f"• location: `{finding.location or '-'}`"
     )
 
+    # DB의 FINDING purpose 채널 우선, 없으면 DEFAULT, 없으면 ENV.
+    async with AsyncSessionLocal() as db:
+        slack_url = await slack_service.resolve_webhook(db, SlackPurpose.FINDING)
+
     payloads: list[tuple[str, dict]] = []
-    if settings.SLACK_WEBHOOK_URL:
-        payloads.append((settings.SLACK_WEBHOOK_URL, {"text": text}))
+    if slack_url:
+        payloads.append((slack_url, {"text": text}))
     if settings.GENERIC_WEBHOOK_URL:
         payloads.append(
             (

--- a/backend/app/services/slack.py
+++ b/backend/app/services/slack.py
@@ -1,0 +1,88 @@
+"""
+조직 Slack 채널 — DB CRUD + purpose별 webhook URL 조회.
+
+알림 발송 시 라우팅:
+  resolve_webhook(purpose) → DB의 해당 purpose · enabled 채널 → DEFAULT 채널 → ENV fallback.
+"""
+
+from __future__ import annotations
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.models.slack import SlackChannel, SlackPurpose
+
+logger = get_logger(__name__)
+
+
+async def list_channels(db: AsyncSession) -> list[SlackChannel]:
+    rows = await db.execute(select(SlackChannel).order_by(SlackChannel.purpose))
+    return list(rows.scalars().all())
+
+
+async def get_channel(db: AsyncSession, purpose: SlackPurpose) -> SlackChannel | None:
+    row = await db.execute(
+        select(SlackChannel).where(SlackChannel.purpose == purpose, SlackChannel.enabled.is_(True))
+    )
+    return row.scalar_one_or_none()
+
+
+async def upsert_channel(
+    db: AsyncSession,
+    purpose: SlackPurpose,
+    webhook_url: str,
+    label: str | None,
+    enabled: bool,
+) -> SlackChannel:
+    row = await db.execute(select(SlackChannel).where(SlackChannel.purpose == purpose))
+    existing = row.scalar_one_or_none()
+    if existing is None:
+        ch = SlackChannel(purpose=purpose, webhook_url=webhook_url, label=label, enabled=enabled)
+        db.add(ch)
+    else:
+        existing.webhook_url = webhook_url
+        existing.label = label
+        existing.enabled = enabled
+        ch = existing
+    await db.commit()
+    await db.refresh(ch)
+    return ch
+
+
+async def delete_channel(db: AsyncSession, purpose: SlackPurpose) -> bool:
+    row = await db.execute(select(SlackChannel).where(SlackChannel.purpose == purpose))
+    existing = row.scalar_one_or_none()
+    if existing is None:
+        return False
+    await db.delete(existing)
+    await db.commit()
+    return True
+
+
+async def resolve_webhook(db: AsyncSession, purpose: SlackPurpose) -> str | None:
+    """purpose → 해당 채널 → DEFAULT 채널 → ENV fallback."""
+    direct = await get_channel(db, purpose)
+    if direct:
+        return direct.webhook_url
+    default = await get_channel(db, SlackPurpose.DEFAULT)
+    if default:
+        return default.webhook_url
+    # ENV fallback — purpose에 따라 두 변수 분기
+    if purpose == SlackPurpose.DIGEST and settings.DIGEST_SLACK_WEBHOOK_URL:
+        return settings.DIGEST_SLACK_WEBHOOK_URL
+    return settings.SLACK_WEBHOOK_URL
+
+
+async def test_send(webhook_url: str, text: str) -> tuple[bool, str | None]:
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            r = await client.post(webhook_url, json={"text": text})
+            if r.status_code >= 400:
+                return False, f"HTTP {r.status_code}: {r.text[:120]}"
+            return True, None
+    except Exception as exc:
+        logger.warning("slack_test_failed", error=str(exc))
+        return False, str(exc)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -613,6 +613,22 @@ NOTIFY_MIN_SEVERITY=high   # critical / high / medium / low / info (threshold)
 - 보안팀 전담 채널 — `medium`
 - 데모 — `critical`만
 
+#### 7-0) Slack 연동 페이지 (Admin → Slack 연동)
+
+ENV에 single webhook을 박는 대신 UI에서 purpose별 채널을 등록하고 싶을 때:
+
+1. Slack workspace → Apps → **Incoming Webhooks** → 채널 선택 → URL 복사
+2. Mond에서 `Admin → Slack 연동`(`/admin/slack`) 진입
+3. 5종 purpose 카드에 webhook URL 등록
+   - `default` — purpose가 더 구체적으로 잡히지 않을 때 fallback
+   - `digest` — Daily Digest
+   - `finding` — severity 임계 이상 신규 발견
+   - `access_request` — 권한 요청 / 검토
+   - `role_request` — 역할 변경 요청
+4. 카드별 `테스트` 버튼으로 실제 메시지 발송 확인
+
+DB에 등록된 채널이 ENV(`SLACK_WEBHOOK_URL` · `DIGEST_SLACK_WEBHOOK_URL`)보다 우선합니다. ENV는 그대로 fallback으로 남아 OSS 초기 설치도 매끄럽게.
+
 <a id="daily-digest"></a>
 #### 7-1) Daily Security Digest — 매일 아침 어제 일어난 일 요약
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import Scans from "@/pages/Scans";
 import Settings from "@/pages/Settings";
 import AdminConnections from "@/pages/admin/AdminConnections";
 import AdminPolicies from "@/pages/admin/AdminPolicies";
+import AdminSlack from "@/pages/admin/AdminSlack";
 import AdminUsers from "@/pages/admin/AdminUsers";
 
 export default function App() {
@@ -115,6 +116,14 @@ export default function App() {
           element={
             <RequireAuth minRole="admin">
               <AdminConnections />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="admin/slack"
+          element={
+            <RequireAuth minRole="admin">
+              <AdminSlack />
             </RequireAuth>
           }
         />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -95,6 +95,7 @@ export default function Layout() {
     { key: "/admin/access-review", icon: <SolutionOutlined />, label: t.adminArea.menuAccessReview, minRole: "reviewer" as const },
     { key: "/admin/policies", icon: <ExperimentOutlined />, label: t.adminArea.menuPolicies, minRole: "reviewer" as const },
     { key: "/admin/connections", icon: <ApiOutlined />, label: t.adminArea.menuConnections, minRole: "admin" as const },
+    { key: "/admin/slack", icon: <BulbOutlined />, label: t.adminArea.menuSlack, minRole: "admin" as const },
     { key: "/admin/users", icon: <TeamOutlined />, label: t.adminArea.menuUsers, minRole: "admin" as const },
   ].filter((i) => hasRole(user, i.minRole));
 

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -44,6 +44,7 @@ export const en: Dict = {
     backToApp: "Back to app",
     menuAccessReview: "Access Review",
     menuConnections: "Connections",
+    menuSlack: "Slack Integration",
     menuPolicies: "Policy Management",
     menuUsers: "Users & Roles",
     connectionsTitle: "Connections",

--- a/frontend/src/i18n/ko.ts
+++ b/frontend/src/i18n/ko.ts
@@ -42,6 +42,7 @@ export const ko = {
     backToApp: "일반 모드로 복귀",
     menuAccessReview: "권한 검토",
     menuConnections: "연동 관리",
+    menuSlack: "Slack 연동",
     menuPolicies: "정책 관리",
     menuUsers: "사용자·역할",
     connectionsTitle: "연동 관리",

--- a/frontend/src/lib/admin-slack-api.ts
+++ b/frontend/src/lib/admin-slack-api.ts
@@ -1,0 +1,28 @@
+import { api } from "./api";
+
+export type SlackPurpose = "default" | "digest" | "finding" | "access_request" | "role_request";
+
+export interface SlackChannelRow {
+  id: number;
+  purpose: SlackPurpose;
+  label: string | null;
+  enabled: boolean;
+  webhook_masked: string;
+}
+
+export interface SlackChannelUpsert {
+  purpose: SlackPurpose;
+  webhook_url: string;
+  label?: string | null;
+  enabled: boolean;
+}
+
+export const adminSlackApi = {
+  list: async (): Promise<SlackChannelRow[]> => (await api.get("/admin/slack")).data,
+  upsert: async (body: SlackChannelUpsert): Promise<SlackChannelRow> =>
+    (await api.put("/admin/slack", body)).data,
+  remove: async (purpose: SlackPurpose): Promise<{ deleted: string }> =>
+    (await api.delete(`/admin/slack/${purpose}`)).data,
+  test: async (body: { purpose?: SlackPurpose; webhook_url?: string; text?: string }) =>
+    (await api.post<{ ok: boolean; error: string | null }>("/admin/slack/test", body)).data,
+};

--- a/frontend/src/pages/admin/AdminSlack.tsx
+++ b/frontend/src/pages/admin/AdminSlack.tsx
@@ -1,0 +1,292 @@
+/**
+ * Admin · Slack 연동 — 워크스페이스 채널을 purpose별로 매핑.
+ *
+ * 채널 4종 (default / digest / finding / access_request / role_request) 각각
+ * Slack Incoming Webhook URL을 등록. ENV(SLACK_WEBHOOK_URL · DIGEST_SLACK_WEBHOOK_URL)는
+ * DB가 비었을 때만 fallback으로 쓰인다.
+ */
+
+import { DeleteOutlined, SendOutlined, SlackOutlined } from "@ant-design/icons";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Alert,
+  Button,
+  Card,
+  Form,
+  Input,
+  Popconfirm,
+  Space,
+  Switch,
+  Tag,
+  Typography,
+  message,
+} from "antd";
+
+import { useI18n } from "@/i18n";
+import {
+  adminSlackApi,
+  type SlackChannelRow,
+  type SlackPurpose,
+} from "@/lib/admin-slack-api";
+
+const { Title, Paragraph, Text } = Typography;
+
+interface PurposeDef {
+  key: SlackPurpose;
+  ko: string;
+  en: string;
+  desc_ko: string;
+  desc_en: string;
+}
+
+const PURPOSES: PurposeDef[] = [
+  {
+    key: "default",
+    ko: "기본 채널",
+    en: "Default",
+    desc_ko: "다른 purpose에 맞는 채널이 없을 때 폴백.",
+    desc_en: "Fallback when a more specific channel is not set.",
+  },
+  {
+    key: "digest",
+    ko: "Daily Digest",
+    en: "Daily Digest",
+    desc_ko: "매일 어제 일어난 일을 요약하는 카드.",
+    desc_en: "Daily summary card of yesterday.",
+  },
+  {
+    key: "finding",
+    ko: "발견사항 알림",
+    en: "Findings",
+    desc_ko: "severity 임계 이상 신규 발견 알림.",
+    desc_en: "New findings above severity threshold.",
+  },
+  {
+    key: "access_request",
+    ko: "권한 요청",
+    en: "Access Requests",
+    desc_ko: "권한 요청 / 검토 / 회수 흐름.",
+    desc_en: "Access request, review, and revoke events.",
+  },
+  {
+    key: "role_request",
+    ko: "역할 변경 요청",
+    en: "Role Changes",
+    desc_ko: "임직원 role 변경 요청 알림.",
+    desc_en: "Employee role-change requests.",
+  },
+];
+
+export default function AdminSlack() {
+  const { locale } = useI18n();
+  const qc = useQueryClient();
+
+  const { data: rows, isLoading } = useQuery({
+    queryKey: ["admin-slack-channels"],
+    queryFn: adminSlackApi.list,
+  });
+
+  const byPurpose = (p: SlackPurpose): SlackChannelRow | undefined =>
+    (rows ?? []).find((r) => r.purpose === p);
+
+  return (
+    <div>
+      <Title level={2} style={{ marginBottom: 4 }}>
+        {locale === "ko" ? "Slack 연동" : "Slack Integration"}
+      </Title>
+      <Paragraph type="secondary">
+        {locale === "ko"
+          ? "워크스페이스의 Incoming Webhook URL을 목적별 채널에 매핑합니다. 등록된 채널이 있으면 그것을 우선 사용하고, 비어 있으면 .env의 SLACK_WEBHOOK_URL / DIGEST_SLACK_WEBHOOK_URL을 fallback으로 사용합니다."
+          : "Map Slack Incoming Webhook URLs to channels by purpose. DB values take precedence over .env fallbacks (SLACK_WEBHOOK_URL / DIGEST_SLACK_WEBHOOK_URL)."}
+      </Paragraph>
+
+      <Alert
+        type="info"
+        showIcon
+        style={{ marginBottom: 16 }}
+        message={
+          locale === "ko"
+            ? "Slack workspace에서 Incoming Webhook을 만드는 법"
+            : "How to create a Slack Incoming Webhook"
+        }
+        description={
+          <Text style={{ fontSize: 12 }}>
+            Slack workspace → Apps → 검색 <b>Incoming Webhooks</b> → 채널 선택 → URL 복사.{" "}
+            <a
+              href="https://api.slack.com/messaging/webhooks"
+              target="_blank"
+              rel="noreferrer"
+            >
+              공식 가이드
+            </a>
+          </Text>
+        }
+      />
+
+      <Space direction="vertical" style={{ width: "100%" }} size={12}>
+        {PURPOSES.map((p) => (
+          <ChannelCard
+            key={p.key}
+            def={p}
+            row={byPurpose(p.key)}
+            loading={isLoading}
+            onChange={() => qc.invalidateQueries({ queryKey: ["admin-slack-channels"] })}
+          />
+        ))}
+      </Space>
+    </div>
+  );
+}
+
+function ChannelCard({
+  def,
+  row,
+  loading,
+  onChange,
+}: {
+  def: PurposeDef;
+  row: SlackChannelRow | undefined;
+  loading: boolean;
+  onChange: () => void;
+}) {
+  const { locale } = useI18n();
+  const [form] = Form.useForm();
+
+  const upsert = useMutation({
+    mutationFn: (v: { webhook_url: string; label?: string; enabled: boolean }) =>
+      adminSlackApi.upsert({
+        purpose: def.key,
+        webhook_url: v.webhook_url,
+        label: v.label ?? null,
+        enabled: v.enabled,
+      }),
+    onSuccess: () => {
+      message.success(locale === "ko" ? "저장됨" : "Saved");
+      form.resetFields(["webhook_url"]);
+      onChange();
+    },
+    onError: (e: Error & { response?: { data?: { detail?: string } } }) =>
+      message.error(e.response?.data?.detail ?? e.message),
+  });
+
+  const remove = useMutation({
+    mutationFn: () => adminSlackApi.remove(def.key),
+    onSuccess: () => {
+      message.success(locale === "ko" ? "삭제됨" : "Deleted");
+      onChange();
+    },
+  });
+
+  const testSend = useMutation({
+    mutationFn: () =>
+      adminSlackApi.test({
+        purpose: def.key,
+        text: `Mond ${def.en} test — ${new Date().toISOString()}`,
+      }),
+    onSuccess: (r) => {
+      if (r.ok) message.success(locale === "ko" ? "전송됨" : "Sent");
+      else message.error(r.error || "fail");
+    },
+  });
+
+  return (
+    <Card
+      size="small"
+      title={
+        <Space>
+          <SlackOutlined />
+          <span>{locale === "ko" ? def.ko : def.en}</span>
+          {row?.enabled && <Tag color="green">{locale === "ko" ? "활성" : "Active"}</Tag>}
+          {row && !row.enabled && <Tag>{locale === "ko" ? "비활성" : "Disabled"}</Tag>}
+          {!row && <Tag>{locale === "ko" ? "미설정 — ENV fallback" : "Not set — ENV fallback"}</Tag>}
+        </Space>
+      }
+      loading={loading}
+      extra={
+        row && (
+          <Space>
+            <Button
+              size="small"
+              icon={<SendOutlined />}
+              loading={testSend.isPending}
+              onClick={() => testSend.mutate()}
+            >
+              {locale === "ko" ? "테스트" : "Test"}
+            </Button>
+            <Popconfirm
+              title={locale === "ko" ? "이 채널 매핑을 삭제할까요?" : "Delete this mapping?"}
+              okType="danger"
+              onConfirm={() => remove.mutate()}
+            >
+              <Button size="small" danger icon={<DeleteOutlined />}>
+                {locale === "ko" ? "삭제" : "Remove"}
+              </Button>
+            </Popconfirm>
+          </Space>
+        )
+      }
+    >
+      <Paragraph type="secondary" style={{ marginBottom: 12, fontSize: 12 }}>
+        {locale === "ko" ? def.desc_ko : def.desc_en}
+      </Paragraph>
+
+      {row && (
+        <Space wrap style={{ marginBottom: 12 }}>
+          {row.label && <Tag color="geekblue">{row.label}</Tag>}
+          <code style={{ fontFamily: "monospace", fontSize: 12 }}>{row.webhook_masked}</code>
+        </Space>
+      )}
+
+      <Form
+        form={form}
+        layout="vertical"
+        initialValues={{
+          label: row?.label ?? "",
+          enabled: row?.enabled ?? true,
+        }}
+        onFinish={(v) =>
+          upsert.mutate({
+            webhook_url: v.webhook_url,
+            label: v.label,
+            enabled: v.enabled,
+          })
+        }
+      >
+        <Form.Item
+          name="webhook_url"
+          label={locale === "ko" ? "Webhook URL" : "Webhook URL"}
+          rules={[
+            { required: true },
+            {
+              pattern: /^https:\/\/hooks\.slack\.com\//,
+              message: locale === "ko" ? "Slack incoming webhook URL이어야 합니다" : "Must be a Slack hooks URL",
+            },
+          ]}
+          extra={
+            row
+              ? locale === "ko"
+                ? "비워두면 기존 값 유지가 아니라 변경하려면 새 URL을 적어주세요."
+                : "Submit a new URL to overwrite."
+              : undefined
+          }
+        >
+          <Input.Password placeholder="https://hooks.slack.com/services/T.../B.../XXXX" autoComplete="off" />
+        </Form.Item>
+
+        <Space>
+          <Form.Item name="label" label={locale === "ko" ? "라벨 (예: #mond-alerts)" : "Label"} style={{ marginBottom: 0, width: 260 }}>
+            <Input placeholder="#mond-alerts" />
+          </Form.Item>
+          <Form.Item name="enabled" label={locale === "ko" ? "활성" : "Enabled"} valuePropName="checked" style={{ marginBottom: 0 }}>
+            <Switch />
+          </Form.Item>
+          <Form.Item style={{ marginBottom: 0 }}>
+            <Button type="primary" htmlType="submit" loading={upsert.isPending}>
+              {row ? (locale === "ko" ? "갱신" : "Update") : locale === "ko" ? "등록" : "Save"}
+            </Button>
+          </Form.Item>
+        </Space>
+      </Form>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
OSS 사용자가 자기 워크스페이스 Slack Incoming Webhook URL을 purpose별 채널에 매핑하는 별도 페이지. ENV는 fallback.

### Backend
- `models/slack.py` — SlackPurpose enum + SlackChannel (purpose UNIQUE / webhook_url / label / enabled)
- `services/slack.py` — CRUD + `resolve_webhook(purpose)` (purpose → DEFAULT → ENV)
- `endpoints/admin_slack.py` — list / upsert / delete / test (Admin 전용)
- `services/notifications.py` · `services/digest.py` — DB resolve 사용

### Frontend
- `pages/admin/AdminSlack.tsx` — 5 purpose 카드 (등록 · 갱신 · 삭제 · 테스트)
- 사이드바 Admin Area에 'Slack 연동' 추가

## Test plan
- [x] /admin/slack 5 카드 노출 정상
- [x] 사이드바 'Slack 연동' active
- [x] 라우터 등록 확인 (401 ↔ 200)
- [x] ruff check 통과
- [ ] CI

## 문서
- CHANGELOG [Unreleased] Added
- docs/SETUP.md Part 5 7-0) Slack 연동 페이지