### PR TITLE
fix(models): SlackChannel/SlackPurpose __all__ 등록 (ruff F401)

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -48,6 +48,8 @@ __all__ = [
     "Severity",
     "Policy",
     "PolicyType",
+    "SlackChannel",
+    "SlackPurpose",
     "AIInsight",
     "InsightKind",
     "AIProviderConfig",


### PR DESCRIPTION
PR #46 머지 후 main CI Ruff F401 실패. `models/__init__.py`에서 import만 하고 `__all__`에 안 넣어 unused. 한 줄 fix.