### PR TITLE
feat: SBOM 실 의존성 추출 (npm · pypi · go · docker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [Unreleased]
 
 ### Added
+- **SBOM 실 의존성 추출** — `package.json` / `package-lock.json` / `requirements.txt` / `go.mod` / Dockerfile 5종 파서. 백엔드 `POST /api/v1/reports/sbom/parse` (filename + content → ecosystem 감지 + 패키지 리스트). Reports 페이지에 "SBOM 파일 파싱" 카드 추가 (붙여넣기 → 추출 → 테이블). 기존 finding 기반 lightweight SBOM은 유지하되 stub Alert 톤을 정직화.
 - **사용자별 Slack 알림 설정** — Security Settings의 "내 Slack 알림" 카드. 본인 DM webhook URL과 Slack user ID(@mention용)를 등록할 수 있고, 본인이 owner인 자산의 신규 finding 발생 시 organization 채널에 @mention + 본인 DM(설정 시) 발송. 별도 테이블 `user_slack_preferences`로 운영 중 환경에서도 schema migration 없이 자동 추가.
 - **Slack 연동 별도 페이지** — `/admin/slack` (Admin). 워크스페이스의 Incoming Webhook URL을 5종 purpose(`default` · `digest` · `finding` · `access_request` · `role_request`) 채널에 매핑하고, 카드별로 테스트 메시지 전송. DB에 저장된 채널이 ENV(`SLACK_WEBHOOK_URL` · `DIGEST_SLACK_WEBHOOK_URL`)보다 우선. `notifications` · `digest` 둘 다 `slack.resolve_webhook(purpose)`로 라우팅 일원화.
 - **권한 만료 임박 + 1-click 갱신** — My Mond (`/me`)의 "만료 임박" 카드 각 항목에 `갱신 요청` 버튼. 백엔드 `POST /api/v1/me/access-requests/{id}/renew`가 같은 identity·permission으로 새 AccessRequest를 만들어 AI 1차 검토 흐름에 태움. Daily Digest에도 3일 내 만료 권한 수가 추가됨.

--- a/backend/app/api/v1/endpoints/reports.py
+++ b/backend/app/api/v1/endpoints/reports.py
@@ -4,13 +4,14 @@ Reports 엔드포인트 — SBOM / Compliance
 권한 모델: 인증된 사용자만 (감사·컴플라이언스 리포트는 외부 공개 금지)
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from fastapi.responses import PlainTextResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.deps import current_user
 from app.core.database import get_db
 from app.models.user import User
+from app.services import sbom_parser
 from app.services.reports import (
     compliance_report,
     compliance_report_markdown,
@@ -18,6 +19,51 @@ from app.services.reports import (
 )
 
 router = APIRouter()
+
+
+@router.post("/sbom/parse")
+async def sbom_parse(
+    payload: dict = Body(
+        ...,
+        example={
+            "filename": "package.json",
+            "content": "{...}",
+        },
+    ),
+    _user: User = Depends(current_user),
+) -> dict:
+    """의존성 파일 내용을 받아 ecosystem 감지 + 패키지 리스트 반환.
+
+    지원 파일:
+      - package.json / package-lock.json (npm)
+      - requirements.txt (pypi)
+      - go.mod (Go modules)
+      - Dockerfile (base images)
+    """
+    filename = payload.get("filename") or ""
+    content = payload.get("content") or ""
+    if not filename or not content:
+        raise HTTPException(status_code=400, detail="filename · content 모두 필요")
+    eco, pkgs = sbom_parser.parse(content, filename)
+    if eco is None:
+        raise HTTPException(
+            status_code=400,
+            detail="지원하지 않는 파일 — package.json / package-lock.json / requirements.txt / go.mod / Dockerfile",
+        )
+    return {
+        "filename": filename,
+        "ecosystem": eco,
+        "count": len(pkgs),
+        "packages": [
+            {
+                "name": p.name,
+                "version": p.version,
+                "ecosystem": p.ecosystem,
+                "dev": p.dev,
+            }
+            for p in pkgs
+        ],
+    }
 
 
 @router.get("/sbom")

--- a/backend/app/services/sbom_parser.py
+++ b/backend/app/services/sbom_parser.py
@@ -1,0 +1,171 @@
+"""
+의존성 파일 파서 — npm · pip · Go modules · Dockerfile.
+
+기존 lightweight_sbom은 finding 기반 합성. 여기는 의존성 선언 파일에서 직접 추출.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+
+@dataclass
+class Package:
+    ecosystem: str
+    name: str
+    version: str | None
+    source_file: str | None = None
+    dev: bool = False
+
+
+def detect_ecosystem(filename: str) -> str | None:
+    base = filename.rsplit("/", 1)[-1].lower()
+    if base in ("package.json", "package-lock.json"):
+        return "npm"
+    if base in ("requirements.txt", "pyproject.toml", "poetry.lock"):
+        return "pypi"
+    if base == "go.mod":
+        return "go"
+    if base == "dockerfile" or base.endswith(".dockerfile"):
+        return "docker"
+    return None
+
+
+def parse_package_json(content: str, source_file: str | None = None) -> list[Package]:
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        return []
+    out: list[Package] = []
+    for k, v in (data.get("dependencies") or {}).items():
+        out.append(Package(ecosystem="npm", name=k, version=str(v), source_file=source_file))
+    for k, v in (data.get("devDependencies") or {}).items():
+        out.append(Package(ecosystem="npm", name=k, version=str(v), source_file=source_file, dev=True))
+    return out
+
+
+def parse_package_lock_json(content: str, source_file: str | None = None) -> list[Package]:
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        return []
+    out: list[Package] = []
+    # v3 lockfile: packages dict (key는 node_modules/pkg)
+    for path, meta in (data.get("packages") or {}).items():
+        if path == "":
+            continue
+        name = path.split("node_modules/")[-1] if "node_modules/" in path else path
+        version = (meta or {}).get("version")
+        if name and version:
+            out.append(
+                Package(
+                    ecosystem="npm",
+                    name=name,
+                    version=version,
+                    source_file=source_file,
+                    dev=bool((meta or {}).get("dev")),
+                )
+            )
+    # v1/v2 fallback — dependencies (deprecated이지만 흔함)
+    if not out:
+        for name, meta in (data.get("dependencies") or {}).items():
+            version = (meta or {}).get("version")
+            if version:
+                out.append(Package(ecosystem="npm", name=name, version=version, source_file=source_file))
+    return out
+
+
+_REQ_LINE = re.compile(r"^([A-Za-z0-9_\-\.\[\]]+)\s*([=<>!~]+)\s*([^\s,;]+)")
+
+
+def parse_requirements_txt(content: str, source_file: str | None = None) -> list[Package]:
+    out: list[Package] = []
+    for raw in content.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line or line.startswith("-"):  # -r other.txt 등 skip
+            continue
+        m = _REQ_LINE.match(line)
+        if m:
+            out.append(
+                Package(ecosystem="pypi", name=m.group(1), version=m.group(3), source_file=source_file)
+            )
+        else:
+            # 버전 없이 패키지만 (== 없이)
+            name = line.split()[0]
+            if re.match(r"^[A-Za-z0-9_\-\.]+$", name):
+                out.append(Package(ecosystem="pypi", name=name, version=None, source_file=source_file))
+    return out
+
+
+_GO_REQUIRE_LINE = re.compile(r"^\s*([^\s]+)\s+v?([^\s]+)")
+
+
+def parse_go_mod(content: str, source_file: str | None = None) -> list[Package]:
+    out: list[Package] = []
+    in_block = False
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("//"):
+            continue
+        if line.startswith("require ("):
+            in_block = True
+            continue
+        if in_block and line == ")":
+            in_block = False
+            continue
+        if in_block:
+            m = _GO_REQUIRE_LINE.match(line)
+            if m:
+                out.append(
+                    Package(ecosystem="go", name=m.group(1), version=m.group(2), source_file=source_file)
+                )
+        elif line.startswith("require "):
+            m = _GO_REQUIRE_LINE.match(line[len("require "):])
+            if m:
+                out.append(
+                    Package(ecosystem="go", name=m.group(1), version=m.group(2), source_file=source_file)
+                )
+    return out
+
+
+_DOCKER_FROM = re.compile(r"^FROM\s+(?:--platform=[^\s]+\s+)?([^\s:]+)(?::([^\s@]+))?", re.IGNORECASE)
+
+
+def parse_dockerfile(content: str, source_file: str | None = None) -> list[Package]:
+    out: list[Package] = []
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = _DOCKER_FROM.match(line)
+        if m:
+            out.append(
+                Package(
+                    ecosystem="docker",
+                    name=m.group(1),
+                    version=m.group(2),  # 태그 없으면 None
+                    source_file=source_file,
+                )
+            )
+    return out
+
+
+def parse(content: str, filename: str) -> tuple[str | None, list[Package]]:
+    """filename으로 ecosystem 감지 후 알맞은 파서 실행."""
+    base = filename.rsplit("/", 1)[-1].lower()
+    eco = detect_ecosystem(filename)
+    if eco is None:
+        return None, []
+    if base == "package.json":
+        return eco, parse_package_json(content, filename)
+    if base == "package-lock.json":
+        return eco, parse_package_lock_json(content, filename)
+    if base == "requirements.txt":
+        return eco, parse_requirements_txt(content, filename)
+    if base == "go.mod":
+        return eco, parse_go_mod(content, filename)
+    if base == "dockerfile" or base.endswith(".dockerfile"):
+        return eco, parse_dockerfile(content, filename)
+    return eco, []

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -2,15 +2,29 @@
  * Reports — SBOM / Compliance 다운로드
  */
 
-import { DownloadOutlined, ExperimentOutlined } from "@ant-design/icons";
-import { useQuery } from "@tanstack/react-query";
-import { Alert, Button, Card, Col, Row, Select, Space, Tag, Typography } from "antd";
+import { DownloadOutlined, ExperimentOutlined, FileSearchOutlined } from "@ant-design/icons";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Alert, Button, Card, Col, Input, Row, Select, Space, Table, Tag, Typography, message } from "antd";
 import { useState } from "react";
 
 import { useI18n } from "@/i18n";
 import { api, type Asset, type Page } from "@/lib/api";
 
-const { Title, Paragraph } = Typography;
+const { Title, Paragraph, Text } = Typography;
+
+interface ParsedPackage {
+  name: string;
+  version: string | null;
+  ecosystem: string;
+  dev: boolean;
+}
+
+interface ParseResult {
+  filename: string;
+  ecosystem: string;
+  count: number;
+  packages: ParsedPackage[];
+}
 
 interface ScenarioLite {
   id: string;
@@ -21,6 +35,28 @@ export default function Reports() {
   const { t, locale } = useI18n();
   const [assetId, setAssetId] = useState<number | undefined>(undefined);
   const [scenarioId, setScenarioId] = useState<string | undefined>(undefined);
+
+  // SBOM 파일 파싱 (실 추출)
+  const [filename, setFilename] = useState("package.json");
+  const [content, setContent] = useState("");
+  const [parsed, setParsed] = useState<ParseResult | null>(null);
+
+  const parseSbom = useMutation({
+    mutationFn: async () => {
+      const { data } = await api.post<ParseResult>("/reports/sbom/parse", { filename, content });
+      return data;
+    },
+    onSuccess: (r) => {
+      setParsed(r);
+      message.success(
+        locale === "ko"
+          ? `${r.count}개 패키지 추출 (${r.ecosystem})`
+          : `${r.count} packages extracted (${r.ecosystem})`,
+      );
+    },
+    onError: (e: Error & { response?: { data?: { detail?: string } } }) =>
+      message.error(e.response?.data?.detail ?? e.message),
+  });
 
   const { data: assets } = useQuery({
     queryKey: ["assets-lite-reports"],
@@ -57,13 +93,13 @@ export default function Reports() {
             }
           >
             <Alert
-              type="warning"
+              type="info"
               showIcon
               style={{ marginBottom: 12 }}
               message={
                 locale === "ko"
-                  ? "SBOM은 현재 CycloneDX-lite stub입니다. 실제 의존성 추출 (package.json·go.mod·Dockerfile 파싱)은 v0.2 로드맵."
-                  : "SBOM is a CycloneDX-lite stub. Real dependency extraction (package.json · go.mod · Dockerfile) is on the v0.2 roadmap."
+                  ? "이 카드의 SBOM은 자산의 finding을 묶은 CycloneDX-lite입니다. 의존성 파일 직접 파싱은 아래 'SBOM 파일 파싱' 카드 사용."
+                  : "This SBOM is a finding-based CycloneDX-lite. For real dependency parsing use the 'SBOM File Parsing' card below."
               }
             />
             <Paragraph type="secondary">{t.reports.sbomDesc}</Paragraph>
@@ -135,6 +171,85 @@ export default function Reports() {
                 </Button>
               </Space>
             </Space>
+          </Card>
+        </Col>
+
+        <Col xs={24}>
+          <Card
+            title={
+              <Space>
+                <FileSearchOutlined />
+                <span>{locale === "ko" ? "SBOM 파일 파싱" : "SBOM File Parsing"}</span>
+                <Tag color="blue">npm · pypi · go · docker</Tag>
+              </Space>
+            }
+          >
+            <Paragraph type="secondary">
+              {locale === "ko"
+                ? "package.json / package-lock.json / requirements.txt / go.mod / Dockerfile 내용을 붙여 넣으면 의존성을 추출합니다."
+                : "Paste contents of package.json / package-lock.json / requirements.txt / go.mod / Dockerfile to extract dependencies."}
+            </Paragraph>
+            <Space style={{ width: "100%", marginBottom: 12 }} wrap>
+              <Select
+                style={{ width: 240 }}
+                value={filename}
+                onChange={setFilename}
+                options={[
+                  { value: "package.json", label: "package.json" },
+                  { value: "package-lock.json", label: "package-lock.json" },
+                  { value: "requirements.txt", label: "requirements.txt" },
+                  { value: "go.mod", label: "go.mod" },
+                  { value: "Dockerfile", label: "Dockerfile" },
+                ]}
+              />
+              <Button
+                type="primary"
+                onClick={() => parseSbom.mutate()}
+                disabled={!content.trim()}
+                loading={parseSbom.isPending}
+              >
+                {locale === "ko" ? "추출" : "Parse"}
+              </Button>
+              {parsed && (
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  {locale === "ko"
+                    ? `${parsed.ecosystem} · ${parsed.count}개`
+                    : `${parsed.ecosystem} · ${parsed.count} packages`}
+                </Text>
+              )}
+            </Space>
+            <Input.TextArea
+              rows={6}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder={locale === "ko" ? "파일 내용 붙여넣기" : "Paste file content"}
+              style={{ fontFamily: "monospace", fontSize: 12, marginBottom: 12 }}
+            />
+
+            {parsed && parsed.packages.length > 0 && (
+              <Table
+                size="small"
+                rowKey={(r: ParsedPackage, i?: number) => `${r.name}@${r.version}@${i}`}
+                dataSource={parsed.packages}
+                pagination={{ pageSize: 20 }}
+                columns={[
+                  { title: locale === "ko" ? "패키지" : "Name", dataIndex: "name" },
+                  { title: locale === "ko" ? "버전" : "Version", dataIndex: "version", width: 180, render: (v: string | null) => v ?? "—" },
+                  {
+                    title: "ecosystem",
+                    dataIndex: "ecosystem",
+                    width: 110,
+                    render: (e: string) => <Tag>{e}</Tag>,
+                  },
+                  {
+                    title: locale === "ko" ? "dev" : "dev",
+                    dataIndex: "dev",
+                    width: 70,
+                    render: (d: boolean) => (d ? <Tag>dev</Tag> : null),
+                  },
+                ]}
+              />
+            )}
           </Card>
         </Col>
       </Row>


### PR DESCRIPTION
## Summary
README v0.2 로드맵의 "SBOM 실 의존성 추출" 항목. 의존성 선언 파일에서 직접 패키지 추출.

### Backend
- `services/sbom_parser.py` — 5종 파서: package.json · package-lock.json (v3+) · requirements.txt · go.mod · Dockerfile
- `endpoints/reports.py` — POST `/api/v1/reports/sbom/parse` (filename + content)

### Frontend
- `pages/Reports.tsx` — 새 카드 'SBOM 파일 파싱' (filename 선택 + textarea + 결과 Table)
- 기존 SBOM 카드의 stub Alert 톤을 정직화

## Test plan
- [x] 4 ecosystem 실제 호출 → 패키지 정확 추출 (react · fastapi · gin · nginx 등)
- [x] /reports 페이지에 새 카드 노출
- [x] `ruff check .` 통과
- [ ] CI