### PR TITLE
feat: Celery 비동기 스캔 큐 (SCAN_QUEUE_ENABLED 토글)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,13 @@ DATABASE_URL=postgresql+asyncpg://mond:mond@localhost:5432/mond
 # ─── Redis (Celery broker + 캐시) ──────────────────────
 REDIS_URL=redis://localhost:6379/0
 
+# ─── 스캔 큐 (Celery) — 운영 안정성 옵션 ─────────────
+# true면 인라인 동기 실행 대신 worker가 비동기 처리. 별도 worker 컨테이너 필요.
+SCAN_QUEUE_ENABLED=false
+# REDIS_URL을 기본 사용. 분리하려면 명시.
+CELERY_BROKER_URL=
+CELERY_RESULT_BACKEND=
+
 # ─── CORS ───────────────────────────────────────────
 ALLOWED_ORIGINS=["http://localhost:3000","http://localhost:5173"]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [Unreleased]
 
 ### Added
+- **Celery 비동기 스캔 큐** — `SCAN_QUEUE_ENABLED=true`로 켜면 인라인 동기 실행 대신 PENDING Scan 생성 + Celery 큐에 enqueue. 별도 worker(`mond.run_scan` task)가 비동기 실행하고 결과를 DB 업데이트. 대용량/장시간 스캔에서 backend 타임아웃 회피. 기본은 인라인(false)이라 OSS 첫 설치 영향 없음. `docker-compose.yml`에 `worker` 서비스 추가, Helm/Compose 모두 동일 패턴.
 - **SBOM Diff on PR** — GitHub `pull_request` (opened / synchronize / reopened) webhook 이벤트에 변경된 의존성 파일을 감지해 before/after 파싱, 신규/제거/버전 변경을 정리. `GITHUB_TOKEN`이 설정되면 PR에 comment를 달고, FINDING purpose의 Slack 채널이 있으면 Slack에도 알림. 공개 repo는 토큰 없어도 raw fetch 가능.
 - **SBOM 실 의존성 추출** — `package.json` / `package-lock.json` / `requirements.txt` / `go.mod` / Dockerfile 5종 파서. 백엔드 `POST /api/v1/reports/sbom/parse` (filename + content → ecosystem 감지 + 패키지 리스트). Reports 페이지에 "SBOM 파일 파싱" 카드 추가 (붙여넣기 → 추출 → 테이블). 기존 finding 기반 lightweight SBOM은 유지하되 stub Alert 톤을 정직화.
 - **사용자별 Slack 알림 설정** — Security Settings의 "내 Slack 알림" 카드. 본인 DM webhook URL과 Slack user ID(@mention용)를 등록할 수 있고, 본인이 owner인 자산의 신규 finding 발생 시 organization 채널에 @mention + 본인 DM(설정 시) 발송. 별도 테이블 `user_slack_preferences`로 운영 중 환경에서도 schema migration 없이 자동 추가.

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -1,0 +1,32 @@
+"""
+Celery 앱 — 스캔 큐.
+
+OSS 기본은 인라인 실행 (SCAN_QUEUE_ENABLED=false).
+운영에서 대용량/장시간 스캔의 타임아웃을 피하려면 true로 설정하고
+별도 worker 프로세스를 띄운다.
+
+docker compose:
+  - SCAN_QUEUE_ENABLED=true 로 backend env 갱신
+  - worker 서비스 추가 (entrypoint: celery worker)
+"""
+
+from __future__ import annotations
+
+from celery import Celery
+
+from app.core.config import settings
+
+celery_app = Celery(
+    "mond",
+    broker=settings.CELERY_BROKER_URL or settings.REDIS_URL,
+    backend=settings.CELERY_RESULT_BACKEND or settings.REDIS_URL,
+)
+celery_app.conf.update(
+    task_acks_late=True,
+    worker_prefetch_multiplier=1,
+    task_default_queue="mond_scans",
+    task_track_started=True,
+)
+
+# task 정의 모듈을 명시적으로 import해야 worker가 task를 인식.
+celery_app.autodiscover_tasks(["app.tasks"], force=True)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -51,6 +51,13 @@ class Settings(BaseSettings):
     # Redis (Celery broker + 캐시)
     REDIS_URL: str = "redis://localhost:6379/0"
 
+    # 스캔 큐 (Celery) — 기본 false. 인라인 동기 실행.
+    # 운영에서 대용량/장시간 스캔의 backend 타임아웃을 피하려면 true + 별도 worker.
+    SCAN_QUEUE_ENABLED: bool = False
+    # broker/result backend는 REDIS_URL을 기본 사용. 분리하려면 ENV로 override.
+    CELERY_BROKER_URL: Optional[str] = None
+    CELERY_RESULT_BACKEND: Optional[str] = None
+
     # CORS
     ALLOWED_ORIGINS: List[str] = ["http://localhost:3000", "http://localhost:5173"]
 

--- a/backend/app/services/scan.py
+++ b/backend/app/services/scan.py
@@ -10,6 +10,8 @@ from datetime import datetime, timezone
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
+from app.core.database import AsyncSessionLocal
 from app.core.logging import get_logger
 from app.models.asset import Asset
 from app.models.finding import Severity
@@ -47,10 +49,11 @@ async def trigger_scan(
     scanner_name: str,
     trigger: ScanTrigger = ScanTrigger.MANUAL,
 ) -> Scan:
-    """스캔을 동기적으로 실행한다.
+    """스캔을 시작한다.
 
-    OSS MVP는 작은 환경을 가정하므로 인라인 실행으로 충분하다.
-    프로덕션에서는 Celery로 옮기는 게 자연스럽다.
+    기본은 인라인 동기 실행 — 빠르게 끝나는 단일 자산 스캔에 적합.
+    `SCAN_QUEUE_ENABLED=true`면 PENDING 상태로 Scan만 만들고 Celery 큐에 enqueue,
+    worker가 비동기로 실행. 운영의 대용량/장시간 스캔에서 backend 타임아웃 회피.
     """
     adapter = get_scanner(scanner_name)
     if adapter is None:
@@ -81,6 +84,24 @@ async def trigger_scan(
         await db.refresh(scan)
         return scan
 
+    # Celery 모드 — PENDING으로 생성하고 worker에 위임.
+    if settings.SCAN_QUEUE_ENABLED:
+        scan = Scan(
+            asset_id=asset.id,
+            scanner=scanner_name,
+            trigger=trigger,
+            status=ScanStatus.PENDING,
+        )
+        db.add(scan)
+        await db.commit()
+        await db.refresh(scan)
+        # task import는 여기서만 — celery_app이 backend 부팅 시 매번 로드되지 않도록.
+        from app.tasks.scan_tasks import run_scan as run_scan_task
+
+        run_scan_task.delay(scan.id)
+        return scan
+
+    # 인라인 모드 — 그대로 실행.
     scan = Scan(
         asset_id=asset.id,
         scanner=scanner_name,
@@ -149,3 +170,93 @@ async def trigger_scan(
             logger.warning("notify_failed", finding_id=f.id, error=str(exc))
 
     return scan
+
+
+async def execute_pending_scan(scan_id: int) -> dict:
+    """worker entrypoint — PENDING Scan 하나를 받아 실제 스캔을 끝까지 진행.
+
+    호출 측에서 새 DB session을 열어 사용한다 (각 task는 독립).
+    반환은 task 결과로 쓸 요약 dict (Celery task가 그대로 반환).
+    """
+    async with AsyncSessionLocal() as db:
+        scan = (await db.execute(select(Scan).where(Scan.id == scan_id))).scalar_one_or_none()
+        if scan is None:
+            return {"scan_id": scan_id, "status": "not_found"}
+        asset = (await db.execute(select(Asset).where(Asset.id == scan.asset_id))).scalar_one_or_none()
+        if asset is None:
+            scan.status = ScanStatus.FAILED
+            scan.error_message = "asset not found"
+            await db.commit()
+            return {"scan_id": scan_id, "status": "failed", "error": "asset not found"}
+
+        adapter = get_scanner(scan.scanner)
+        if adapter is None:
+            scan.status = ScanStatus.FAILED
+            scan.error_message = f"Unknown scanner: {scan.scanner}"
+            await db.commit()
+            return {"scan_id": scan_id, "status": "failed", "error": scan.error_message}
+
+        scan.status = ScanStatus.RUNNING
+        scan.started_at = datetime.now(timezone.utc)
+        await db.commit()
+        await db.refresh(scan)
+
+        start = time.monotonic()
+        try:
+            result = await adapter.scan(asset)
+        except Exception as exc:
+            logger.exception("scanner_unexpected_error", scanner=scan.scanner, asset_id=asset.id)
+            scan.status = ScanStatus.FAILED
+            scan.error_message = str(exc)
+            scan.finished_at = datetime.now(timezone.utc)
+            scan.duration_ms = int((time.monotonic() - start) * 1000)
+            await db.commit()
+            return {"scan_id": scan_id, "status": "failed", "error": str(exc)}
+
+        saved = 0
+        created_findings = []
+        for raw in result.findings:
+            try:
+                severity = Severity(raw.severity.lower())
+            except ValueError:
+                severity = Severity.INFO
+            finding = await finding_service.upsert_finding(
+                db,
+                asset_id=asset.id,
+                scan_id=scan.id,
+                scanner=scan.scanner,
+                rule_id=raw.rule_id,
+                title=raw.title,
+                severity=severity,
+                description=raw.description,
+                location=raw.location,
+                references=raw.references,
+                extra=raw.extra,
+            )
+            created_findings.append(finding)
+            saved += 1
+
+        scan.finished_at = datetime.now(timezone.utc)
+        scan.duration_ms = int((time.monotonic() - start) * 1000)
+        scan.findings_count = saved
+        scan.raw_output = result.raw_output
+        scan.status = ScanStatus.FAILED if result.error else ScanStatus.COMPLETED
+        if result.error:
+            scan.error_message = result.error
+        await db.commit()
+
+        asset.last_scanned_at_str = scan.finished_at.isoformat() if scan.finished_at else None
+        await asset_service.refresh_open_findings_count(db, asset.id)
+
+        for f in created_findings:
+            try:
+                await notify.notify_finding(f)
+            except Exception as exc:
+                logger.warning("notify_failed", finding_id=f.id, error=str(exc))
+
+        return {
+            "scan_id": scan_id,
+            "status": scan.status.value,
+            "findings": saved,
+            "duration_ms": scan.duration_ms,
+        }

--- a/backend/app/tasks/__init__.py
+++ b/backend/app/tasks/__init__.py
@@ -1,0 +1,1 @@
+from app.tasks import scan_tasks  # noqa: F401

--- a/backend/app/tasks/scan_tasks.py
+++ b/backend/app/tasks/scan_tasks.py
@@ -1,0 +1,26 @@
+"""
+Celery 스캔 태스크 — async 코어를 sync wrapper로 감싸 실행.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from app.celery_app import celery_app
+from app.core.logging import get_logger
+from app.services import scan as scan_service
+
+logger = get_logger(__name__)
+
+
+@celery_app.task(name="mond.run_scan", bind=True, max_retries=2)
+def run_scan(self, scan_id: int) -> dict:
+    """worker가 호출하는 entrypoint.
+
+    pending Scan 객체를 받아서 스캐너 실행 + Finding 저장 + 알림까지.
+    """
+    try:
+        return asyncio.run(scan_service.execute_pending_scan(scan_id))
+    except Exception as exc:
+        logger.exception("celery_scan_failed", scan_id=scan_id)
+        raise self.retry(exc=exc, countdown=30)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       GITHUB_WEBHOOK_SECRET: ${GITHUB_WEBHOOK_SECRET:-}
       DEFAULT_LOCALE: ${DEFAULT_LOCALE:-ko}
       MCP_HTTP_ENABLED: ${MCP_HTTP_ENABLED:-false}
+      SCAN_QUEUE_ENABLED: ${SCAN_QUEUE_ENABLED:-false}
       AUTH_MODE: ${AUTH_MODE:-dev}
       SSO_PROVIDERS: ${SSO_PROVIDERS:-}
       SSO_KEYCLOAK_ISSUER: ${SSO_KEYCLOAK_ISSUER:-}
@@ -84,6 +85,33 @@ services:
         condition: service_healthy
     networks: [mond-network]
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+    volumes:
+      - ./backend:/app
+    restart: unless-stopped
+
+  # Celery worker — SCAN_QUEUE_ENABLED=true 일 때만 의미 있음.
+  # 기본 인라인 모드에서는 컨테이너가 idle하게 떠있을 뿐 영향 없음.
+  worker:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: mond-worker
+    environment:
+      DATABASE_URL: postgresql+asyncpg://mond:mond@postgres:5432/mond
+      REDIS_URL: redis://redis:6379/0
+      SECRET_KEY: ${SECRET_KEY:-development-secret-change-me}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      SCAN_QUEUE_ENABLED: ${SCAN_QUEUE_ENABLED:-false}
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:-}
+      GENERIC_WEBHOOK_URL: ${GENERIC_WEBHOOK_URL:-}
+      NOTIFY_MIN_SEVERITY: ${NOTIFY_MIN_SEVERITY:-high}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks: [mond-network]
+    command: celery -A app.celery_app:celery_app worker --loglevel=info --concurrency=2
     volumes:
       - ./backend:/app
     restart: unless-stopped

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -706,6 +706,28 @@ GitHub repo Settings → Webhooks:
 
 **Skip 옵션**: 수동 스캔으로 충분하면 webhook 없이도 OK.
 
+### 8-1) 스캔 큐 (Celery) — 운영 안정성
+
+기본은 인라인 동기 실행. 대용량/장시간 스캔에서 backend 타임아웃이 문제라면 비동기 큐로 전환.
+
+```bash
+# .env 또는 compose env
+SCAN_QUEUE_ENABLED=true
+# broker는 REDIS_URL을 기본 사용. 분리하려면:
+# CELERY_BROKER_URL=redis://redis:6379/1
+```
+
+docker compose:
+```bash
+docker compose up -d backend worker
+# worker 로그
+docker compose logs -f worker
+```
+
+scan 트리거 시 backend가 즉시 `PENDING` Scan을 반환하고, worker가 `mond.run_scan` task로 실제 스캐너를 실행합니다. 결과는 DB에 기록되고 UI는 status를 폴링.
+
+운영 (Helm) — 별도 Deployment로 worker를 띄우고 `replicaCount`로 동시 처리량 조절. concurrency는 `command: celery -A app.celery_app:celery_app worker --concurrency=N`로 worker 인스턴스 안에서 조절.
+
 ### 9) 데모 시드 끄기
 
 ```bash


### PR DESCRIPTION
v0.2 로드맵 "비동기 스캔 큐 (Celery)" 항목. 인라인 유지 + ENV opt-in 큐 모드. backend·tasks·docker-compose worker 서비스·문서 일괄.