### PR TITLE
feat(security): Rate limit — login · AI · webhook · github-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [Unreleased]
 
 ### Added
+- **Rate limit (abuse 보호)** — Redis 기반 fixed-window counter. `POST /auth/dev-login` 10/min/IP · `POST /ai/analyze` 20/min/user · `POST /webhooks/github` 120/min/IP · `POST /webhooks/personal` 30/min/IP · `POST /admin/github-sync/run` 5/min/user. 응답에 `X-RateLimit-Limit/Remaining/Reset` 헤더, 초과 시 429 + `Retry-After`. Redis 다운 시 fail open(가용성 우선). `RATE_LIMIT_ENABLED=false`로 전체 끄기 가능(test/CI 편의). SETUP.md에 표.
 - **GitHub org 자산 자동 동기화** — Admin → Connections에 "GitHub Org Asset Sync" 카드. org 또는 user 이름 입력 → 미리보기/동기화 버튼으로 해당 org의 모든 repo를 `https://github.com/{owner}/{repo}` URI의 REPOSITORY 자산으로 일괄 등록. 동일 URI는 라벨(language/private/archived/default_branch)만 갱신하고 사용자가 수정한 owner/environment는 보존. `GITHUB_TOKEN` 있으면 private repo 포함 + rate limit 5000/h, 없으면 public 60/h. `GITHUB_ORG` 환경변수로 기본값 채울 수 있음. 백엔드 `POST /api/v1/admin/github-sync/run` 신설(Admin 전용).
 - **GitHub Actions composite action** — `.github/actions/mond-scan/action.yml`. 사용자 repo의 workflow에서 `uses: jland-93/mond/.github/actions/mond-scan@main` 한 줄로 Mond 스캔 트리거. 입력: `mond_host` · `webhook_token` · `asset_id` · `scanner`. 출력: `scan_id` · `status`. backend의 기존 `POST /api/v1/webhooks/personal` 사용. README에 사용 예시 추가.
 - **AI Insights RAG에 Asset 소스 추가** — 자연어 질의 시 RAG가 Asset(이름·URI·설명)도 함께 검색. "우리 nginx 자산" 같은 질문에 자산을 직접 짚어주고, citations에 kind=`asset`(녹색 chip)으로 노출. open_findings 수로 가중 정렬. 기존 Finding · Policy · Knowledge에 더해 4 소스 RAG.

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ class MyAdapter(ScannerAdapter):
 - [x] 자산 자동 동기화 — GitHub org (Kubernetes / AWS Auto-scaling는 v0.3)
 - [ ] Webhook push 이벤트 → diff 분석 후 적절한 스캐너 선택
 - [ ] CI 통합 패키지 (GitHub Actions / GitLab CI step)
-- [ ] Rate limiting / abuse protection
+- [x] Rate limiting / abuse protection (login · AI · webhook · github-sync)
 - [ ] AI 프롬프트 E2E 암호화 (고객 코드 포함 시)
 - [ ] GCP / Azure IAM 어댑터 권한 부여(grant) 완성도 보강
 

--- a/backend/app/api/v1/endpoints/admin_github_sync.py
+++ b/backend/app/api/v1/endpoints/admin_github_sync.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.deps import require_role
 from app.core.config import settings
 from app.core.database import get_db
+from app.core.rate_limit import RateLimiter
 from app.models.user import Role
 from app.services import github_sync
 
@@ -17,7 +18,7 @@ async def status() -> dict:
     return github_sync.status_payload()
 
 
-@router.post("/run")
+@router.post("/run", dependencies=[Depends(RateLimiter("github_sync", 5, 60, "user"))])
 async def run(
     payload: dict = Body(...),
     db: AsyncSession = Depends(get_db),

--- a/backend/app/api/v1/endpoints/ai.py
+++ b/backend/app/api/v1/endpoints/ai.py
@@ -9,6 +9,7 @@ from app.ai import insights as ai_insights
 from app.ai.client import current_model_label, get_provider as ai_provider, is_enabled as ai_enabled
 from app.auth.deps import current_user
 from app.core.database import get_db
+from app.core.rate_limit import RateLimiter
 from app.models.ai_insight import InsightKind
 from app.models.user import User
 from app.schemas.ai_insight import AIInsightRead, AnalyzeRequest, AnalyzeResponse
@@ -54,7 +55,11 @@ async def list_finding_insights(
     return [AIInsightRead.model_validate(i) for i in items]
 
 
-@router.post("/analyze", response_model=AnalyzeResponse)
+@router.post(
+    "/analyze",
+    response_model=AnalyzeResponse,
+    dependencies=[Depends(RateLimiter("ai_analyze", 20, 60, "user"))],
+)
 async def analyze_query(
     payload: AnalyzeRequest,
     _user: User = Depends(current_user),

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -16,6 +16,7 @@ from app.auth.session import clear_cookie, create_session, resolve_session, revo
 from app.core.config import settings
 from app.core.database import get_db
 from app.core.logging import get_logger
+from app.core.rate_limit import RateLimiter
 from app.models.user import Role
 from app.services import user as user_service
 
@@ -73,7 +74,11 @@ class DevLoginIn(BaseModel):
     name: str | None = None
 
 
-@router.post("/dev-login", response_model=MeOut)
+@router.post(
+    "/dev-login",
+    response_model=MeOut,
+    dependencies=[Depends(RateLimiter("login", 10, 60, "ip"))],
+)
 async def dev_login(
     payload: DevLoginIn,
     response: Response,

--- a/backend/app/api/v1/endpoints/webhooks.py
+++ b/backend/app/api/v1/endpoints/webhooks.py
@@ -23,6 +23,7 @@ from app.auth.deps import require_role
 from app.core.config import settings
 from app.core.database import get_db
 from app.core.logging import get_logger
+from app.core.rate_limit import RateLimiter
 from app.models.asset import Asset, AssetType
 from app.models.scan import ScanTrigger
 from app.models.user import Role
@@ -53,7 +54,7 @@ def _verify_github(signature: str | None, body: bytes) -> bool:
     return hmac.compare_digest(expected, signature)
 
 
-@router.post("/github")
+@router.post("/github", dependencies=[Depends(RateLimiter("webhook_github", 120, 60, "ip"))])
 async def github_webhook(
     request: Request,
     x_github_event: str | None = Header(default=None),
@@ -143,7 +144,7 @@ async def github_webhook(
     }
 
 
-@router.post("/personal")
+@router.post("/personal", dependencies=[Depends(RateLimiter("webhook_personal", 30, 60, "ip"))])
 async def personal_webhook(
     request: Request,
     payload: dict = Body(...),

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -116,6 +116,10 @@ class Settings(BaseSettings):
     # 자산 자동 동기화 대상 org. 비우면 admin UI에서 매번 입력.
     GITHUB_ORG: Optional[str] = None
 
+    # Rate limit — Redis 기반 fixed window. 끄면 모든 버킷 통과 (test/CI 편의).
+    # 기본 true — 운영에서 abuse 보호. Redis 다운 시 fail open(가용성 우선).
+    RATE_LIMIT_ENABLED: bool = True
+
     # i18n 기본 언어 (UI 초기 로드 시 사용)
     DEFAULT_LOCALE: str = "ko"
 

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,0 +1,104 @@
+"""
+Rate limit — Redis 기반 fixed-window counter
+
+운영용 abuse 보호. login brute-force · AI 호출 비용 · webhook flood 차단.
+
+설계 메모:
+  - sliding window log보다 메모리/CPU가 적은 fixed window 사용. 1분 윈도우면
+    경계 효과는 무시 가능. abuse 보호 목적엔 충분.
+  - Redis 실패 시 fail open. 보안보다 가용성을 택함 (자체 호스팅 OSS이므로
+    의도된 결정). 실패는 structlog warn으로 남김.
+  - RATE_LIMIT_ENABLED=false면 의존성 자체가 통과. test/CI 편의.
+
+scope:
+  - "ip"   원격 IP. 로그인 · webhook 등 익명 endpoint에 사용.
+  - "user" 인증된 사용자 ID. AI · admin action 등 비용/책임이 사용자에 귀속.
+  - "global" 단일 키. 전체 처리량 상한 (드물게 사용).
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import Depends, HTTPException, Request, Response, status
+from redis import asyncio as aioredis
+
+from app.auth.deps import current_user_or_none
+from app.core.config import settings
+from app.models.user import User
+
+logger = structlog.get_logger(__name__)
+
+_redis: aioredis.Redis | None = None
+
+
+def _client() -> aioredis.Redis:
+    """lazy singleton. Celery worker / web 둘 다 같은 URL 공유."""
+    global _redis
+    if _redis is None:
+        _redis = aioredis.from_url(settings.REDIS_URL, decode_responses=True)
+    return _redis
+
+
+def _client_ip(request: Request) -> str:
+    # X-Forwarded-For 첫 항목 → fallback to socket. 신뢰 가능한 reverse proxy 가정.
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        return xff.split(",")[0].strip()
+    if request.client:
+        return request.client.host
+    return "unknown"
+
+
+class RateLimiter:
+    """단일 버킷 의존성 팩토리.
+
+    사용 예:
+      router = APIRouter(dependencies=[Depends(RateLimiter("login", 10, 60, "ip"))])
+    """
+
+    def __init__(self, name: str, limit: int, window_s: int, scope: str = "ip") -> None:
+        self.name = name
+        self.limit = limit
+        self.window_s = window_s
+        self.scope = scope
+
+    async def __call__(
+        self,
+        request: Request,
+        response: Response,
+        user: User | None = Depends(current_user_or_none),
+    ) -> None:
+        if not settings.RATE_LIMIT_ENABLED:
+            return
+
+        if self.scope == "user":
+            ident = f"u:{user.id}" if user else f"ip:{_client_ip(request)}"
+        elif self.scope == "global":
+            ident = "global"
+        else:
+            ident = f"ip:{_client_ip(request)}"
+
+        key = f"rl:{self.name}:{ident}"
+        try:
+            r = _client()
+            current = await r.incr(key)
+            if current == 1:
+                await r.expire(key, self.window_s)
+                ttl = self.window_s
+            else:
+                ttl = await r.ttl(key)
+        except Exception as e:
+            logger.warning("rate_limit_redis_down", bucket=self.name, error=str(e))
+            return
+
+        remaining = max(0, self.limit - current)
+        response.headers["X-RateLimit-Limit"] = str(self.limit)
+        response.headers["X-RateLimit-Remaining"] = str(remaining)
+        response.headers["X-RateLimit-Reset"] = str(max(ttl, 0))
+
+        if current > self.limit:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=f"요청이 너무 많습니다 — {self.name} (한도 {self.limit}/{self.window_s}s)",
+                headers={"Retry-After": str(max(ttl, 1))},
+            )

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -746,6 +746,28 @@ scan 트리거 시 backend가 즉시 `PENDING` Scan을 반환하고, worker가 `
 
 운영 (Helm) — 별도 Deployment로 worker를 띄우고 `replicaCount`로 동시 처리량 조절. concurrency는 `command: celery -A app.celery_app:celery_app worker --concurrency=N`로 worker 인스턴스 안에서 조절.
 
+### 8-2) Rate limit (abuse 보호)
+
+기본 활성. Redis 기반 fixed-window counter로 OSS 공개 인스턴스의 brute-force/스크래핑을 막는다.
+
+```bash
+RATE_LIMIT_ENABLED=true     # 기본. false로 끄면 모든 버킷 통과 (test/CI 편의)
+```
+
+기본 한도(분당):
+
+| 버킷 | 한도 | scope | 대상 |
+|------|------|-------|------|
+| `login` | 10 | IP | `POST /auth/dev-login` |
+| `ai_analyze` | 20 | user | `POST /ai/analyze` |
+| `webhook_github` | 120 | IP | `POST /webhooks/github` |
+| `webhook_personal` | 30 | IP | `POST /webhooks/personal` |
+| `github_sync` | 5 | user | `POST /admin/github-sync/run` |
+
+응답 헤더 — `X-RateLimit-Limit` / `X-RateLimit-Remaining` / `X-RateLimit-Reset`. 초과 시 HTTP 429 + `Retry-After`.
+
+Redis 다운 시 fail open(가용성 우선) — `rate_limit_redis_down` 경고 로그를 남기고 요청은 통과. 보안 critical 환경이면 monitor에서 이 로그를 알림으로 연결할 것.
+
 ### 9) 데모 시드 끄기
 
 ```bash


### PR DESCRIPTION
## Summary
v0.2 로드맵 'Rate limiting / abuse protection' 항목. OSS 공개 인스턴스를 brute-force / 스크래핑 / LLM 비용 공격으로부터 보호.

## 설계
`core/rate_limit.py` — Redis 기반 fixed-window counter (INCR + EXPIRE).

`RateLimiter(name, limit, window_s, scope)` 의존성 팩토리.
- scope `ip` — X-Forwarded-For 첫 항목 → socket fallback
- scope `user` — 인증된 사용자 ID. 미인증이면 IP로 폴백
- scope `global` — 단일 키 (전체 처리량 상한, 드물게 사용)
- Redis 다운 시 **fail open**(가용성 우선) + structlog warn. 보안 critical 환경에선 monitor에서 `rate_limit_redis_down` 로그를 알림으로 연결할 것

응답: `X-RateLimit-Limit` · `Remaining` · `Reset` 헤더. 초과 시 `429` + `Retry-After`.

## 적용 (분당 한도)
| endpoint | 한도 | scope | 동기 |
|---|---|---|---|
| `POST /auth/dev-login` | 10 | IP | brute-force |
| `POST /ai/analyze` | 20 | user | LLM 비용 |
| `POST /webhooks/github` | 120 | IP | push flood |
| `POST /webhooks/personal` | 30 | IP | CI 토큰 abuse |
| `POST /admin/github-sync/run` | 5 | user | GitHub 5000/h 보호 |

## Config
- `RATE_LIMIT_ENABLED=true` (기본). `false`로 전체 disable (test/CI 편의)
- `REDIS_URL` — 기존 Celery/캐시와 공유

## 로컬 검증
- dev-login 11연발 → 11번째부터 `429`
- github-sync 6연발 → 6번째 `429`
- `X-RateLimit-Limit/Remaining/Reset` 헤더 노출 확인
- 60초 후 reset 확인

## Test plan
- [x] 한도 초과 시 429
- [x] 응답 헤더 정상
- [x] reset window 정상
- [x] backend ruff clean
- [ ] CI 통과