### PR TITLE
feat(ai): RAG에 Asset 소스 추가 + 4 소스 인용

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [Unreleased]
 
 ### Added
+- **AI Insights RAG에 Asset 소스 추가** — 자연어 질의 시 RAG가 Asset(이름·URI·설명)도 함께 검색. "우리 nginx 자산" 같은 질문에 자산을 직접 짚어주고, citations에 kind=`asset`(녹색 chip)으로 노출. open_findings 수로 가중 정렬. 기존 Finding · Policy · Knowledge에 더해 4 소스 RAG.
 - **Celery 비동기 스캔 큐** — `SCAN_QUEUE_ENABLED=true`로 켜면 인라인 동기 실행 대신 PENDING Scan 생성 + Celery 큐에 enqueue. 별도 worker(`mond.run_scan` task)가 비동기 실행하고 결과를 DB 업데이트. 대용량/장시간 스캔에서 backend 타임아웃 회피. 기본은 인라인(false)이라 OSS 첫 설치 영향 없음. `docker-compose.yml`에 `worker` 서비스 추가, Helm/Compose 모두 동일 패턴.
 - **SBOM Diff on PR** — GitHub `pull_request` (opened / synchronize / reopened) webhook 이벤트에 변경된 의존성 파일을 감지해 before/after 파싱, 신규/제거/버전 변경을 정리. `GITHUB_TOKEN`이 설정되면 PR에 comment를 달고, FINDING purpose의 Slack 채널이 있으면 Slack에도 알림. 공개 repo는 토큰 없어도 raw fetch 가능.
 - **SBOM 실 의존성 추출** — `package.json` / `package-lock.json` / `requirements.txt` / `go.mod` / Dockerfile 5종 파서. 백엔드 `POST /api/v1/reports/sbom/parse` (filename + content → ecosystem 감지 + 패키지 리스트). Reports 페이지에 "SBOM 파일 파싱" 카드 추가 (붙여넣기 → 추출 → 테이블). 기존 finding 기반 lightweight SBOM은 유지하되 stub Alert 톤을 정직화.

--- a/backend/app/ai/rag.py
+++ b/backend/app/ai/rag.py
@@ -2,12 +2,12 @@
 RAG MVP — Mond 데이터를 검색해 LLM에 context로 주입
 
 검색 대상 (모두 사용자가 등록·시드한 자체 데이터):
+  - Asset     : 이름·URI·설명 매칭 + open_findings 가중
   - Finding   : 최근 미해결 finding (severity 가중)
   - Policy    : 활성 정책
   - Knowledge : 카드 (title / summary 매칭)
-  - Regulation: 시나리오/규제 가이드 (정적 데이터)
 
-알고리즘 — MVP는 PostgreSQL ILIKE 매칭 (벡터 임베딩은 v0.2).
+알고리즘 — PostgreSQL ILIKE 매칭. 벡터 임베딩(pgvector / 외부 모델)은 v0.3.
 한국어 토큰화는 simple split (정확도보다 invariant).
 각 결과를 `[N]` 번호로 인용해 LLM에 넘기고, frontend가 카드로 출처 노출.
 """
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.asset import Asset
 from app.models.finding import Finding, FindingStatus, Severity
 from app.models.knowledge import KnowledgeCard
 from app.models.policy import Policy
@@ -53,7 +54,35 @@ async def search(db: AsyncSession, query: str, *, limit_per_source: int = 3) -> 
     citations: list[Citation] = []
     n = 1
 
-    # 1) Finding — title/description 매칭 + 미해결 우선
+    # 1) Asset — 이름/URI/설명 매칭. "우리 nginx 자산" 같은 질문 시 자산을 짚어준다.
+    a_conditions = [
+        Asset.name.ilike(f"%{t}%")
+        | Asset.uri.ilike(f"%{t}%")
+        | Asset.description.ilike(f"%{t}%")
+        for t in toks
+    ]
+    a_stmt = (
+        select(Asset)
+        .where(or_(*a_conditions))
+        .order_by(Asset.open_findings_count.desc().nullslast(), Asset.id.desc())
+        .limit(limit_per_source)
+    )
+    for a in (await db.execute(a_stmt)).scalars().all():
+        bits = [a.asset_type.value]
+        if a.environment:
+            bits.append(a.environment)
+        if a.open_findings_count:
+            bits.append(f"미해결 {a.open_findings_count}")
+        snippet = (a.description or " · ".join(bits))[:120]
+        citations.append(Citation(
+            n=n, kind="asset",
+            title=a.name,
+            snippet=snippet,
+            url=f"/assets?focus={a.id}",
+        ))
+        n += 1
+
+    # 2) Finding — title/description 매칭 + 미해결 우선
     f_conditions = [Finding.title.ilike(f"%{t}%") | Finding.description.ilike(f"%{t}%") for t in toks]
     f_stmt = (
         select(Finding)

--- a/frontend/src/pages/AIInsights.tsx
+++ b/frontend/src/pages/AIInsights.tsx
@@ -16,7 +16,7 @@ const { TextArea } = Input;
 
 interface Citation {
   n: number;
-  kind: "finding" | "policy" | "knowledge" | string;
+  kind: "asset" | "finding" | "policy" | "knowledge" | string;
   title: string;
   snippet: string;
   url?: string | null;
@@ -31,6 +31,7 @@ interface AnalyzeResponse {
 }
 
 const KIND_COLOR: Record<string, string> = {
+  asset: "green",
   finding: "red",
   policy: "purple",
   knowledge: "blue",


### PR DESCRIPTION
## Summary
기존 RAG가 Finding · Policy · Knowledge 3소스만 검색해 "우리 nginx 자산" 같은 질문에 자산을 짚지 못했음. Asset(name · uri · description) 검색을 추가.

### Backend
- `ai/rag.py` — Asset 검색 분기 (open_findings_count 가중 정렬). citation kind=`asset`.

### Frontend
- `AIInsights.tsx` — Citation kind `asset` 인식, 녹색 chip.

### 문서
- CHANGELOG Added

## Note
벡터 임베딩(pgvector / 외부 embedding API)은 v0.3 backlog. 현재는 PostgreSQL ILIKE — 한국어 토큰 매칭에 충분.

## Test plan
- [x] rag.search() 함수 직접 호출 → critical 키워드 1 citation
- [x] ruff check . 통과
- [x] frontend rebuild + /ai-insights 200
- [ ] CI