### PR TITLE
feat(integrations): GitHub org 자산 자동 동기화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [Unreleased]
 
 ### Added
+- **GitHub org 자산 자동 동기화** — Admin → Connections에 "GitHub Org Asset Sync" 카드. org 또는 user 이름 입력 → 미리보기/동기화 버튼으로 해당 org의 모든 repo를 `https://github.com/{owner}/{repo}` URI의 REPOSITORY 자산으로 일괄 등록. 동일 URI는 라벨(language/private/archived/default_branch)만 갱신하고 사용자가 수정한 owner/environment는 보존. `GITHUB_TOKEN` 있으면 private repo 포함 + rate limit 5000/h, 없으면 public 60/h. `GITHUB_ORG` 환경변수로 기본값 채울 수 있음. 백엔드 `POST /api/v1/admin/github-sync/run` 신설(Admin 전용).
 - **GitHub Actions composite action** — `.github/actions/mond-scan/action.yml`. 사용자 repo의 workflow에서 `uses: jland-93/mond/.github/actions/mond-scan@main` 한 줄로 Mond 스캔 트리거. 입력: `mond_host` · `webhook_token` · `asset_id` · `scanner`. 출력: `scan_id` · `status`. backend의 기존 `POST /api/v1/webhooks/personal` 사용. README에 사용 예시 추가.
 - **AI Insights RAG에 Asset 소스 추가** — 자연어 질의 시 RAG가 Asset(이름·URI·설명)도 함께 검색. "우리 nginx 자산" 같은 질문에 자산을 직접 짚어주고, citations에 kind=`asset`(녹색 chip)으로 노출. open_findings 수로 가중 정렬. 기존 Finding · Policy · Knowledge에 더해 4 소스 RAG.
 - **Celery 비동기 스캔 큐** — `SCAN_QUEUE_ENABLED=true`로 켜면 인라인 동기 실행 대신 PENDING Scan 생성 + Celery 큐에 enqueue. 별도 worker(`mond.run_scan` task)가 비동기 실행하고 결과를 DB 업데이트. 대용량/장시간 스캔에서 backend 타임아웃 회피. 기본은 인라인(false)이라 OSS 첫 설치 영향 없음. `docker-compose.yml`에 `worker` 서비스 추가, Helm/Compose 모두 동일 패턴.

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ class MyAdapter(ScannerAdapter):
 - [ ] AI Insights RAG — 조직 문서/정책을 검색해 응답 근거화
 - [ ] 비동기 스캔 큐 (Celery) — 인라인 실행 대체
 - [ ] OPA Rego 정책 평가
-- [ ] 자산 자동 동기화 (Kubernetes / AWS Auto-scaling / GitHub org)
+- [x] 자산 자동 동기화 — GitHub org (Kubernetes / AWS Auto-scaling는 v0.3)
 - [ ] Webhook push 이벤트 → diff 분석 후 적절한 스캐너 선택
 - [ ] CI 통합 패키지 (GitHub Actions / GitLab CI step)
 - [ ] Rate limiting / abuse protection

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -5,6 +5,7 @@ API v1 라우터
 from fastapi import APIRouter
 
 from app.api.v1.endpoints import (
+    admin_github_sync,
     admin_slack,
     ai,
     ai_providers,
@@ -49,6 +50,7 @@ api_router.include_router(reports.router, prefix="/reports", tags=["Reports"])
 api_router.include_router(ai.router, prefix="/ai", tags=["AI"])
 api_router.include_router(ai_providers.router, prefix="/admin/ai-providers", tags=["AI Providers (Admin)"])
 api_router.include_router(admin_slack.router, prefix="/admin/slack", tags=["Slack Channels (Admin)"])
+api_router.include_router(admin_github_sync.router, prefix="/admin/github-sync", tags=["GitHub Sync (Admin)"])
 api_router.include_router(digest.router, prefix="/admin/digest", tags=["Daily Digest (Admin)"])
 api_router.include_router(integrations.router, prefix="/integrations", tags=["Integrations"])
 api_router.include_router(webhooks.router, prefix="/webhooks", tags=["Webhooks"])

--- a/backend/app/api/v1/endpoints/admin_github_sync.py
+++ b/backend/app/api/v1/endpoints/admin_github_sync.py
@@ -1,0 +1,44 @@
+"""GitHub org → Asset 자동 동기화 — Admin 전용."""
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.deps import require_role
+from app.core.config import settings
+from app.core.database import get_db
+from app.models.user import Role
+from app.services import github_sync
+
+router = APIRouter(dependencies=[Depends(require_role(Role.ADMIN))])
+
+
+@router.get("/status")
+async def status() -> dict:
+    return github_sync.status_payload()
+
+
+@router.post("/run")
+async def run(
+    payload: dict = Body(...),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    org = (payload.get("org") or settings.GITHUB_ORG or "").strip()
+    if not org:
+        raise HTTPException(status_code=400, detail="org 이름이 필요합니다")
+
+    dry_run = bool(payload.get("dry_run", False))
+    include_archived = bool(payload.get("include_archived", False))
+
+    result = await github_sync.sync_org(
+        db,
+        org,
+        token=settings.GITHUB_TOKEN,
+        dry_run=dry_run,
+        include_archived=include_archived,
+    )
+    if result.get("error"):
+        # 인증/404 등은 사용자에게 그대로 노출 — secret 마스킹은 service에서 끝남
+        raise HTTPException(status_code=400, detail=result["error"])
+    result["dry_run"] = dry_run
+    result["org"] = org
+    return result

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -113,6 +113,8 @@ class Settings(BaseSettings):
     # GitHub API 토큰 — PR comment 작성 + 사설 repo raw fetch 시 사용 (선택).
     # 없으면 SBOM diff는 public repo만 동작하고 PR comment는 skip.
     GITHUB_TOKEN: Optional[str] = None
+    # 자산 자동 동기화 대상 org. 비우면 admin UI에서 매번 입력.
+    GITHUB_ORG: Optional[str] = None
 
     # i18n 기본 언어 (UI 초기 로드 시 사용)
     DEFAULT_LOCALE: str = "ko"

--- a/backend/app/services/github_sync.py
+++ b/backend/app/services/github_sync.py
@@ -1,0 +1,176 @@
+"""
+GitHub org → Mond Asset 자동 동기화
+
+org 안의 repo 목록을 GitHub REST API로 받아와서 Mond Asset으로 등록.
+이미 같은 uri로 등록된 자산은 라벨/설명만 업데이트.
+
+호출 흐름:
+  1) GET /orgs/{org}/repos (org 아니면 /users/{user}/repos로 fallback)
+  2) 각 repo → Asset(uri=https://github.com/{full_name}, asset_type=REPOSITORY)
+  3) labels에 language · archived · private · default_branch 기록
+
+토큰 없이도 public repo는 보임 (rate limit 60/h). PAT 권장.
+"""
+
+from __future__ import annotations
+
+import httpx
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.asset import Asset, AssetType
+
+logger = structlog.get_logger(__name__)
+
+GH_API = "https://api.github.com"
+PER_PAGE = 100
+MAX_PAGES = 20  # 토큰 없는 사용자가 실수로 거대 org 입력 시 보호
+
+
+async def discover_repos(org: str, token: str | None) -> tuple[list[dict], str | None]:
+    """org 또는 user의 repo 목록을 페이지네이션으로 모두 수집.
+
+    Returns: (repos, error_message). error_message가 None이면 성공.
+    """
+    if not org:
+        return [], "org 이름이 비어 있습니다"
+
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    # 1) /orgs/{org} 시도
+    base_org = f"{GH_API}/orgs/{org}/repos"
+    base_user = f"{GH_API}/users/{org}/repos"
+
+    repos: list[dict] = []
+    async with httpx.AsyncClient(timeout=20, headers=headers) as client:
+        url = base_org
+        used_user_fallback = False
+        for page in range(1, MAX_PAGES + 1):
+            resp = await client.get(url, params={"per_page": PER_PAGE, "page": page, "type": "all"})
+            if resp.status_code == 404 and not used_user_fallback:
+                # org가 아니라 user 계정인 경우
+                used_user_fallback = True
+                url = base_user
+                page = 1
+                resp = await client.get(url, params={"per_page": PER_PAGE, "page": page})
+            if resp.status_code == 401:
+                return [], "GitHub token 인증 실패 (401)"
+            if resp.status_code == 403:
+                return [], "GitHub API rate limit 또는 권한 부족 (403)"
+            if resp.status_code == 404:
+                return [], f"org/user '{org}'를 찾을 수 없습니다 (404)"
+            if resp.status_code >= 400:
+                return [], f"GitHub API {resp.status_code}: {resp.text[:200]}"
+
+            batch = resp.json()
+            if not isinstance(batch, list) or not batch:
+                break
+            repos.extend(batch)
+            if len(batch) < PER_PAGE:
+                break
+
+    return repos, None
+
+
+def _labels_from_repo(repo: dict) -> dict:
+    return {
+        "source": "github_sync",
+        "language": repo.get("language") or "unknown",
+        "default_branch": repo.get("default_branch") or "main",
+        "archived": bool(repo.get("archived")),
+        "private": bool(repo.get("private")),
+    }
+
+
+async def sync_org(
+    db: AsyncSession,
+    org: str,
+    *,
+    token: str | None,
+    dry_run: bool,
+    include_archived: bool = False,
+) -> dict:
+    """org 안의 repo들을 Asset으로 upsert.
+
+    Returns:
+      {discovered, created, updated, skipped_archived, error, repos: [...]}
+    """
+    repos, err = await discover_repos(org, token)
+    if err:
+        return {"discovered": 0, "created": 0, "updated": 0, "skipped_archived": 0, "error": err, "repos": []}
+
+    created = 0
+    updated = 0
+    skipped = 0
+    preview: list[dict] = []
+
+    for r in repos:
+        full_name = r.get("full_name")
+        if not full_name:
+            continue
+        if r.get("archived") and not include_archived:
+            skipped += 1
+            continue
+
+        uri = f"https://github.com/{full_name}"
+        existing = (await db.execute(select(Asset).where(Asset.uri == uri))).scalar_one_or_none()
+        labels = _labels_from_repo(r)
+        description = (r.get("description") or "")[:1024] or None
+        action = "skip"
+
+        if existing is None:
+            if not dry_run:
+                db.add(
+                    Asset(
+                        name=full_name,
+                        asset_type=AssetType.REPOSITORY,
+                        uri=uri,
+                        description=description,
+                        labels=labels,
+                    )
+                )
+            created += 1
+            action = "create"
+        else:
+            # 사용자가 손으로 바꾼 owner/environment는 건드리지 않음
+            changed = False
+            if existing.description != description and description:
+                existing.description = description
+                changed = True
+            # github_sync가 채운 라벨만 갱신, 사용자 라벨은 보존
+            current = dict(existing.labels or {})
+            for k, v in labels.items():
+                if current.get(k) != v:
+                    current[k] = v
+                    changed = True
+            if changed:
+                existing.labels = current
+                updated += 1
+                action = "update"
+
+        preview.append({"name": full_name, "private": labels["private"], "language": labels["language"], "action": action})
+
+    if not dry_run:
+        await db.commit()
+
+    logger.info("github_sync_done", org=org, created=created, updated=updated, dry_run=dry_run)
+    return {
+        "discovered": len(repos),
+        "created": created,
+        "updated": updated,
+        "skipped_archived": skipped,
+        "error": None,
+        "repos": preview[:200],  # UI 보호
+    }
+
+
+def status_payload() -> dict:
+    """admin UI가 토큰/기본 org 설정 상태를 확인하는 용도."""
+    return {
+        "token_configured": bool(settings.GITHUB_TOKEN),
+        "default_org": settings.GITHUB_ORG,
+    }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -706,6 +706,24 @@ GitHub repo Settings → Webhooks:
 
 **Skip 옵션**: 수동 스캔으로 충분하면 webhook 없이도 OK.
 
+#### GitHub org 자산 자동 동기화
+
+수십~수백 개 repo를 손으로 자산 등록하는 대신, org 단위로 한 번에 가져온다.
+
+```bash
+GITHUB_TOKEN=ghp_xxxx       # 위와 동일하게 재사용
+GITHUB_ORG=your-org         # 선택, admin UI에 기본값으로 채워짐
+```
+
+Admin → **Connections → GitHub Org Asset Sync** 카드에서:
+1. org 또는 user 이름 입력 (`jland-93`, `your-corp` 등)
+2. **미리보기**(dry-run)로 등록 예정 목록 확인
+3. **동기화** 클릭 → 신규 자산 자동 등록 + 라벨 갱신
+
+동일 URI(`https://github.com/{owner}/{repo}`)는 라벨만 갱신하므로 반복 실행이 안전. `owner`/`environment` 필드는 사용자가 손으로 채운 값 그대로 유지.
+
+API 직접 호출: `POST /api/v1/admin/github-sync/run` body `{"org":"...","dry_run":false,"include_archived":false}`.
+
 ### 8-1) 스캔 큐 (Celery) — 운영 안정성
 
 기본은 인라인 동기 실행. 대용량/장시간 스캔에서 backend 타임아웃이 문제라면 비동기 큐로 전환.

--- a/frontend/src/pages/admin/AdminConnections.tsx
+++ b/frontend/src/pages/admin/AdminConnections.tsx
@@ -16,6 +16,7 @@ import { useI18n } from "@/i18n";
 
 import AIProvidersCard from "./connections/AIProvidersCard";
 import DailyDigestCard from "./connections/DailyDigestCard";
+import GitHubOrgSyncCard from "./connections/GitHubOrgSyncCard";
 import IAMSourceCard from "./connections/IAMSourceCard";
 import IAMSourceModal from "./connections/IAMSourceModal";
 import SSOCard from "./connections/SSOCard";
@@ -38,6 +39,7 @@ export default function AdminConnections() {
       <SSOCard />
       <AIProvidersCard />
       <DailyDigestCard />
+      <GitHubOrgSyncCard />
       <WebhookCard />
 
       <IAMSourceModal open={modalOpen} onClose={() => setModalOpen(false)} />

--- a/frontend/src/pages/admin/connections/GitHubOrgSyncCard.tsx
+++ b/frontend/src/pages/admin/connections/GitHubOrgSyncCard.tsx
@@ -1,0 +1,220 @@
+import { GithubOutlined, SyncOutlined } from "@ant-design/icons";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  Alert,
+  Button,
+  Card,
+  Checkbox,
+  Input,
+  List,
+  Space,
+  Statistic,
+  Tag,
+  Typography,
+  message,
+} from "antd";
+import { useEffect, useState } from "react";
+
+import { useI18n } from "@/i18n";
+import { api } from "@/lib/api";
+
+const { Paragraph, Text } = Typography;
+
+interface StatusResp {
+  token_configured: boolean;
+  default_org: string | null;
+}
+
+interface RunResp {
+  discovered: number;
+  created: number;
+  updated: number;
+  skipped_archived: number;
+  dry_run: boolean;
+  org: string;
+  repos: Array<{ name: string; private: boolean; language: string; action: string }>;
+}
+
+export default function GitHubOrgSyncCard() {
+  const { locale } = useI18n();
+  const [org, setOrg] = useState("");
+  const [includeArchived, setIncludeArchived] = useState(false);
+  const [lastResult, setLastResult] = useState<RunResp | null>(null);
+
+  const { data: status } = useQuery({
+    queryKey: ["github-sync-status"],
+    queryFn: async () => (await api.get<StatusResp>("/admin/github-sync/status")).data,
+  });
+
+  // status 받은 후 org 기본값 1회만 채움
+  useEffect(() => {
+    if (status?.default_org && !org) setOrg(status.default_org);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status?.default_org]);
+
+  const run = useMutation({
+    mutationFn: async (dry: boolean) => {
+      const { data } = await api.post<RunResp>("/admin/github-sync/run", {
+        org,
+        dry_run: dry,
+        include_archived: includeArchived,
+      });
+      return data;
+    },
+    onSuccess: (r) => {
+      setLastResult(r);
+      if (r.dry_run) {
+        message.info(
+          locale === "ko"
+            ? `미리보기 — 등록 예정 ${r.created}, 업데이트 ${r.updated}`
+            : `Preview — to create ${r.created}, to update ${r.updated}`,
+        );
+      } else {
+        message.success(
+          locale === "ko"
+            ? `동기화 완료 — 신규 ${r.created}, 갱신 ${r.updated}`
+            : `Synced — created ${r.created}, updated ${r.updated}`,
+        );
+      }
+    },
+    onError: (e: Error) => message.error(e.message),
+  });
+
+  const r = lastResult;
+
+  return (
+    <Card
+      title={
+        <Space>
+          <GithubOutlined />
+          <span>{locale === "ko" ? "GitHub org 자산 동기화" : "GitHub Org Asset Sync"}</span>
+        </Space>
+      }
+      style={{ marginBottom: 16 }}
+    >
+      <Paragraph type="secondary" style={{ marginBottom: 12 }}>
+        {locale === "ko"
+          ? "GitHub org 또는 사용자의 모든 repo를 Mond Asset으로 등록합니다. 같은 URI는 라벨만 갱신, 사용자가 수정한 owner/environment는 보존."
+          : "Register every repo in a GitHub org/user as Mond Asset. Re-running only refreshes sync-managed labels; owner/environment edits are preserved."}
+      </Paragraph>
+
+      <Space.Compact style={{ width: "100%", marginBottom: 8 }}>
+        <Input
+          placeholder={locale === "ko" ? "org 또는 user 이름 (예: jland-93)" : "org or user (e.g. jland-93)"}
+          value={org}
+          onChange={(e) => setOrg(e.target.value)}
+        />
+        <Button
+          icon={<SyncOutlined />}
+          loading={run.isPending && run.variables === true}
+          onClick={() => run.mutate(true)}
+          disabled={!org}
+        >
+          {locale === "ko" ? "미리보기" : "Dry-run"}
+        </Button>
+        <Button
+          type="primary"
+          icon={<SyncOutlined />}
+          loading={run.isPending && run.variables === false}
+          onClick={() => run.mutate(false)}
+          disabled={!org}
+        >
+          {locale === "ko" ? "동기화" : "Sync"}
+        </Button>
+      </Space.Compact>
+
+      <Checkbox checked={includeArchived} onChange={(e) => setIncludeArchived(e.target.checked)}>
+        {locale === "ko" ? "archived repo도 포함" : "Include archived repos"}
+      </Checkbox>
+
+      {r && (
+        <div style={{ marginTop: 16 }}>
+          <Space size="large" style={{ marginBottom: 12 }}>
+            <Statistic title={locale === "ko" ? "발견" : "Discovered"} value={r.discovered} />
+            <Statistic title={locale === "ko" ? "신규" : "Created"} value={r.created} />
+            <Statistic title={locale === "ko" ? "갱신" : "Updated"} value={r.updated} />
+            <Statistic title={locale === "ko" ? "스킵(archived)" : "Skipped"} value={r.skipped_archived} />
+          </Space>
+          {r.repos.length > 0 && (
+            <List
+              size="small"
+              header={
+                <Text strong>
+                  {r.dry_run
+                    ? locale === "ko"
+                      ? "미리보기"
+                      : "Preview"
+                    : locale === "ko"
+                      ? "결과"
+                      : "Result"}{" "}
+                  ({r.repos.length})
+                </Text>
+              }
+              dataSource={r.repos.slice(0, 30)}
+              renderItem={(item) => (
+                <List.Item>
+                  <Space>
+                    <Tag
+                      color={
+                        item.action === "create"
+                          ? "green"
+                          : item.action === "update"
+                            ? "blue"
+                            : "default"
+                      }
+                    >
+                      {item.action}
+                    </Tag>
+                    <Text>{item.name}</Text>
+                    {item.private && <Tag color="orange">private</Tag>}
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      {item.language}
+                    </Text>
+                  </Space>
+                </List.Item>
+              )}
+              footer={
+                r.repos.length > 30 ? (
+                  <Text type="secondary" style={{ fontSize: 12 }}>
+                    {locale === "ko"
+                      ? `상위 30개만 표시 (총 ${r.repos.length}개)`
+                      : `Showing top 30 of ${r.repos.length}`}
+                  </Text>
+                ) : null
+              }
+            />
+          )}
+        </div>
+      )}
+
+      <Alert
+        type={status?.token_configured ? "info" : "warning"}
+        showIcon
+        style={{ marginTop: 12 }}
+        message={
+          <Text style={{ fontSize: 12 }}>
+            {status?.token_configured ? (
+              locale === "ko" ? (
+                <>
+                  <code>GITHUB_TOKEN</code> 활성 — private repo 포함 가능. rate limit 5000/h.
+                </>
+              ) : (
+                <>
+                  <code>GITHUB_TOKEN</code> active — private repos visible. 5000 req/h.
+                </>
+              )
+            ) : locale === "ko" ? (
+              <>
+                <code>GITHUB_TOKEN</code> 미설정 — public repo만 보이고 rate limit 60/h. <code>.env</code>에서 설정 권장.
+              </>
+            ) : (
+              <>
+                <code>GITHUB_TOKEN</code> not set — public repos only, 60 req/h. Configure in <code>.env</code>.
+              </>
+            )}
+          </Text>
+        }
+      />
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
v0.2 로드맵 '자산 자동 동기화 (GitHub org)' 항목. 수십~수백 repo가 있는 조직이 자산을 손으로 등록하는 부담을 없앤다.

### 흐름
Admin → Connections → **GitHub Org Asset Sync** 카드에 org/user 이름 입력 → 미리보기(dry-run) → 동기화. URI 기준 upsert이므로 반복 실행 안전.

### Backend
- `services/github_sync.py`
  - `discover_repos` — `/orgs/{org}/repos` 시도 후 404면 `/users/{org}/repos`로 fallback (개인 계정 자동 감지)
  - `sync_org` — Asset upsert by `uri=https://github.com/{full_name}`. 라벨에 `source=github_sync` · language · default_branch · archived · private. 사용자가 설정한 다른 라벨 키와 owner/environment는 그대로 보존
  - 페이지네이션 `MAX_PAGES=20` (거대 org 폭주 방지)
- `endpoints/admin_github_sync.py`
  - `POST /admin/github-sync/run` body `{org, dry_run, include_archived}` (ADMIN)
  - `GET /admin/github-sync/status` — 토큰/기본 org 설정 여부
- `core/config.py` — `GITHUB_ORG` 추가 (admin UI 기본값). `GITHUB_TOKEN`은 기존(SBOM diff와 공유)

### Frontend
- `admin/connections/GitHubOrgSyncCard.tsx` — org input + 미리보기/동기화 버튼 + archived 토글
- 결과 4 KPI(발견/신규/갱신/skip) + 상위 30개 액션 리스트
- 토큰 미설정 시 rate limit 안내(60/h vs 5000/h)

### Docs
- README v0.2 체크 ✅
- SETUP.md 8번 섹션 후속에 사용 가이드
- CHANGELOG Unreleased Added

## Test plan
- [x] dry-run idempotent (재실행 시 update=0)
- [x] 존재하지 않는 org → 400 + 명확한 메시지
- [x] org 아닌 user 계정 → /users/{user}/repos fallback
- [x] 사용자가 손으로 채운 라벨/owner 보존 (재 sync 후 `{team, criticality}` 유지 확인)
- [x] Admin 권한 외 호출 → 403
- [x] backend ruff clean · frontend vite build clean
- [ ] CI Backend / Frontend / CodeQL 통과