### PR TITLE
feat: SBOM Diff on PR — GitHub PR 이벤트에 의존성 변경 자동 분석

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,10 @@ NOTIFY_MIN_SEVERITY=high
 # 보안팀 채널을 finding 알림과 분리하고 싶을 때.
 DIGEST_SLACK_WEBHOOK_URL=
 
+# GitHub API 토큰 (선택) — PR comment 작성 + 사설 repo의 의존성 파일 fetch.
+# 비우면 SBOM diff는 public repo만 동작하고 PR comment는 건너뜀.
+GITHUB_TOKEN=
+
 # ─── GitHub Webhook 검증 ─────────────────────────────
 # GitHub Webhook 설정 시 Secret과 동일하게 맞추세요.
 # 비어있으면 서명 검증 생략 (개발 편의)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [Unreleased]
 
 ### Added
+- **SBOM Diff on PR** — GitHub `pull_request` (opened / synchronize / reopened) webhook 이벤트에 변경된 의존성 파일을 감지해 before/after 파싱, 신규/제거/버전 변경을 정리. `GITHUB_TOKEN`이 설정되면 PR에 comment를 달고, FINDING purpose의 Slack 채널이 있으면 Slack에도 알림. 공개 repo는 토큰 없어도 raw fetch 가능.
 - **SBOM 실 의존성 추출** — `package.json` / `package-lock.json` / `requirements.txt` / `go.mod` / Dockerfile 5종 파서. 백엔드 `POST /api/v1/reports/sbom/parse` (filename + content → ecosystem 감지 + 패키지 리스트). Reports 페이지에 "SBOM 파일 파싱" 카드 추가 (붙여넣기 → 추출 → 테이블). 기존 finding 기반 lightweight SBOM은 유지하되 stub Alert 톤을 정직화.
 - **사용자별 Slack 알림 설정** — Security Settings의 "내 Slack 알림" 카드. 본인 DM webhook URL과 Slack user ID(@mention용)를 등록할 수 있고, 본인이 owner인 자산의 신규 finding 발생 시 organization 채널에 @mention + 본인 DM(설정 시) 발송. 별도 테이블 `user_slack_preferences`로 운영 중 환경에서도 schema migration 없이 자동 추가.
 - **Slack 연동 별도 페이지** — `/admin/slack` (Admin). 워크스페이스의 Incoming Webhook URL을 5종 purpose(`default` · `digest` · `finding` · `access_request` · `role_request`) 채널에 매핑하고, 카드별로 테스트 메시지 전송. DB에 저장된 채널이 ENV(`SLACK_WEBHOOK_URL` · `DIGEST_SLACK_WEBHOOK_URL`)보다 우선. `notifications` · `digest` 둘 다 `slack.resolve_webhook(purpose)`로 라우팅 일원화.

--- a/backend/app/api/v1/endpoints/webhooks.py
+++ b/backend/app/api/v1/endpoints/webhooks.py
@@ -26,8 +26,9 @@ from app.core.logging import get_logger
 from app.models.asset import Asset, AssetType
 from app.models.scan import ScanTrigger
 from app.models.user import Role
+from app.models.slack import SlackPurpose
 from app.models.webhook_token import WebhookToken
-from app.services import scan as scan_service
+from app.services import sbom_diff, scan as scan_service, slack as slack_service
 
 router = APIRouter()
 logger = get_logger(__name__)
@@ -65,6 +66,49 @@ async def github_webhook(
         raise HTTPException(status_code=401, detail="invalid signature")
 
     payload = await request.json()
+
+    # pull_request opened/synchronize → 의존성 diff + Slack + (선택) PR comment
+    if x_github_event == "pull_request":
+        action = payload.get("action")
+        if action not in ("opened", "synchronize", "reopened"):
+            return {"ignored": f"pull_request.{action}"}
+        pr = payload.get("pull_request") or {}
+        repo = payload.get("repository") or {}
+        full_name = repo.get("full_name") or ""
+        if "/" not in full_name:
+            return {"ignored": "missing repository full_name"}
+        owner, name = full_name.split("/", 1)
+        pr_number = pr.get("number")
+        base_sha = (pr.get("base") or {}).get("sha")
+        head_sha = (pr.get("head") or {}).get("sha")
+        if not (pr_number and base_sha and head_sha):
+            return {"ignored": "missing PR sha"}
+
+        diffs = await sbom_diff.diff_for_pr(owner, name, pr_number, base_sha, head_sha)
+        commented = False
+        if diffs:
+            commented = await sbom_diff.post_pr_comment(
+                owner, name, pr_number, sbom_diff.format_pr_comment(diffs)
+            )
+            # Slack 알림 (FINDING purpose)
+            slack_url = await slack_service.resolve_webhook(db, SlackPurpose.FINDING)
+            if slack_url:
+                import httpx
+
+                msg = sbom_diff.format_slack(owner, name, pr_number, diffs)
+                try:
+                    async with httpx.AsyncClient(timeout=10) as client:
+                        await client.post(slack_url, json=msg)
+                except Exception as exc:
+                    logger.warning("sbom_diff_slack_failed", error=str(exc))
+        return {
+            "kind": "pull_request",
+            "repository": full_name,
+            "pr": pr_number,
+            "diff_count": len(diffs),
+            "pr_comment_posted": commented,
+        }
+
     if x_github_event != "push":
         return {"ignored": x_github_event}
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -103,6 +103,9 @@ class Settings(BaseSettings):
 
     # 외부 통합 — GitHub Webhook 검증용 (없으면 검증 생략, 개발 편의)
     GITHUB_WEBHOOK_SECRET: Optional[str] = None
+    # GitHub API 토큰 — PR comment 작성 + 사설 repo raw fetch 시 사용 (선택).
+    # 없으면 SBOM diff는 public repo만 동작하고 PR comment는 skip.
+    GITHUB_TOKEN: Optional[str] = None
 
     # i18n 기본 언어 (UI 초기 로드 시 사용)
     DEFAULT_LOCALE: str = "ko"

--- a/backend/app/services/sbom_diff.py
+++ b/backend/app/services/sbom_diff.py
@@ -1,0 +1,191 @@
+"""
+PR diff에서 의존성 변경분 추출.
+
+흐름:
+  1. GitHub PR webhook payload에서 repo + base/head sha + 변경된 파일 받기
+  2. 변경된 파일 중 sbom_parser가 인식하는 ecosystem 파일만 필터
+  3. base/head 각각 raw content fetch → sbom_parser.parse
+  4. diff (added · removed · changed)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.services import sbom_parser
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class PackageDiff:
+    name: str
+    ecosystem: str
+    before: str | None
+    after: str | None
+
+    @property
+    def kind(self) -> str:
+        if self.before is None:
+            return "added"
+        if self.after is None:
+            return "removed"
+        return "changed"
+
+
+def diff_packages(
+    before: list[sbom_parser.Package],
+    after: list[sbom_parser.Package],
+) -> list[PackageDiff]:
+    """before/after 패키지 리스트를 (ecosystem, name) 키로 비교."""
+    key = lambda p: (p.ecosystem, p.name)  # noqa: E731
+    before_map = {key(p): p for p in before}
+    after_map = {key(p): p for p in after}
+
+    diffs: list[PackageDiff] = []
+    for k, p in after_map.items():
+        b = before_map.get(k)
+        if b is None:
+            diffs.append(PackageDiff(name=p.name, ecosystem=p.ecosystem, before=None, after=p.version))
+        elif (b.version or "") != (p.version or ""):
+            diffs.append(PackageDiff(name=p.name, ecosystem=p.ecosystem, before=b.version, after=p.version))
+    for k, p in before_map.items():
+        if k not in after_map:
+            diffs.append(PackageDiff(name=p.name, ecosystem=p.ecosystem, before=p.version, after=None))
+    return diffs
+
+
+async def _fetch_raw(client: httpx.AsyncClient, url: str, token: str | None) -> str | None:
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        r = await client.get(url, headers=headers, timeout=15, follow_redirects=True)
+        if r.status_code >= 400:
+            return None
+        return r.text
+    except Exception as exc:
+        logger.warning("github_fetch_failed", url=url, error=str(exc))
+        return None
+
+
+async def diff_for_pr(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    base_sha: str,
+    head_sha: str,
+) -> list[PackageDiff]:
+    """PR의 변경 파일을 GitHub API로 조회 후 의존성 파일만 diff."""
+    token = settings.GITHUB_TOKEN
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    async with httpx.AsyncClient(timeout=20, headers=headers) as client:
+        # PR의 변경 파일 (최대 100개)
+        files_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/files?per_page=100"
+        r = await client.get(files_url)
+        if r.status_code >= 400:
+            logger.warning("github_pr_files_failed", status=r.status_code, body=r.text[:200])
+            return []
+        files = r.json()
+
+        all_diffs: list[PackageDiff] = []
+        for f in files:
+            path = f.get("filename") or ""
+            if sbom_parser.detect_ecosystem(path) is None:
+                continue
+            before_raw = await _fetch_raw(
+                client, f"https://raw.githubusercontent.com/{owner}/{repo}/{base_sha}/{path}", token
+            )
+            after_raw = await _fetch_raw(
+                client, f"https://raw.githubusercontent.com/{owner}/{repo}/{head_sha}/{path}", token
+            )
+            before_pkgs = sbom_parser.parse(before_raw, path)[1] if before_raw else []
+            after_pkgs = sbom_parser.parse(after_raw, path)[1] if after_raw else []
+            all_diffs.extend(diff_packages(before_pkgs, after_pkgs))
+        return all_diffs
+
+
+def format_slack(owner: str, repo: str, pr_number: int, diffs: list[PackageDiff]) -> dict:
+    if not diffs:
+        return {"text": f"*Mond* — `{owner}/{repo}` PR #{pr_number} 의존성 변경 없음"}
+    added = [d for d in diffs if d.kind == "added"]
+    removed = [d for d in diffs if d.kind == "removed"]
+    changed = [d for d in diffs if d.kind == "changed"]
+
+    lines = [
+        f"*Mond* — `{owner}/{repo}` PR #{pr_number}",
+        f"의존성 변경: 신규 {len(added)} · 제거 {len(removed)} · 버전 변경 {len(changed)}",
+    ]
+    for d in added[:8]:
+        lines.append(f"➕ {d.ecosystem}: `{d.name}` @{d.after}")
+    if len(added) > 8:
+        lines.append(f"… 외 {len(added) - 8}건")
+    for d in changed[:8]:
+        lines.append(f"↗ {d.ecosystem}: `{d.name}` {d.before} → {d.after}")
+    if len(changed) > 8:
+        lines.append(f"… 외 {len(changed) - 8}건")
+    for d in removed[:8]:
+        lines.append(f"➖ {d.ecosystem}: `{d.name}`")
+    if len(removed) > 8:
+        lines.append(f"… 외 {len(removed) - 8}건")
+    return {"text": "\n".join(lines)}
+
+
+def format_pr_comment(diffs: list[PackageDiff]) -> str:
+    """GitHub PR comment markdown."""
+    if not diffs:
+        return "🌙 **Mond SBOM diff** — 의존성 변경 없음."
+    added = [d for d in diffs if d.kind == "added"]
+    removed = [d for d in diffs if d.kind == "removed"]
+    changed = [d for d in diffs if d.kind == "changed"]
+    parts = [
+        "🌙 **Mond SBOM diff**",
+        "",
+        f"- 신규 추가: **{len(added)}**",
+        f"- 제거: **{len(removed)}**",
+        f"- 버전 변경: **{len(changed)}**",
+    ]
+    if added:
+        parts += ["", "### Added", "| ecosystem | package | version |", "|---|---|---|"]
+        parts += [f"| {d.ecosystem} | `{d.name}` | {d.after} |" for d in added[:40]]
+    if changed:
+        parts += ["", "### Changed", "| ecosystem | package | before → after |", "|---|---|---|"]
+        parts += [f"| {d.ecosystem} | `{d.name}` | {d.before} → {d.after} |" for d in changed[:40]]
+    if removed:
+        parts += ["", "### Removed", "| ecosystem | package |", "|---|---|"]
+        parts += [f"| {d.ecosystem} | `{d.name}` |" for d in removed[:40]]
+    return "\n".join(parts)
+
+
+async def post_pr_comment(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    body: str,
+) -> bool:
+    """선택적 — GITHUB_TOKEN이 있으면 PR에 comment 작성."""
+    token = settings.GITHUB_TOKEN
+    if not token:
+        return False
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=15, headers=headers) as client:
+            r = await client.post(url, json={"body": body})
+            if r.status_code >= 400:
+                logger.warning("github_pr_comment_failed", status=r.status_code, body=r.text[:200])
+                return False
+            return True
+    except Exception as exc:
+        logger.warning("github_pr_comment_exception", error=str(exc))
+        return False

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -684,22 +684,27 @@ spec:
 
 **미리보기 (Reviewer+):** `GET /api/v1/admin/digest/preview` — 전송 없이 집계와 Slack 메시지 포맷 확인.
 
-### 8) GitHub Webhook 자동 스캔 (선택)
-
-push마다 자동 스캔하려면:
+### 8) GitHub Webhook 자동 스캔 + SBOM Diff on PR (선택)
 
 ```bash
 GITHUB_WEBHOOK_SECRET=<random-secret>
 # python -c 'import secrets;print(secrets.token_urlsafe(32))'
+
+# PR에 SBOM diff comment를 달려면 추가 (선택):
+GITHUB_TOKEN=ghp_xxxx   # PR comment 작성 권한 PAT 또는 App token
 ```
 
 GitHub repo Settings → Webhooks:
 - **Payload URL**: `https://mond.your-corp.com/api/v1/webhooks/github`
 - **Content type**: `application/json`
 - **Secret**: 위 secret과 동일
-- **Events**: `push` (선택) + `pull_request` (권장)
+- **Events**: `push` + `pull_request` 둘 다 체크
 
-**Skip 옵션 옵션**: 수동 스캔 화면에서 충분하면 webhook 없이도 OK.
+#### 동작
+- `push` 이벤트 — 매칭 자산이 있으면 Trivy 스캔 자동 트리거
+- `pull_request` (opened / synchronize / reopened) — 변경된 의존성 파일(`package.json` / `package-lock.json` / `requirements.txt` / `go.mod` / `Dockerfile`)에서 before/after를 파싱해 **신규 / 제거 / 버전 변경**을 추출. `GITHUB_TOKEN`이 있으면 PR에 comment를 달고, FINDING purpose의 Slack 채널이 설정되어 있으면 Slack에도 알림.
+
+**Skip 옵션**: 수동 스캔으로 충분하면 webhook 없이도 OK.
 
 ### 9) 데모 시드 끄기
 


### PR DESCRIPTION
## Summary
v0.2 로드맵 "Webhook push 이벤트 → diff 분석" 항목의 의존성 측 구현. PR마다 신규/제거/버전 변경을 정리해서 PR comment + Slack로.

### Backend
- `services/sbom_diff.py` — `diff_packages` · `diff_for_pr` (GitHub API + raw fetch) · `format_slack` · `format_pr_comment` · `post_pr_comment`
- `endpoints/webhooks.py` — `pull_request` 이벤트 처리 (opened / synchronize / reopened)
- `config.GITHUB_TOKEN` 추가 (선택) — PR comment + 사설 repo fetch

### 문서
- `.env.example` GITHUB_TOKEN
- `docs/SETUP.md` Part 5 8) pull_request 동작 안내
- CHANGELOG Added

## Test plan
- [x] diff_packages 단위 동작 (added/changed/removed)
- [x] PR comment markdown 형식 검증
- [x] ruff check . 통과
- [ ] CI
- 실 GitHub PR 호출은 OSS 사용자가 자기 repo로 셋업 후 검증 (데모 환경에서 호출 불가)