### PR TITLE
feat: 사용자별 personal Slack DM + @mention 라우팅

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [Unreleased]
 
 ### Added
+- **사용자별 Slack 알림 설정** — Security Settings의 "내 Slack 알림" 카드. 본인 DM webhook URL과 Slack user ID(@mention용)를 등록할 수 있고, 본인이 owner인 자산의 신규 finding 발생 시 organization 채널에 @mention + 본인 DM(설정 시) 발송. 별도 테이블 `user_slack_preferences`로 운영 중 환경에서도 schema migration 없이 자동 추가.
 - **Slack 연동 별도 페이지** — `/admin/slack` (Admin). 워크스페이스의 Incoming Webhook URL을 5종 purpose(`default` · `digest` · `finding` · `access_request` · `role_request`) 채널에 매핑하고, 카드별로 테스트 메시지 전송. DB에 저장된 채널이 ENV(`SLACK_WEBHOOK_URL` · `DIGEST_SLACK_WEBHOOK_URL`)보다 우선. `notifications` · `digest` 둘 다 `slack.resolve_webhook(purpose)`로 라우팅 일원화.
 - **권한 만료 임박 + 1-click 갱신** — My Mond (`/me`)의 "만료 임박" 카드 각 항목에 `갱신 요청` 버튼. 백엔드 `POST /api/v1/me/access-requests/{id}/renew`가 같은 identity·permission으로 새 AccessRequest를 만들어 AI 1차 검토 흐름에 태움. Daily Digest에도 3일 내 만료 권한 수가 추가됨.
 - **Daily Security Digest** — 어제 일어난 일(신규 finding severity별 · 스캔 실행/실패 · 권한 요청 흐름)을 Slack 카드 한 장으로. Admin → Connections에 카드 + `지금 전송` 버튼. 자동 실행은 외부 cron(k8s CronJob 예시 포함)이 `POST /api/v1/admin/digest/send` 호출. 미리보기 `GET /api/v1/admin/digest/preview` (Reviewer+). 전용 채널 ENV `DIGEST_SLACK_WEBHOOK_URL` (없으면 `SLACK_WEBHOOK_URL` fallback).

--- a/backend/app/api/v1/endpoints/me.py
+++ b/backend/app/api/v1/endpoints/me.py
@@ -5,6 +5,7 @@
 """
 
 from fastapi import APIRouter, Body, Depends, HTTPException
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,11 +13,105 @@ from app.auth.deps import current_user
 from app.core.database import get_db
 from app.models.iam import AccessRequest
 from app.models.user import User
+from app.models.user_slack import UserSlackPreference
 from app.schemas.iam import AccessRequestCreate, AccessRequestRead
 from app.services import iam as iam_service
 from app.services import me as me_service
+from app.services import slack as slack_service
 
 router = APIRouter()
+
+
+class SlackPrefIn(BaseModel):
+    slack_dm_webhook_url: str | None = None
+    slack_user_id: str | None = None
+    notify_finding: bool = True
+
+
+def _mask(url: str | None) -> str | None:
+    if not url:
+        return None
+    if len(url) <= 30:
+        return "…"
+    return url[:30] + "…" + url[-4:]
+
+
+@router.get("/slack-preference")
+async def get_slack_pref(
+    user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    pref = (await db.execute(
+        select(UserSlackPreference).where(UserSlackPreference.user_id == user.id)
+    )).scalar_one_or_none()
+    if pref is None:
+        return {"configured": False, "notify_finding": True}
+    return {
+        "configured": True,
+        "webhook_masked": _mask(pref.slack_dm_webhook_url),
+        "slack_user_id": pref.slack_user_id,
+        "notify_finding": pref.notify_finding,
+    }
+
+
+@router.put("/slack-preference")
+async def put_slack_pref(
+    payload: SlackPrefIn,
+    user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    if payload.slack_dm_webhook_url and not payload.slack_dm_webhook_url.startswith("https://hooks.slack.com/"):
+        raise HTTPException(status_code=400, detail="Slack incoming webhook URL이어야 합니다")
+    if payload.slack_user_id and not payload.slack_user_id.startswith(("U", "W")):
+        raise HTTPException(status_code=400, detail="Slack user ID는 U.. 또는 W..로 시작합니다")
+
+    pref = (await db.execute(
+        select(UserSlackPreference).where(UserSlackPreference.user_id == user.id)
+    )).scalar_one_or_none()
+    if pref is None:
+        pref = UserSlackPreference(user_id=user.id)
+        db.add(pref)
+    pref.slack_dm_webhook_url = payload.slack_dm_webhook_url or None
+    pref.slack_user_id = payload.slack_user_id or None
+    pref.notify_finding = payload.notify_finding
+    await db.commit()
+    await db.refresh(pref)
+    return {
+        "configured": True,
+        "webhook_masked": _mask(pref.slack_dm_webhook_url),
+        "slack_user_id": pref.slack_user_id,
+        "notify_finding": pref.notify_finding,
+    }
+
+
+@router.delete("/slack-preference")
+async def delete_slack_pref(
+    user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    pref = (await db.execute(
+        select(UserSlackPreference).where(UserSlackPreference.user_id == user.id)
+    )).scalar_one_or_none()
+    if pref is None:
+        return {"deleted": False}
+    await db.delete(pref)
+    await db.commit()
+    return {"deleted": True}
+
+
+@router.post("/slack-preference/test")
+async def test_slack_pref(
+    user: User = Depends(current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    pref = (await db.execute(
+        select(UserSlackPreference).where(UserSlackPreference.user_id == user.id)
+    )).scalar_one_or_none()
+    if pref is None or not pref.slack_dm_webhook_url:
+        raise HTTPException(status_code=400, detail="등록된 webhook URL이 없습니다")
+    text = f"Mond — {user.email} 본인 DM 테스트"
+    ok, err = await slack_service.test_send(pref.slack_dm_webhook_url, text)
+    return {"ok": ok, "error": err}
 
 
 @router.get("/overview")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -26,6 +26,7 @@ from app.models.knowledge import KnowledgeCard, KnowledgeCategory, KnowledgeSour
 from app.models.policy import Policy, PolicyType
 from app.models.scan import Scan, ScanStatus, ScanTrigger
 from app.models.slack import SlackChannel, SlackPurpose
+from app.models.user_slack import UserSlackPreference
 from app.models.user import (
     MfaBackupCode,
     Role,
@@ -50,6 +51,7 @@ __all__ = [
     "PolicyType",
     "SlackChannel",
     "SlackPurpose",
+    "UserSlackPreference",
     "AIInsight",
     "InsightKind",
     "AIProviderConfig",

--- a/backend/app/models/user_slack.py
+++ b/backend/app/models/user_slack.py
@@ -1,0 +1,32 @@
+"""
+사용자별 Slack 알림 설정.
+
+User 테이블에 컬럼을 추가하면 schema migration이 필요하지만,
+별도 테이블로 두면 Base.metadata.create_all로 신규 환경에서 자동 생성된다.
+이미 운영 중인 환경에는 backend 재시작 시 누락 테이블이 추가된다.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Boolean, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class UserSlackPreference(Base, TimestampMixin):
+    __tablename__ = "user_slack_preferences"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False, index=True
+    )
+    # 본인 DM webhook (선택) — workspace에서 본인 DM을 받는 채널을 위한 URL.
+    # 보통 Slack workflow 또는 사용자 본인이 만든 채널의 webhook을 등록.
+    slack_dm_webhook_url: Mapped[str | None] = mapped_column(String(1024))
+    # Slack user ID (선택) — U12345 형식. organization 채널 알림에 @mention용.
+    slack_user_id: Mapped[str | None] = mapped_column(String(64))
+    # 본인 owner asset의 신규 finding을 DM으로 받을지.
+    notify_finding: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
+    )

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -9,10 +9,15 @@ from __future__ import annotations
 
 import httpx
 
+from sqlalchemy import select
+
 from app.core.config import settings
 from app.core.database import AsyncSessionLocal
 from app.core.logging import get_logger
+from app.models.asset import Asset
 from app.models.slack import SlackPurpose
+from app.models.user import User
+from app.models.user_slack import UserSlackPreference
 from app.services import slack as slack_service
 
 logger = get_logger(__name__)
@@ -37,20 +42,42 @@ async def notify_finding(finding) -> None:
         return
 
     emoji = SEVERITY_EMOJI.get(finding.severity.value, "🔍")
-    text = (
+    base_text = (
         f"{emoji} *Mond* — {finding.severity.value.upper()} finding\n"
         f"• *{finding.title}*\n"
         f"• rule: `{finding.rule_id}` · scanner: `{finding.scanner}`\n"
         f"• location: `{finding.location or '-'}`"
     )
 
-    # DB의 FINDING purpose 채널 우선, 없으면 DEFAULT, 없으면 ENV.
+    # asset owner의 Slack preference 찾기 — DM + mention.
+    owner_dm_url: str | None = None
+    owner_mention: str | None = None
     async with AsyncSessionLocal() as db:
+        asset = (await db.execute(select(Asset).where(Asset.id == finding.asset_id))).scalar_one_or_none()
+        owner_email = asset.owner if asset else None
+        if owner_email:
+            owner_user = (await db.execute(select(User).where(User.email == owner_email))).scalar_one_or_none()
+            if owner_user:
+                pref = (await db.execute(
+                    select(UserSlackPreference).where(UserSlackPreference.user_id == owner_user.id)
+                )).scalar_one_or_none()
+                if pref and pref.notify_finding:
+                    owner_dm_url = pref.slack_dm_webhook_url
+                    owner_mention = pref.slack_user_id
+
+        # DB의 FINDING purpose 채널 우선, 없으면 DEFAULT, 없으면 ENV.
         slack_url = await slack_service.resolve_webhook(db, SlackPurpose.FINDING)
+
+    text = base_text
+    if owner_mention:
+        text = f"<@{owner_mention}> {base_text}"
 
     payloads: list[tuple[str, dict]] = []
     if slack_url:
         payloads.append((slack_url, {"text": text}))
+    if owner_dm_url and owner_dm_url != slack_url:
+        # 본인 DM은 mention 빼고 본문만.
+        payloads.append((owner_dm_url, {"text": base_text}))
     if settings.GENERIC_WEBHOOK_URL:
         payloads.append(
             (

--- a/frontend/src/pages/SecuritySettings.tsx
+++ b/frontend/src/pages/SecuritySettings.tsx
@@ -12,6 +12,7 @@ import { useI18n } from "@/i18n";
 import { mfaApi } from "@/lib/mfa-api";
 
 import BackupCodesCard from "./security/BackupCodesCard";
+import MySlackDmCard from "./security/MySlackDmCard";
 import PasskeysCard from "./security/PasskeysCard";
 import PersonalWebhookTokensCard from "./security/PersonalWebhookTokensCard";
 import RoleChangeRequestCard from "./security/RoleChangeRequestCard";
@@ -43,6 +44,7 @@ export default function SecuritySettings() {
       <TOTPCard />
       <BackupCodesCard />
 
+      <MySlackDmCard />
       <PersonalWebhookTokensCard />
       <RoleChangeRequestCard />
     </div>

--- a/frontend/src/pages/security/MySlackDmCard.tsx
+++ b/frontend/src/pages/security/MySlackDmCard.tsx
@@ -1,0 +1,209 @@
+/**
+ * 내 Slack DM 알림 설정 — 본인 owner asset의 finding 발생 시 본인 DM 또는
+ * organization 채널에 @mention.
+ */
+
+import { DeleteOutlined, SendOutlined, SlackOutlined } from "@ant-design/icons";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Alert,
+  Button,
+  Card,
+  Form,
+  Input,
+  Popconfirm,
+  Space,
+  Switch,
+  Tag,
+  Typography,
+  message,
+} from "antd";
+
+import { useI18n } from "@/i18n";
+import { api } from "@/lib/api";
+
+const { Paragraph, Text } = Typography;
+
+interface SlackPref {
+  configured: boolean;
+  webhook_masked?: string;
+  slack_user_id?: string | null;
+  notify_finding: boolean;
+}
+
+export default function MySlackDmCard() {
+  const { locale } = useI18n();
+  const qc = useQueryClient();
+  const [form] = Form.useForm();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["me-slack-pref"],
+    queryFn: async () => (await api.get<SlackPref>("/me/slack-preference")).data,
+  });
+
+  const save = useMutation({
+    mutationFn: (v: { slack_dm_webhook_url: string; slack_user_id: string; notify_finding: boolean }) =>
+      api.put<SlackPref>("/me/slack-preference", {
+        slack_dm_webhook_url: v.slack_dm_webhook_url || null,
+        slack_user_id: v.slack_user_id || null,
+        notify_finding: v.notify_finding,
+      }),
+    onSuccess: () => {
+      message.success(locale === "ko" ? "저장됨" : "Saved");
+      form.resetFields(["slack_dm_webhook_url"]);
+      qc.invalidateQueries({ queryKey: ["me-slack-pref"] });
+    },
+    onError: (e: Error & { response?: { data?: { detail?: string } } }) =>
+      message.error(e.response?.data?.detail ?? e.message),
+  });
+
+  const remove = useMutation({
+    mutationFn: () => api.delete("/me/slack-preference"),
+    onSuccess: () => {
+      message.success(locale === "ko" ? "삭제됨" : "Deleted");
+      form.resetFields();
+      qc.invalidateQueries({ queryKey: ["me-slack-pref"] });
+    },
+  });
+
+  const testSend = useMutation({
+    mutationFn: () => api.post<{ ok: boolean; error: string | null }>("/me/slack-preference/test"),
+    onSuccess: (r) => {
+      if (r.data.ok) message.success(locale === "ko" ? "전송됨" : "Sent");
+      else message.error(r.data.error || "fail");
+    },
+    onError: (e: Error & { response?: { data?: { detail?: string } } }) =>
+      message.error(e.response?.data?.detail ?? e.message),
+  });
+
+  return (
+    <Card
+      title={
+        <Space>
+          <SlackOutlined />
+          <span>{locale === "ko" ? "내 Slack 알림" : "My Slack Notifications"}</span>
+          {data?.configured && <Tag color="green">{locale === "ko" ? "활성" : "Active"}</Tag>}
+        </Space>
+      }
+      style={{ marginTop: 16 }}
+      loading={isLoading}
+      extra={
+        data?.configured && (
+          <Space>
+            <Button
+              size="small"
+              icon={<SendOutlined />}
+              loading={testSend.isPending}
+              onClick={() => testSend.mutate()}
+            >
+              {locale === "ko" ? "테스트" : "Test"}
+            </Button>
+            <Popconfirm
+              title={locale === "ko" ? "내 Slack 설정을 지울까요?" : "Remove your Slack preferences?"}
+              okType="danger"
+              onConfirm={() => remove.mutate()}
+            >
+              <Button size="small" danger icon={<DeleteOutlined />}>
+                {locale === "ko" ? "삭제" : "Remove"}
+              </Button>
+            </Popconfirm>
+          </Space>
+        )
+      }
+    >
+      <Paragraph type="secondary" style={{ marginBottom: 12 }}>
+        {locale === "ko"
+          ? "내가 owner인 자산의 finding이 생기면 본인 Slack DM으로 받거나, organization 채널에 본인 @mention을 추가합니다. 둘 중 하나만 등록해도 됩니다."
+          : "Get DMs (or be @mentioned in the org channel) when findings appear on assets you own."}
+      </Paragraph>
+
+      {data?.configured && (
+        <Space wrap style={{ marginBottom: 12 }}>
+          {data.webhook_masked && (
+            <Tag>
+              {locale === "ko" ? "내 DM" : "My DM"}: <code style={{ fontFamily: "monospace" }}>{data.webhook_masked}</code>
+            </Tag>
+          )}
+          {data.slack_user_id && (
+            <Tag>
+              @mention: <code style={{ fontFamily: "monospace" }}>{data.slack_user_id}</code>
+            </Tag>
+          )}
+        </Space>
+      )}
+
+      <Form
+        form={form}
+        layout="vertical"
+        initialValues={{
+          slack_user_id: data?.slack_user_id ?? "",
+          notify_finding: data?.notify_finding ?? true,
+        }}
+        onFinish={(v) => save.mutate(v)}
+      >
+        <Form.Item
+          name="slack_dm_webhook_url"
+          label={locale === "ko" ? "내 DM webhook URL (선택)" : "My DM webhook URL (optional)"}
+          extra={
+            locale === "ko"
+              ? "본인 DM 채널을 가진 워크스페이스에서 만든 Incoming Webhook URL. 등록 시 본인만 받는 DM으로 발송."
+              : "Slack Incoming Webhook URL pointing to your DM channel."
+          }
+          rules={[
+            {
+              validator: (_, v) =>
+                !v || /^https:\/\/hooks\.slack\.com\//.test(v)
+                  ? Promise.resolve()
+                  : Promise.reject(new Error("Slack hooks URL")),
+            },
+          ]}
+        >
+          <Input.Password placeholder="https://hooks.slack.com/services/..." autoComplete="off" />
+        </Form.Item>
+
+        <Form.Item
+          name="slack_user_id"
+          label={locale === "ko" ? "Slack user ID (선택, @mention용)" : "Slack user ID (optional, for @mention)"}
+          extra={
+            locale === "ko"
+              ? "U12345 형식. 본인 Slack 프로필 → 더보기 → 멤버 ID 복사. 조직 채널 알림에 본인 mention이 추가됩니다."
+              : "U12345 format. From Slack profile → More → Copy member ID."
+          }
+          rules={[
+            {
+              validator: (_, v) =>
+                !v || /^[UW][A-Z0-9]+$/.test(v)
+                  ? Promise.resolve()
+                  : Promise.reject(new Error("U.. or W.. ID")),
+            },
+          ]}
+        >
+          <Input placeholder="U12345ABCDE" />
+        </Form.Item>
+
+        <Form.Item name="notify_finding" valuePropName="checked" label={locale === "ko" ? "발견사항 알림 받기" : "Notify on findings"}>
+          <Switch />
+        </Form.Item>
+
+        <Form.Item style={{ marginBottom: 0 }}>
+          <Button type="primary" htmlType="submit" loading={save.isPending}>
+            {data?.configured ? (locale === "ko" ? "갱신" : "Update") : locale === "ko" ? "등록" : "Save"}
+          </Button>
+        </Form.Item>
+      </Form>
+
+      <Alert
+        type="info"
+        showIcon
+        style={{ marginTop: 12 }}
+        message={
+          <Text style={{ fontSize: 12 }}>
+            {locale === "ko"
+              ? "본인이 owner로 등록된 자산의 finding이 trigger됩니다. 자산 상세에서 owner = 본인 이메일 확인."
+              : "Triggered for findings on assets where owner = your email."}
+          </Text>
+        }
+      />
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
본인이 owner인 자산의 finding 발생 시 본인 DM 또는 organization 채널에 @mention 추가. Wave 3 (페르소나 가치) 완성.

### Backend
- `models/user_slack.py` — `UserSlackPreference` 별도 테이블 (auto-create로 기존 환경에도 자동 추가)
- `endpoints/me.py` — GET/PUT/DELETE `/me/slack-preference` + POST `/test`
- `services/notifications.py` — finding.asset.owner → user preference 매핑, mention + DM 라우팅

### Frontend
- `pages/security/MySlackDmCard.tsx` — DM URL + user ID + 알림 토글 + 테스트 + 삭제
- `SecuritySettings` 페이지 백업 코드 다음에 카드 배치

## Test plan
- [x] /security 페이지에 카드 노출
- [x] 라우터 등록 (401 ↔ 200)
- [x] `ruff check .` 전체 통과 (지난 회귀 학습 반영)
- [ ] CI

## 문서
- CHANGELOG [Unreleased] Added