### PR TITLE
feat(ci): GitHub Actions composite action — 한 줄 Mond 스캔 통합

### DIFF
--- a/.github/actions/mond-scan/action.yml
+++ b/.github/actions/mond-scan/action.yml
@@ -1,0 +1,83 @@
+name: Mond Scan
+description: Trigger a Mond security scan on a registered asset using a personal webhook token.
+author: jland-93
+
+inputs:
+  mond_host:
+    description: Mond 인스턴스 호스트 (예 mond.your-corp.com). 스킴은 자동으로 https://를 붙입니다.
+    required: true
+  webhook_token:
+    description: Mond에서 발급한 webhook token (mond_xxx로 시작). repository secret 사용 권장.
+    required: true
+  asset_id:
+    description: 스캔 대상 자산 ID (Mond UI의 Assets 페이지에서 확인).
+    required: true
+  scanner:
+    description: trivy | semgrep | nuclei. 자산 타입과 매칭되는 스캐너여야 함.
+    required: false
+    default: trivy
+  fail_on_error:
+    description: backend가 오류를 반환할 때 step을 실패시킬지. false면 step은 통과하고 로그만 남김.
+    required: false
+    default: "true"
+
+outputs:
+  scan_id:
+    description: 생성된 Scan의 ID.
+    value: ${{ steps.trigger.outputs.scan_id }}
+  status:
+    description: PENDING / RUNNING / COMPLETED / FAILED 중 하나.
+    value: ${{ steps.trigger.outputs.status }}
+
+runs:
+  using: composite
+  steps:
+    - name: Trigger Mond scan
+      id: trigger
+      shell: bash
+      env:
+        MOND_HOST: ${{ inputs.mond_host }}
+        MOND_TOKEN: ${{ inputs.webhook_token }}
+        ASSET_ID: ${{ inputs.asset_id }}
+        SCANNER: ${{ inputs.scanner }}
+        FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
+      run: |
+        set -u
+        if [ -z "$MOND_TOKEN" ] || [ -z "$MOND_HOST" ] || [ -z "$ASSET_ID" ]; then
+          echo "::error::mond_host · webhook_token · asset_id 필수"
+          exit 1
+        fi
+
+        url="https://${MOND_HOST}/api/v1/webhooks/personal"
+        body=$(printf '{"asset_id":%s,"scanner":"%s"}' "$ASSET_ID" "$SCANNER")
+
+        response=$(curl -sS -w "\n%{http_code}" -X POST "$url" \
+          -H "Authorization: Bearer $MOND_TOKEN" \
+          -H "Content-Type: application/json" \
+          -d "$body")
+        http_code=$(echo "$response" | tail -n1)
+        body_json=$(echo "$response" | sed '$d')
+
+        echo "Mond response ($http_code):"
+        echo "$body_json"
+
+        if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+          if [ "$FAIL_ON_ERROR" = "true" ]; then
+            echo "::error::Mond returned $http_code"
+            exit 1
+          else
+            echo "::warning::Mond returned $http_code — continuing (fail_on_error=false)"
+            exit 0
+          fi
+        fi
+
+        # JSON에서 scan_id · status 추출 — jq가 없을 수 있어 sed/grep 조합.
+        scan_id=$(echo "$body_json" | sed -n 's/.*"scan_id":[[:space:]]*\([0-9]*\).*/\1/p' | head -n1)
+        status=$(echo "$body_json" | sed -n 's/.*"status":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
+        echo "scan_id=${scan_id}" >> "$GITHUB_OUTPUT"
+        echo "status=${status}" >> "$GITHUB_OUTPUT"
+        echo "Mond scan #${scan_id} status=${status}"
+
+branding:
+  icon: shield
+  color: blue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [Unreleased]
 
 ### Added
+- **GitHub Actions composite action** — `.github/actions/mond-scan/action.yml`. 사용자 repo의 workflow에서 `uses: jland-93/mond/.github/actions/mond-scan@main` 한 줄로 Mond 스캔 트리거. 입력: `mond_host` · `webhook_token` · `asset_id` · `scanner`. 출력: `scan_id` · `status`. backend의 기존 `POST /api/v1/webhooks/personal` 사용. README에 사용 예시 추가.
 - **AI Insights RAG에 Asset 소스 추가** — 자연어 질의 시 RAG가 Asset(이름·URI·설명)도 함께 검색. "우리 nginx 자산" 같은 질문에 자산을 직접 짚어주고, citations에 kind=`asset`(녹색 chip)으로 노출. open_findings 수로 가중 정렬. 기존 Finding · Policy · Knowledge에 더해 4 소스 RAG.
 - **Celery 비동기 스캔 큐** — `SCAN_QUEUE_ENABLED=true`로 켜면 인라인 동기 실행 대신 PENDING Scan 생성 + Celery 큐에 enqueue. 별도 worker(`mond.run_scan` task)가 비동기 실행하고 결과를 DB 업데이트. 대용량/장시간 스캔에서 backend 타임아웃 회피. 기본은 인라인(false)이라 OSS 첫 설치 영향 없음. `docker-compose.yml`에 `worker` 서비스 추가, Helm/Compose 모두 동일 패턴.
 - **SBOM Diff on PR** — GitHub `pull_request` (opened / synchronize / reopened) webhook 이벤트에 변경된 의존성 파일을 감지해 before/after 파싱, 신규/제거/버전 변경을 정리. `GITHUB_TOKEN`이 설정되면 PR에 comment를 달고, FINDING purpose의 Slack 채널이 있으면 Slack에도 알림. 공개 repo는 토큰 없어도 raw fetch 가능.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,22 @@ helm install mond oci://ghcr.io/jland-93/charts/mond \
 
 > 🛠️ SSO · MFA · AI provider 전환 · 관리자 초기 세팅 → **[docs/SETUP.md](docs/SETUP.md)**
 
+### 🤖 GitHub Actions — 한 줄 통합
+
+CI/CD에서 push 또는 PR마다 Mond 스캔을 자동 트리거. Security Settings에서 webhook 토큰 발급 → repo secrets에 등록 → workflow에 다음 step 한 줄.
+
+```yaml
+- name: Mond scan
+  uses: jland-93/mond/.github/actions/mond-scan@main
+  with:
+    mond_host: mond.your-corp.com
+    webhook_token: ${{ secrets.MOND_WEBHOOK_TOKEN }}
+    asset_id: 42          # Mond UI Assets 페이지에서 ID 확인
+    scanner: trivy        # trivy | semgrep | nuclei
+```
+
+자동 생성된 YAML은 Mond `Security Settings → Personal Webhook Tokens → CI 스니펫 생성`에서도 받을 수 있습니다.
+
 ---
 
 ## 📋 Overview


### PR DESCRIPTION
## Summary
v0.2 로드맵 "CI 통합 패키지" 항목. `.github/actions/mond-scan/action.yml` 하나로 사용자 repo workflow에서 한 줄 통합.

```yaml
- name: Mond scan
  uses: jland-93/mond/.github/actions/mond-scan@main
  with:
    mond_host: mond.your-corp.com
    webhook_token: ${{ secrets.MOND_WEBHOOK_TOKEN }}
    asset_id: 42
    scanner: trivy
```

### inputs / outputs
- inputs: `mond_host` · `webhook_token` · `asset_id` · `scanner` · `fail_on_error`
- outputs: `scan_id` · `status`

### 동작
- curl로 `POST /api/v1/webhooks/personal` 호출 (backend 변경 없음)
- jq 없는 runner도 동작 (sed 응답 파싱)
- HTTP non-2xx → `fail_on_error=true` 기본이면 step 실패

### 문서
- README: 'GitHub Actions — 한 줄 통합' 섹션
- CHANGELOG: Added

## Test plan
- [x] action.yml syntax 정상 (composite + branding)
- [ ] CI Backend / Frontend / CodeQL 통과
- 실 호출은 OSS 사용자가 자기 repo에 추가 후 확인