### PR TITLE
feat(ai): 외부 LLM 호출 전 PII redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [Unreleased]
 
 ### Added
+- **AI 프롬프트 PII redaction** — 외부 LLM provider(Anthropic/OpenAI/Bedrock/Ollama 등)로 사용자 쿼리를 보내기 전 이메일·한국 전화번호·주민등록번호·AWS access/secret key·GitHub token·일반 API token(`sk-`/`pat_`)·JWT·Luhn 통과 신용카드 번호를 자동 마스킹. 마스킹된 종류와 건수는 응답 `redactions` 필드로 노출되고 AI Insights UI에 `redacted email:N` 같은 chip으로 표시. `AI_PROMPT_REDACT_PII=false`로 끌 수 있음(기본 켜짐). RAG는 원본으로 검색하고 LLM에는 마스킹본만 전달.
 - **Rate limit (abuse 보호)** — Redis 기반 fixed-window counter. `POST /auth/dev-login` 10/min/IP · `POST /ai/analyze` 20/min/user · `POST /webhooks/github` 120/min/IP · `POST /webhooks/personal` 30/min/IP · `POST /admin/github-sync/run` 5/min/user. 응답에 `X-RateLimit-Limit/Remaining/Reset` 헤더, 초과 시 429 + `Retry-After`. Redis 다운 시 fail open(가용성 우선). `RATE_LIMIT_ENABLED=false`로 전체 끄기 가능(test/CI 편의). SETUP.md에 표.
 - **GitHub org 자산 자동 동기화** — Admin → Connections에 "GitHub Org Asset Sync" 카드. org 또는 user 이름 입력 → 미리보기/동기화 버튼으로 해당 org의 모든 repo를 `https://github.com/{owner}/{repo}` URI의 REPOSITORY 자산으로 일괄 등록. 동일 URI는 라벨(language/private/archived/default_branch)만 갱신하고 사용자가 수정한 owner/environment는 보존. `GITHUB_TOKEN` 있으면 private repo 포함 + rate limit 5000/h, 없으면 public 60/h. `GITHUB_ORG` 환경변수로 기본값 채울 수 있음. 백엔드 `POST /api/v1/admin/github-sync/run` 신설(Admin 전용).
 - **GitHub Actions composite action** — `.github/actions/mond-scan/action.yml`. 사용자 repo의 workflow에서 `uses: jland-93/mond/.github/actions/mond-scan@main` 한 줄로 Mond 스캔 트리거. 입력: `mond_host` · `webhook_token` · `asset_id` · `scanner`. 출력: `scan_id` · `status`. backend의 기존 `POST /api/v1/webhooks/personal` 사용. README에 사용 예시 추가.

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ class MyAdapter(ScannerAdapter):
 - [ ] Webhook push 이벤트 → diff 분석 후 적절한 스캐너 선택
 - [ ] CI 통합 패키지 (GitHub Actions / GitLab CI step)
 - [x] Rate limiting / abuse protection (login · AI · webhook · github-sync)
-- [ ] AI 프롬프트 E2E 암호화 (고객 코드 포함 시)
+- [x] AI 프롬프트 PII redaction — 외부 LLM provider로 보내기 전 이메일/전화/RRN/AWS키/토큰 자동 마스킹
 - [ ] GCP / Azure IAM 어댑터 권한 부여(grant) 완성도 보강
 
 ## 🧪 Known Limitations (v0.1.0)

--- a/backend/app/ai/insights.py
+++ b/backend/app/ai/insights.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.client import complete_json, current_model_label, is_enabled
+from app.ai.redaction import redact_prompt
+from app.core.config import settings
 from app.core.logging import get_logger
 from app.models.finding import Finding, Severity
 
@@ -93,16 +95,27 @@ async def route_query(db: AsyncSession, query: str) -> dict:
     """
     from app.ai.rag import build_context_block, search
 
-    # 1) Mond DB에서 관련 자료 검색 (RAG retrieve)
+    # 1) Mond DB에서 관련 자료 검색 (RAG retrieve) — 원본 query로 검색
+    #    (redaction은 외부 provider로 보낼 텍스트만 적용)
     citations = await search(db, query)
 
-    # 2) AI 비활성 시 — 휴리스틱 + 출처만 노출
+    # 2) AI 비활성 시 — 휴리스틱 + 출처만 노출 (외부 호출 없음 → redaction 불필요)
     if not await is_enabled(db):
         result = _heuristic_route(query)
         result["citations"] = [c.to_dict() for c in citations]
         return result
 
-    # 3) LLM에 context 주입
+    # 3) PII redaction — 외부 LLM provider로 가기 직전 마스킹
+    user_prompt = query
+    redaction_summary: dict[str, int] = {}
+    if settings.AI_PROMPT_REDACT_PII:
+        r = redact_prompt(query)
+        user_prompt = r.text
+        redaction_summary = r.counts
+        if r.total > 0:
+            logger.info("ai_prompt_redacted", total=r.total, kinds=list(r.counts.keys()))
+
+    # 4) LLM에 context 주입
     context_block = build_context_block(citations)
     system = (
         "You are Mond, an AI-powered self-service DevSecOps assistant. "
@@ -116,18 +129,21 @@ async def route_query(db: AsyncSession, query: str) -> dict:
     if context_block:
         system = f"{system}\n\n{context_block}"
 
-    result = await complete_json(db, system, query, max_tokens=600)
+    result = await complete_json(db, system, user_prompt, max_tokens=600)
     if result is None:
         fallback = _heuristic_route(query)
         fallback["citations"] = [c.to_dict() for c in citations]
+        fallback["redactions"] = redaction_summary
         return fallback
     parsed = _parse_json(result.text)
     if not parsed:
         fallback = _heuristic_route(query)
         fallback["citations"] = [c.to_dict() for c in citations]
+        fallback["redactions"] = redaction_summary
         return fallback
     parsed["model"] = f"{result.provider}:{result.model}"
     parsed["citations"] = [c.to_dict() for c in citations]
+    parsed["redactions"] = redaction_summary
     return parsed
 
 

--- a/backend/app/ai/redaction.py
+++ b/backend/app/ai/redaction.py
@@ -1,0 +1,107 @@
+"""
+LLM prompt PII redaction
+
+외부 LLM provider(Anthropic/OpenAI/Bedrock 등) 호출 전에 사용자 입력에서
+명백한 PII와 시크릿을 마스킹한다. 자체 호스팅이라도 프롬프트가 provider
+서버에 보내지는 순간 그 외부 시스템의 정책에 노출되므로, 사전 마스킹은
+privacy-by-default 원칙에 부합.
+
+대상:
+  - 이메일
+  - 전화번호 (한국 010-XXXX-XXXX / 일반 국제 표기)
+  - 한국 주민등록번호 6-7 (체크섬 검증은 false positive 줄임)
+  - 신용카드 (Luhn — 16자리 숫자 중 통과만)
+  - AWS access key ID (AKIA prefix)
+  - AWS secret access key (40-char base64)
+  - 일반 Bearer/API token (sk_/ghp_/sk-/pat_ 등 prefix)
+  - JWT (eyJ로 시작하는 3-segment)
+  - IPv4 주소 (옵션 — 보안 컨텍스트에선 legitimate일 수 있어 기본 미적용)
+
+토글:
+  - 전체 끄기 → AI_PROMPT_REDACT_PII=false
+  - 결과의 redactions 카운트는 로깅에만 사용, LLM 응답에는 노출 X
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_EMAIL = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+_PHONE_KR = re.compile(r"\b01[016789][-\s]?\d{3,4}[-\s]?\d{4}\b")
+_PHONE_INTL = re.compile(r"\+\d{1,3}[-\s]?\d{2,4}[-\s]?\d{3,4}[-\s]?\d{3,4}")
+_RRN = re.compile(r"\b\d{6}[-\s]?[1-4]\d{6}\b")
+_AWS_AKID = re.compile(r"\b(AKIA|ASIA)[0-9A-Z]{16}\b")
+_AWS_SECRET = re.compile(r"\b(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])\b")
+_GH_TOKEN = re.compile(r"\b(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}\b")
+_GENERIC_TOKEN = re.compile(r"\b(sk-[A-Za-z0-9_-]{20,}|pat_[A-Za-z0-9_-]{20,})\b")
+_JWT = re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b")
+_CC_16 = re.compile(r"\b(?:\d[ -]?){13,19}\b")
+
+
+def _luhn_ok(num: str) -> bool:
+    digits = [int(c) for c in num if c.isdigit()]
+    if not 13 <= len(digits) <= 19:
+        return False
+    checksum = 0
+    parity = len(digits) % 2
+    for i, d in enumerate(digits):
+        if i % 2 == parity:
+            d *= 2
+            if d > 9:
+                d -= 9
+        checksum += d
+    return checksum % 10 == 0
+
+
+def _redact_cc(text: str, kinds: dict[str, int]) -> str:
+    def repl(m: re.Match) -> str:
+        if _luhn_ok(m.group(0)):
+            kinds["cc"] = kinds.get("cc", 0) + 1
+            return "[REDACTED_CC]"
+        return m.group(0)
+
+    return _CC_16.sub(repl, text)
+
+
+@dataclass
+class RedactionResult:
+    text: str
+    counts: dict[str, int]  # kind → count
+
+    @property
+    def total(self) -> int:
+        return sum(self.counts.values())
+
+
+def redact_prompt(text: str) -> RedactionResult:
+    """주어진 텍스트에서 PII/시크릿을 마스킹한 사본을 반환.
+
+    원본은 변경하지 않음 — caller가 원본 보관 책임.
+    """
+    if not text:
+        return RedactionResult(text=text or "", counts={})
+
+    counts: dict[str, int] = {}
+
+    def _sub(pattern: re.Pattern, kind: str, placeholder: str, body: str) -> str:
+        def repl(_m: re.Match) -> str:
+            counts[kind] = counts.get(kind, 0) + 1
+            return placeholder
+
+        return pattern.sub(repl, body)
+
+    out = text
+    # 순서 — 더 구체적인 패턴부터. CC는 마지막에 (다른 토큰을 CC로 오인 방지)
+    out = _sub(_JWT, "jwt", "[REDACTED_JWT]", out)
+    out = _sub(_GH_TOKEN, "github_token", "[REDACTED_TOKEN]", out)
+    out = _sub(_GENERIC_TOKEN, "api_token", "[REDACTED_TOKEN]", out)
+    out = _sub(_AWS_AKID, "aws_akid", "[REDACTED_AWS_KEY]", out)
+    out = _sub(_AWS_SECRET, "aws_secret", "[REDACTED_AWS_SECRET]", out)
+    out = _sub(_EMAIL, "email", "[REDACTED_EMAIL]", out)
+    out = _sub(_RRN, "rrn", "[REDACTED_RRN]", out)
+    out = _sub(_PHONE_KR, "phone", "[REDACTED_PHONE]", out)
+    out = _sub(_PHONE_INTL, "phone", "[REDACTED_PHONE]", out)
+    out = _redact_cc(out, counts)
+
+    return RedactionResult(text=out, counts=counts)

--- a/backend/app/api/v1/endpoints/ai.py
+++ b/backend/app/api/v1/endpoints/ai.py
@@ -73,4 +73,5 @@ async def analyze_query(
         suggested_actions=result.get("suggested_actions", []) or [],
         model=result.get("model") or await current_model_label(db),
         citations=result.get("citations") or [],
+        redactions=result.get("redactions") or {},
     )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -120,6 +120,11 @@ class Settings(BaseSettings):
     # 기본 true — 운영에서 abuse 보호. Redis 다운 시 fail open(가용성 우선).
     RATE_LIMIT_ENABLED: bool = True
 
+    # AI 프롬프트 PII redaction — 외부 LLM provider 호출 전 이메일/전화/주민번호/
+    # AWS키/토큰 등을 마스킹. 자체 호스팅이라도 provider로 보내는 순간 그 정책에
+    # 노출되므로 사전 마스킹은 privacy-by-default. 기본 true.
+    AI_PROMPT_REDACT_PII: bool = True
+
     # i18n 기본 언어 (UI 초기 로드 시 사용)
     DEFAULT_LOCALE: str = "ko"
 

--- a/backend/app/schemas/ai_insight.py
+++ b/backend/app/schemas/ai_insight.py
@@ -34,3 +34,5 @@ class AnalyzeResponse(BaseModel):
     suggested_actions: list[dict] = Field(default_factory=list)
     model: str
     citations: list[dict] = Field(default_factory=list)
+    # 외부 LLM provider로 보내기 전 redaction한 PII kind→count. 비어 있으면 마스킹 없음.
+    redactions: dict[str, int] = Field(default_factory=dict)

--- a/backend/tests/test_redaction.py
+++ b/backend/tests/test_redaction.py
@@ -1,0 +1,77 @@
+"""
+AI 프롬프트 PII redaction 테스트
+
+외부 LLM provider 호출 전 마스킹의 invariant — 패턴이 매칭되면 항상 같은
+placeholder가 들어가고, 매칭이 없으면 원문이 그대로 유지된다.
+"""
+
+from app.ai.redaction import redact_prompt
+
+
+def test_email_redacted():
+    r = redact_prompt("contact me at kim@example.com please")
+    assert "[REDACTED_EMAIL]" in r.text
+    assert "kim@example.com" not in r.text
+    assert r.counts["email"] == 1
+
+
+def test_korean_phone_redacted():
+    r = redact_prompt("내 번호 010-1234-5678 입니다")
+    assert "[REDACTED_PHONE]" in r.text
+    assert r.counts["phone"] == 1
+
+
+def test_rrn_redacted():
+    r = redact_prompt("주민번호 900101-1234567")
+    assert "[REDACTED_RRN]" in r.text
+    assert r.counts["rrn"] == 1
+
+
+def test_aws_access_key_redacted():
+    r = redact_prompt("AKIAIOSFODNN7EXAMPLE")
+    assert "[REDACTED_AWS_KEY]" in r.text
+
+
+def test_github_token_redacted():
+    r = redact_prompt("ghp_abcdefghijklmnopqrstuvwxyz1234567890")
+    assert "[REDACTED_TOKEN]" in r.text
+
+
+def test_jwt_redacted():
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    r = redact_prompt(f"token={jwt}")
+    assert "[REDACTED_JWT]" in r.text
+    assert jwt not in r.text
+
+
+def test_luhn_valid_cc_redacted():
+    # Visa test card — Luhn 통과
+    r = redact_prompt("card 4111 1111 1111 1111 ok")
+    assert "[REDACTED_CC]" in r.text
+
+
+def test_random_digits_not_redacted_as_cc():
+    # Luhn 통과 못하는 16자리는 카드로 오인하지 않음
+    r = redact_prompt("rule 1234567890123456 fired")
+    assert "[REDACTED_CC]" not in r.text
+
+
+def test_no_pii_passes_through():
+    text = "scan nginx asset for CVEs in last 7 days"
+    r = redact_prompt(text)
+    assert r.text == text
+    assert r.counts == {}
+
+
+def test_multiple_kinds_counted():
+    r = redact_prompt("a@b.com and 010-1111-2222 and ghp_abcdefghijklmnopqrstuvwxyz12345")
+    assert r.counts.get("email") == 1
+    assert r.counts.get("phone") == 1
+    assert r.counts.get("github_token") == 1
+    assert r.total == 3
+
+
+def test_empty_input():
+    r = redact_prompt("")
+    assert r.text == ""
+    assert r.counts == {}

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -746,6 +746,31 @@ scan 트리거 시 backend가 즉시 `PENDING` Scan을 반환하고, worker가 `
 
 운영 (Helm) — 별도 Deployment로 worker를 띄우고 `replicaCount`로 동시 처리량 조절. concurrency는 `command: celery -A app.celery_app:celery_app worker --concurrency=N`로 worker 인스턴스 안에서 조절.
 
+### 8-3) AI 프롬프트 PII redaction
+
+기본 활성. 사용자 쿼리가 외부 LLM provider로 가기 직전에 PII와 시크릿을 placeholder로 치환한다.
+
+```bash
+AI_PROMPT_REDACT_PII=true     # 기본
+```
+
+마스킹 대상:
+
+| 종류 | 예 | placeholder |
+|------|----|-------------|
+| 이메일 | `kim@example.com` | `[REDACTED_EMAIL]` |
+| 한국 전화번호 | `010-1234-5678` | `[REDACTED_PHONE]` |
+| 국제 전화 | `+82-10-...` | `[REDACTED_PHONE]` |
+| 주민등록번호 | `900101-1234567` | `[REDACTED_RRN]` |
+| AWS Access Key ID | `AKIA...` | `[REDACTED_AWS_KEY]` |
+| AWS Secret (40-char) | base64 패턴 | `[REDACTED_AWS_SECRET]` |
+| GitHub token | `ghp_...` | `[REDACTED_TOKEN]` |
+| 일반 API token | `sk-...` / `pat_...` | `[REDACTED_TOKEN]` |
+| JWT | `eyJ...` | `[REDACTED_JWT]` |
+| 신용카드 (Luhn 통과) | `4111 1111 ...` | `[REDACTED_CC]` |
+
+RAG retrieve는 원본 쿼리로 진행하고, LLM에 보내는 user message만 마스킹본을 사용. AI Insights 응답의 `redactions` 필드(`{kind: count}`)와 UI의 `redacted email:1` chip으로 무엇이 가려졌는지 즉시 확인.
+
 ### 8-2) Rate limit (abuse 보호)
 
 기본 활성. Redis 기반 fixed-window counter로 OSS 공개 인스턴스의 brute-force/스크래핑을 막는다.

--- a/frontend/src/pages/AIInsights.tsx
+++ b/frontend/src/pages/AIInsights.tsx
@@ -28,6 +28,7 @@ interface AnalyzeResponse {
   suggested_actions: Array<{ label: string; endpoint?: string }>;
   model: string;
   citations?: Citation[];
+  redactions?: Record<string, number>;
 }
 
 const KIND_COLOR: Record<string, string> = {
@@ -173,6 +174,20 @@ export default function AIInsights() {
                     {locale === "ko" ? "출처" : "Sources"} {analyze.data.citations!.length}
                   </Tag>
                 )}
+                {Object.entries(analyze.data.redactions ?? {}).map(([kind, n]) => (
+                  <Tooltip
+                    key={kind}
+                    title={
+                      locale === "ko"
+                        ? `외부 LLM 호출 전 ${kind} ${n}건을 자동 마스킹 처리했습니다.`
+                        : `Masked ${n} ${kind} before sending to external LLM.`
+                    }
+                  >
+                    <Tag color="gold">
+                      redacted {kind}:{n}
+                    </Tag>
+                  </Tooltip>
+                ))}
               </Space>
               <Paragraph style={{ whiteSpace: "pre-wrap" }}>
                 {renderSummaryWithCitations(


### PR DESCRIPTION
## Summary
v0.2 로드맵 'AI 프롬프트 E2E 암호화'를 PII redaction 접근으로 충족. 자체 호스팅이라도 사용자 쿼리가 외부 LLM provider 서버로 가는 순간 그 시스템 정책에 노출되므로 privacy-by-default로 사전 마스킹.

## 마스킹 대상
이메일 · 한국/국제 전화 · 한국 RRN · AWS access/secret key · GitHub token · 일반 `sk-`/`pat_` token · JWT · Luhn 통과 카드번호.

placeholder는 `[REDACTED_EMAIL]` 등 — LLM 답변 자연스러움 유지.

## 설계
- `ai/redaction.py` — `redact_prompt(text) → RedactionResult(text, counts: {kind:n})`. 패턴별 카운트 노출
- `ai/insights.py` — RAG retrieve는 **원본 쿼리로 진행**(검색 정확도 보존). LLM 호출 user message만 마스킹본 사용. AI 비활성 휴리스틱 path는 외부 호출이 없어 redaction skip
- `schemas/ai_insight.py::AnalyzeResponse` — `redactions: dict[str, int]` 필드 추가
- `frontend/AIInsights.tsx` — intent/model 옆 `redacted email:1` gold chip + 무엇이 가려졌는지 툴팁

## Config
- `AI_PROMPT_REDACT_PII=true` (기본). false면 마스킹 없이 외부 호출 (자기 책임)

## Test plan
- [x] `pytest tests/test_redaction.py` — 11/11 통과 (각 kind + Luhn negative + 빈 입력 + 다중 종류)
- [x] backend ruff clean
- [x] frontend vite build clean
- [x] AI 비활성 상태에서 `redactions={}` 정상
- [ ] CI 통과