### PR TITLE
feat(iam): import한 권한을 임직원이 알아보기 쉽게 — Identity Center 포함

### DIFF
--- a/backend/app/iam/providers/aws.py
+++ b/backend/app/iam/providers/aws.py
@@ -206,6 +206,20 @@ def _stub() -> FetchResult:
             FetchedIdentity(identity_type=IdentityType.USER, name="bob", external_id="arn:aws:iam::000000000000:user/bob"),
             FetchedIdentity(identity_type=IdentityType.ROLE, name="DeveloperRole", external_id="arn:aws:iam::000000000000:role/DeveloperRole"),
             FetchedIdentity(identity_type=IdentityType.ROLE, name="ReadOnlyRole", external_id="arn:aws:iam::000000000000:role/ReadOnlyRole"),
+            # Identity Center (구 SSO) — Azure AD/Okta 등에서 federation으로 들어온 사람 식별자.
+            # principalId는 UUID, attributes에 display_name·email이 들어 있어 화면에서 사람 이름으로 보임.
+            FetchedIdentity(
+                identity_type=IdentityType.SSO_USER,
+                name="charlie@corp.com",
+                external_id="d4b86c70-1c4e-4a2b-9c5e-7a3f1e8d2c9b",
+                attributes={"display_name": "Charlie Kim", "email": "charlie@corp.com", "source": "identity_center"},
+            ),
+            FetchedIdentity(
+                identity_type=IdentityType.SSO_GROUP,
+                name="aws-platform-admins",
+                external_id="9b1f3d44-2e5a-4c0a-83a1-7b2c6f9d4e1a",
+                attributes={"display_name": "Platform Admins (Identity Center)", "source": "identity_center"},
+            ),
         ],
         permissions=[
             FetchedPermission(name="ReadOnlyAccess", external_id="arn:aws:iam::aws:policy/ReadOnlyAccess", risk_hint="read", description="모든 AWS 리소스 읽기"),

--- a/backend/app/models/iam.py
+++ b/backend/app/models/iam.py
@@ -63,6 +63,10 @@ class IdentityType(str, enum.Enum):
     ROLE = "role"
     SERVICE_ACCOUNT = "service_account"
     GROUP = "group"
+    # AWS IAM Identity Center (구 SSO) — federated user / group.
+    # Azure AD / Entra ID 계열, Okta SCIM 동기화 등 다양한 외부 IdP에서 import된 식별자.
+    SSO_USER = "sso_user"
+    SSO_GROUP = "sso_group"
 
 
 class IAMIdentity(Base, TimestampMixin):

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -363,7 +363,14 @@ export const en: Dict = {
       deny: "Deny",
     },
     riskLevels: { critical: "Critical", high: "High", medium: "Medium", low: "Low" },
-    identityTypes: { user: "User", role: "Role", service_account: "Service account", group: "Group" },
+    identityTypes: {
+      user: "User",
+      role: "Role",
+      service_account: "Service account",
+      group: "Group",
+      sso_user: "SSO user",
+      sso_group: "SSO group",
+    },
   },
 
   settings: {

--- a/frontend/src/i18n/ko.ts
+++ b/frontend/src/i18n/ko.ts
@@ -308,7 +308,8 @@ export const ko = {
     accessCenterDesc:
       "필요한 IAM 권한을 신청하면 Claude가 1차로 위험을 평가하고, 필요 시 보안 담당자가 승인합니다.",
     iamExplorerTitle: "IAM 탐색",
-    iamExplorerDesc: "가져온 IAM 사용자/역할과 부여 가능한 권한을 둘러봅니다.",
+    iamExplorerDesc:
+      "회사 IAM·SSO·디렉토리에서 가져온 계정(Identity)과 신청 가능한 권한(Permission)을 한 곳에서 봅니다. 필요한 권한을 찾으면 옆의 '권한 요청' 버튼으로 바로 신청하세요.",
     accessReviewTitle: "권한 검토",
     accessReviewDesc: "AI가 담당자 검토로 넘긴 요청을 보안 담당자가 승인/거부합니다.",
     fields: {
@@ -362,7 +363,14 @@ export const ko = {
       deny: "거부",
     },
     riskLevels: { critical: "치명적", high: "높음", medium: "중간", low: "낮음" },
-    identityTypes: { user: "사용자", role: "역할", service_account: "서비스 계정", group: "그룹" },
+    identityTypes: {
+      user: "사용자",
+      role: "역할",
+      service_account: "서비스 계정",
+      group: "그룹",
+      sso_user: "SSO 사용자",
+      sso_group: "SSO 그룹",
+    },
   },
 
   settings: {

--- a/frontend/src/lib/iam-api.ts
+++ b/frontend/src/lib/iam-api.ts
@@ -14,7 +14,13 @@ export interface IAMCapability {
   revoke: boolean;
   note: string;
 }
-export type IdentityType = "user" | "role" | "service_account" | "group";
+export type IdentityType =
+  | "user"
+  | "role"
+  | "service_account"
+  | "group"
+  | "sso_user"
+  | "sso_group";
 export type AccessRequestStatus =
   | "pending_ai_review"
   | "ai_auto_approved"

--- a/frontend/src/lib/iam-display.test.ts
+++ b/frontend/src/lib/iam-display.test.ts
@@ -1,0 +1,83 @@
+/**
+ * iam-display 헬퍼 테스트 — Vitest 환경이 없어도 import 검증 + 휴리스틱 동작.
+ *
+ * 현재 frontend는 별도 unit runner를 운영하지 않습니다. 이 파일은
+ * vite build에 포함되지 않도록 `.test.ts` 컨벤션만 유지하고, 실제 검증은
+ * 로컬에서 `vitest`를 띄울 때 수행됩니다. CI에서 깨지지 않도록 module-level
+ * side effect 없음.
+ */
+
+import { identityDisplay, permissionDisplay } from "./iam-display";
+import type { IAMIdentity, PermissionRow } from "./iam-api";
+
+const _expect = (label: string, got: unknown, want: unknown) => {
+  // eslint-disable-next-line no-console
+  if (JSON.stringify(got) !== JSON.stringify(want)) console.error(`FAIL ${label}: got=${JSON.stringify(got)} want=${JSON.stringify(want)}`);
+};
+
+export function runIamDisplayChecks(): void {
+  // ARN → role name 추출
+  const r1 = identityDisplay({
+    id: 1, source_id: 1, identity_type: "role",
+    name: "DeveloperRole",
+    external_id: "arn:aws:iam::000000000000:role/DeveloperRole",
+    attributes: {},
+  } satisfies IAMIdentity);
+  _expect("arn role tail", r1.primary, "DeveloperRole");
+
+  // Identity Center SSO_USER with display_name
+  const r2 = identityDisplay({
+    id: 2, source_id: 1, identity_type: "sso_user",
+    name: "charlie@corp.com",
+    external_id: "d4b86c70-1c4e-4a2b-9c5e-7a3f1e8d2c9b",
+    attributes: { display_name: "Charlie Kim", email: "charlie@corp.com" },
+  });
+  _expect("sso display_name wins", r2.primary, "Charlie Kim");
+
+  // UUID without display_name → short
+  const r3 = identityDisplay({
+    id: 3, source_id: 1, identity_type: "user",
+    name: "00000000-0000-0000-0000-000000000001",
+    external_id: "00000000-0000-0000-0000-000000000001",
+    attributes: {},
+  });
+  _expect("uuid short", r3.primary, "…000001");
+
+  // LDAP DN → CN value
+  const r4 = identityDisplay({
+    id: 4, source_id: 1, identity_type: "user",
+    name: "alice.kim",
+    external_id: "CN=Alice Kim,CN=Users,DC=corp,DC=local",
+    attributes: { mail: "alice@corp.local" },
+  });
+  _expect("ldap mail wins over CN", r4.primary, "alice@corp.local");
+
+  // GCP member prefix
+  const r5 = identityDisplay({
+    id: 5, source_id: 1, identity_type: "user",
+    name: "alice@corp.com",
+    external_id: "user:alice@corp.com",
+    attributes: {},
+  });
+  _expect("gcp member tail", r5.primary, "alice@corp.com");
+
+  // Permission ARN tail
+  const p1 = permissionDisplay({
+    id: 1, source_id: 1,
+    name: "ReadOnlyAccess",
+    external_id: "arn:aws:iam::aws:policy/ReadOnlyAccess",
+    description: null,
+    risk_hint: "read",
+  } as PermissionRow);
+  _expect("perm arn tail", p1.primary, "ReadOnlyAccess");
+
+  // GCP role
+  const p2 = permissionDisplay({
+    id: 2, source_id: 1,
+    name: "roles/owner",
+    external_id: "roles/owner",
+    description: null,
+    risk_hint: "admin",
+  } as PermissionRow);
+  _expect("gcp role kept", p2.primary, "roles/owner");
+}

--- a/frontend/src/lib/iam-display.ts
+++ b/frontend/src/lib/iam-display.ts
@@ -1,0 +1,149 @@
+/**
+ * IAM Identity/Permission 표시용 헬퍼.
+ *
+ * 외부 시스템에서 import한 식별자는 UUID(`00000000-0000-0000-0000-000000000001`),
+ * ARN(`arn:aws:iam::123456789012:role/admin`), DN(`uid=alice,ou=people,...`) 같이
+ * 사람이 한눈에 알아보기 어렵습니다. 화면에는 의미 있는 짧은 이름을 강조하고
+ * 원본 식별자는 tooltip/보조 라인으로 보존합니다.
+ */
+
+import type { IAMIdentity, IdentityType, PermissionRow } from "@/lib/iam-api";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const ARN_RE = /^arn:(aws|aws-cn|aws-us-gov):/;
+const DN_RE = /^(cn|uid|ou|dc)=/i;
+
+export interface DisplayLine {
+  /** 큰 글씨로 보일 사람이 읽는 이름. */
+  primary: string;
+  /** 작은 글씨로 보일 부가 정보 (원본 ID · 출처 등). 없으면 undefined. */
+  secondary?: string;
+  /** tooltip에 보일 원본 전체 식별자. */
+  tooltip?: string;
+}
+
+/** ARN에서 마지막 `/` 또는 `:` 이후 토큰을 추출. */
+function tailOf(value: string): string {
+  const slash = value.lastIndexOf("/");
+  if (slash >= 0 && slash < value.length - 1) return value.slice(slash + 1);
+  const colon = value.lastIndexOf(":");
+  if (colon >= 0 && colon < value.length - 1) return value.slice(colon + 1);
+  return value;
+}
+
+/** UUID는 짧게(`…7e3a`) — 사람이 비교만 할 수 있게. */
+function shortUuid(uuid: string): string {
+  return `…${uuid.slice(-6)}`;
+}
+
+/** DN에서 RDN(`uid=alice`)을 뽑고 그 값(alice)만 반환. */
+function tailOfDn(dn: string): string {
+  const first = dn.split(",")[0] ?? dn;
+  const eq = first.indexOf("=");
+  return eq >= 0 ? first.slice(eq + 1).trim() : first.trim();
+}
+
+export function identityDisplay(i: IAMIdentity): DisplayLine {
+  // 사용자가 attributes.display_name 또는 attributes.email을 채워뒀다면 우선 사용
+  const attrs = (i.attributes ?? {}) as Record<string, unknown>;
+  const displayName =
+    (typeof attrs.display_name === "string" && attrs.display_name) ||
+    (typeof attrs.displayName === "string" && attrs.displayName) ||
+    (typeof attrs.email === "string" && attrs.email) ||
+    (typeof attrs.mail === "string" && attrs.mail) ||
+    null;
+
+  const raw = (i.external_id || i.name || "").trim();
+
+  if (displayName) {
+    return { primary: displayName, secondary: raw || undefined, tooltip: raw || undefined };
+  }
+
+  // ARN
+  if (ARN_RE.test(raw)) {
+    const tail = tailOf(raw);
+    return { primary: tail || raw, secondary: raw, tooltip: raw };
+  }
+
+  // GCP member 표기(`user:alice@corp.com` 등) — prefix는 type tag로 흡수, 뒷부분만
+  const colon = raw.indexOf(":");
+  if (colon > 0 && colon < 20 && raw.length > colon + 1 && !raw.startsWith("arn:")) {
+    const head = raw.slice(0, colon).toLowerCase();
+    const tail = raw.slice(colon + 1);
+    if (["user", "group", "serviceaccount", "domain"].includes(head)) {
+      return { primary: tail, secondary: raw, tooltip: raw };
+    }
+  }
+
+  // LDAP DN
+  if (DN_RE.test(raw)) {
+    return { primary: tailOfDn(raw), secondary: raw, tooltip: raw };
+  }
+
+  // UUID — Azure AD object id / Identity Center principalId 등
+  if (UUID_RE.test(raw)) {
+    return {
+      primary: i.name && i.name !== raw ? i.name : shortUuid(raw),
+      secondary: raw,
+      tooltip: raw,
+    };
+  }
+
+  // 그 외 — 이름을 그대로
+  return {
+    primary: i.name || raw || "(unnamed)",
+    secondary: raw !== i.name ? raw : undefined,
+    tooltip: raw || undefined,
+  };
+}
+
+export function permissionDisplay(p: PermissionRow): DisplayLine {
+  const raw = (p.external_id || p.name || "").trim();
+
+  // ARN
+  if (ARN_RE.test(raw)) {
+    return { primary: tailOf(raw), secondary: raw, tooltip: raw };
+  }
+
+  // GCP roles/owner 처럼 짧은 식별자는 그대로
+  if (raw.startsWith("roles/")) {
+    return { primary: raw, tooltip: raw };
+  }
+
+  // Azure roleDefinition path
+  if (raw.includes("/providers/Microsoft.Authorization/roleDefinitions/")) {
+    return { primary: p.name || tailOf(raw), secondary: raw, tooltip: raw };
+  }
+
+  return {
+    primary: p.name || raw || "(unnamed)",
+    secondary: raw !== p.name ? raw : undefined,
+    tooltip: raw || undefined,
+  };
+}
+
+export const IDENTITY_TYPE_COLOR: Record<IdentityType, string> = {
+  user: "blue",
+  role: "geekblue",
+  service_account: "purple",
+  group: "cyan",
+  sso_user: "magenta",
+  sso_group: "magenta",
+};
+
+/** 검색 텍스트가 identity의 어느 필드에든 포함되는지 (대소문자 무시). */
+export function identityMatches(i: IAMIdentity, q: string): boolean {
+  if (!q) return true;
+  const needle = q.toLowerCase();
+  return [i.name, i.external_id, JSON.stringify(i.attributes ?? {})]
+    .filter(Boolean)
+    .some((s) => (s as string).toLowerCase().includes(needle));
+}
+
+export function permissionMatches(p: PermissionRow, q: string): boolean {
+  if (!q) return true;
+  const needle = q.toLowerCase();
+  return [p.name, p.external_id, p.description, p.risk_hint]
+    .filter(Boolean)
+    .some((s) => (s as string).toLowerCase().includes(needle));
+}

--- a/frontend/src/pages/AccessCenter.tsx
+++ b/frontend/src/pages/AccessCenter.tsx
@@ -26,6 +26,7 @@ import {
   Typography,
 } from "antd";
 import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
 import { useAuth } from "@/auth/AuthContext";
 import { useI18n } from "@/i18n";
@@ -57,13 +58,22 @@ const RISK_COLOR: Record<string, string> = {
   low: "green",
 };
 
-const TYPE_ORDER: IdentityType[] = ["user", "role", "service_account", "group"];
+const TYPE_ORDER: IdentityType[] = [
+  "user",
+  "sso_user",
+  "role",
+  "service_account",
+  "group",
+  "sso_group",
+];
 
 const TYPE_LABEL: Record<IdentityType, { ko: string; en: string }> = {
   user: { ko: "사용자", en: "Users" },
   role: { ko: "역할", en: "Roles" },
   service_account: { ko: "서비스 계정", en: "Service accounts" },
   group: { ko: "그룹", en: "Groups" },
+  sso_user: { ko: "SSO 사용자 (Identity Center 등)", en: "SSO users" },
+  sso_group: { ko: "SSO 그룹 (Identity Center 등)", en: "SSO groups" },
 };
 
 interface PreviewResp {
@@ -107,6 +117,31 @@ export default function AccessCenter() {
   useEffect(() => {
     if (user?.email) form.setFieldValue("requester", user.email);
   }, [user, form]);
+
+  // IAM Explorer의 "권한 요청" CTA에서 진입했을 때 URL 파라미터로 사전 채움
+  const [searchParams, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    const pid = Number(searchParams.get("permission_id"));
+    const sid = Number(searchParams.get("source_id"));
+    const iid = Number(searchParams.get("identity_id"));
+    let touched = false;
+    if (pid && Number.isFinite(pid)) {
+      setPermissionId(pid);
+      form.setFieldValue("permission", pid);
+      touched = true;
+    }
+    if (sid && Number.isFinite(sid)) {
+      setSourceFilter(sid);
+      touched = true;
+    }
+    if (iid && Number.isFinite(iid)) {
+      setIdentityId(iid);
+      form.setFieldValue("identity", iid);
+      touched = true;
+    }
+    if (touched) setSearchParams({}, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // source 필터에 따른 노출 목록
   const filteredIdentities = useMemo(

--- a/frontend/src/pages/IAMExplorer.tsx
+++ b/frontend/src/pages/IAMExplorer.tsx
@@ -1,11 +1,34 @@
 /**
- * IAM Explorer — Identities / Permissions 조회 (read-only).
- * 연동(Source) 추가/동기화는 관리자 모드 → 연동 관리로 분리.
+ * IAM Explorer — 가져온 Identity / Permission을 임직원이 알아보기 쉽게.
+ *
+ * 외부 시스템에서 import한 UUID·ARN·DN은 보조 정보로 두고, 사람이 읽는
+ * 이름을 강조합니다. Source 필터 + 검색 + Permission 인라인 "권한 요청" CTA로
+ * 신청 흐름을 1클릭에 연결합니다.
  */
 
-import { CloudDownloadOutlined } from "@ant-design/icons";
+import {
+  CloudDownloadOutlined,
+  PlusCircleOutlined,
+  SafetyCertificateOutlined,
+  SearchOutlined,
+} from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
-import { Card, Col, Row, Space, Table, Tag, Typography } from "antd";
+import {
+  Alert,
+  Card,
+  Col,
+  Empty,
+  Input,
+  Row,
+  Segmented,
+  Space,
+  Table,
+  Tag,
+  Tooltip,
+  Typography,
+} from "antd";
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 
 import { useI18n } from "@/i18n";
 import {
@@ -13,10 +36,18 @@ import {
   type IAMCapability,
   type IAMIdentity,
   type IAMSourceKind,
+  type IdentityType,
   type PermissionRow,
 } from "@/lib/iam-api";
+import {
+  IDENTITY_TYPE_COLOR,
+  identityDisplay,
+  identityMatches,
+  permissionDisplay,
+  permissionMatches,
+} from "@/lib/iam-display";
 
-const { Title, Paragraph } = Typography;
+const { Title, Paragraph, Text } = Typography;
 
 const RISK_COLOR: Record<string, string> = {
   admin: "red",
@@ -30,28 +61,62 @@ const STATUS_COLOR: Record<IAMCapability["status"], string> = {
   coming_soon: "default",
 };
 
-const STATUS_LABEL_KO: Record<IAMCapability["status"], string> = {
-  ready: "정상 동작",
-  demo: "데모 데이터만",
-  coming_soon: "곧 지원",
-};
-
-const STATUS_LABEL_EN: Record<IAMCapability["status"], string> = {
-  ready: "Ready",
-  demo: "Demo only",
-  coming_soon: "Coming soon",
-};
+const ALL = "__all__";
 
 export default function IAMExplorer() {
   const { t, locale } = useI18n();
 
   const { data: sources } = useQuery({ queryKey: ["iam-sources"], queryFn: iamApi.listSources });
-  const { data: identities } = useQuery({ queryKey: ["iam-identities"], queryFn: () => iamApi.listIdentities() });
-  const { data: permissions } = useQuery({ queryKey: ["iam-permissions"], queryFn: () => iamApi.listPermissions() });
-  const { data: capabilities } = useQuery({ queryKey: ["iam-capabilities"], queryFn: iamApi.capabilities });
+  const { data: identities } = useQuery({
+    queryKey: ["iam-identities"],
+    queryFn: () => iamApi.listIdentities(),
+  });
+  const { data: permissions } = useQuery({
+    queryKey: ["iam-permissions"],
+    queryFn: () => iamApi.listPermissions(),
+  });
+  const { data: capabilities } = useQuery({
+    queryKey: ["iam-capabilities"],
+    queryFn: iamApi.capabilities,
+  });
+
+  const [sourceFilter, setSourceFilter] = useState<string>(ALL);
+  const [query, setQuery] = useState("");
 
   const capByKind = (k: IAMSourceKind): IAMCapability | undefined =>
     (capabilities ?? []).find((c) => c.kind === k);
+
+  const sourceById = useMemo(() => {
+    const m = new Map<number, { name: string; kind: IAMSourceKind }>();
+    for (const s of sources ?? []) m.set(s.id, { name: s.name, kind: s.kind });
+    return m;
+  }, [sources]);
+
+  const filteredIdentities = useMemo(() => {
+    return (identities ?? [])
+      .filter((i) => sourceFilter === ALL || String(i.source_id) === sourceFilter)
+      .filter((i) => identityMatches(i, query));
+  }, [identities, sourceFilter, query]);
+
+  const filteredPermissions = useMemo(() => {
+    return (permissions ?? [])
+      .filter((p) => sourceFilter === ALL || String(p.source_id) === sourceFilter)
+      .filter((p) => permissionMatches(p, query));
+  }, [permissions, sourceFilter, query]);
+
+  const sourceOptions = useMemo(() => {
+    const all = { label: locale === "ko" ? `전체 (${sources?.length ?? 0})` : `All (${sources?.length ?? 0})`, value: ALL };
+    const items = (sources ?? []).map((s) => ({
+      label: (
+        <Space size={4}>
+          <Text strong>{s.name}</Text>
+          <Tag style={{ marginInlineEnd: 0 }}>{s.kind.toUpperCase()}</Tag>
+        </Space>
+      ),
+      value: String(s.id),
+    }));
+    return [all, ...items];
+  }, [sources, locale]);
 
   return (
     <div>
@@ -60,7 +125,32 @@ export default function IAMExplorer() {
       </Title>
       <Paragraph type="secondary">{t.iam.iamExplorerDesc}</Paragraph>
 
-      <Card title="Sources" style={{ marginTop: 12 }}>
+      {/* 상단 필터 — 소스 segment + 검색 박스 */}
+      <Card style={{ marginBottom: 12 }} styles={{ body: { paddingBlock: 12 } }}>
+        <Space direction="vertical" size={8} style={{ width: "100%" }}>
+          <div style={{ overflowX: "auto" }}>
+            <Segmented
+              value={sourceFilter}
+              onChange={(v) => setSourceFilter(String(v))}
+              options={sourceOptions}
+            />
+          </div>
+          <Input
+            allowClear
+            prefix={<SearchOutlined />}
+            placeholder={
+              locale === "ko"
+                ? "이름·ARN·이메일·역할 검색"
+                : "Search by name, ARN, email, role"
+            }
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </Space>
+      </Card>
+
+      {/* Sources 요약 — 정상 동작 여부와 마지막 동기화 시각 */}
+      <Card title={locale === "ko" ? "연결된 IAM 소스" : "Connected IAM sources"} style={{ marginBottom: 16 }}>
         <Table
           dataSource={sources ?? []}
           rowKey="id"
@@ -80,61 +170,209 @@ export default function IAMExplorer() {
                     <Tag>{k.toUpperCase()}</Tag>
                     {cap && (
                       <Tag color={STATUS_COLOR[cap.status]}>
-                        {locale === "ko" ? STATUS_LABEL_KO[cap.status] : STATUS_LABEL_EN[cap.status]}
+                        {locale === "ko"
+                          ? cap.status === "ready"
+                            ? "정상 동작"
+                            : cap.status === "demo"
+                              ? "데모"
+                              : "준비 중"
+                          : cap.status}
                       </Tag>
                     )}
                   </Space>
                 );
               },
             },
-            { title: "last sync", dataIndex: "last_synced_at_str", render: (v: string | null) => v || "—" },
+            {
+              title: locale === "ko" ? "마지막 동기화" : "Last sync",
+              dataIndex: "last_synced_at_str",
+              render: (v: string | null) => v || "—",
+            },
           ]}
         />
       </Card>
 
-      <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
+      <Row gutter={[16, 16]}>
         <Col xs={24} lg={12}>
-          <Card title="Identities" extra={<Tag icon={<CloudDownloadOutlined />}>{identities?.length ?? 0}</Tag>}>
-            <Table
-              dataSource={identities ?? []}
-              rowKey="id"
-              size="small"
-              pagination={{ pageSize: 8 }}
-              columns={[
-                { title: t.iam.fields.identity, dataIndex: "name" },
-                {
-                  title: t.iam.fields.type,
-                  dataIndex: "identity_type",
-                  render: (v: IAMIdentity["identity_type"]) => <Tag>{t.iam.identityTypes[v]}</Tag>,
-                  width: 110,
-                },
-                { title: t.iam.fields.externalId, dataIndex: "external_id", ellipsis: true },
-              ]}
-            />
-          </Card>
+          <IdentityCard
+            identities={filteredIdentities}
+            sourceById={sourceById}
+            locale={locale}
+            t={t}
+          />
         </Col>
         <Col xs={24} lg={12}>
-          <Card title="Permissions" extra={<Tag>{permissions?.length ?? 0}</Tag>}>
-            <Table
-              dataSource={permissions ?? []}
-              rowKey="id"
-              size="small"
-              pagination={{ pageSize: 8 }}
-              columns={[
-                { title: t.iam.fields.permission, dataIndex: "name" },
-                {
-                  title: t.iam.fields.risk,
-                  dataIndex: "risk_hint",
-                  width: 110,
-                  render: (v: PermissionRow["risk_hint"]) =>
-                    v ? <Tag color={RISK_COLOR[v] ?? "default"}>{v.toUpperCase()}</Tag> : "—",
-                },
-                { title: t.iam.fields.externalId, dataIndex: "external_id", ellipsis: true },
-              ]}
-            />
-          </Card>
+          <PermissionCard
+            permissions={filteredPermissions}
+            sourceById={sourceById}
+            locale={locale}
+          />
         </Col>
       </Row>
+
+      <Alert
+        type="info"
+        showIcon
+        style={{ marginTop: 16 }}
+        message={
+          locale === "ko"
+            ? "외부 시스템(AWS · Azure · GCP · Kubernetes · 사내 LDAP/AD)에서 가져온 ARN·UUID·DN은 짧은 이름으로 보여주고, 원본 ID는 그 아래 회색으로 표기합니다. 짧은 이름에 마우스를 올리면 전체 ID가 나옵니다. AWS IAM Identity Center · Azure AD · Google Workspace 등 SSO로 들어온 사람은 자홍색 'SSO' 태그로 구분합니다."
+            : "External system identifiers (ARN / UUID / DN from AWS · Azure · GCP · Kubernetes · LDAP) are shown as short names; the full ID is the gray line below. Hover the short name for the full ID. Federated identities imported from AWS IAM Identity Center / Azure AD / Google Workspace SSO carry a magenta 'SSO' tag."
+        }
+      />
     </div>
+  );
+}
+
+function IdentityCard({
+  identities,
+  sourceById,
+  locale,
+  t,
+}: {
+  identities: IAMIdentity[];
+  sourceById: Map<number, { name: string; kind: IAMSourceKind }>;
+  locale: "ko" | "en";
+  t: ReturnType<typeof useI18n>["t"];
+}) {
+  return (
+    <Card
+      title={
+        <Space>
+          <CloudDownloadOutlined />
+          <span>{locale === "ko" ? "Identity (사용자·역할·서비스 계정·그룹)" : "Identities"}</span>
+        </Space>
+      }
+      extra={<Tag color="cyan">{identities.length}</Tag>}
+    >
+      <Table
+        dataSource={identities}
+        rowKey="id"
+        size="small"
+        pagination={{ pageSize: 8, showSizeChanger: false }}
+        locale={{ emptyText: <Empty description={locale === "ko" ? "검색 결과 없음" : "No matches"} /> }}
+        columns={[
+          {
+            title: locale === "ko" ? "이름" : "Name",
+            key: "name",
+            render: (_, i) => {
+              const d = identityDisplay(i);
+              const src = sourceById.get(i.source_id);
+              const isSso = i.identity_type === "sso_user" || i.identity_type === "sso_group";
+              return (
+                <Space direction="vertical" size={0} style={{ width: "100%" }}>
+                  <Space size={6} wrap>
+                    <Tooltip title={d.tooltip}>
+                      <Text strong style={{ fontSize: 14 }}>{d.primary}</Text>
+                    </Tooltip>
+                    <Tag color={IDENTITY_TYPE_COLOR[i.identity_type as IdentityType]}>
+                      {t.iam.identityTypes[i.identity_type as IdentityType]}
+                    </Tag>
+                    {isSso && <Tag color="magenta">SSO</Tag>}
+                    {src && (
+                      <Tag style={{ marginInlineEnd: 0 }}>
+                        {src.kind.toUpperCase()} · {src.name}
+                      </Tag>
+                    )}
+                  </Space>
+                  {d.secondary && (
+                    <Text type="secondary" style={{ fontSize: 12, fontFamily: "var(--mond-font-mono, monospace)" }} ellipsis>
+                      {d.secondary}
+                    </Text>
+                  )}
+                </Space>
+              );
+            },
+          },
+        ]}
+      />
+    </Card>
+  );
+}
+
+function PermissionCard({
+  permissions,
+  sourceById,
+  locale,
+}: {
+  permissions: PermissionRow[];
+  sourceById: Map<number, { name: string; kind: IAMSourceKind }>;
+  locale: "ko" | "en";
+}) {
+  return (
+    <Card
+      title={
+        <Space>
+          <SafetyCertificateOutlined />
+          <span>{locale === "ko" ? "권한 (요청 가능한 단위)" : "Permissions"}</span>
+        </Space>
+      }
+      extra={<Tag color="cyan">{permissions.length}</Tag>}
+    >
+      <Table
+        dataSource={permissions}
+        rowKey="id"
+        size="small"
+        pagination={{ pageSize: 8, showSizeChanger: false }}
+        locale={{ emptyText: <Empty description={locale === "ko" ? "검색 결과 없음" : "No matches"} /> }}
+        columns={[
+          {
+            title: locale === "ko" ? "권한 이름" : "Permission",
+            key: "name",
+            render: (_, p) => {
+              const d = permissionDisplay(p);
+              const src = sourceById.get(p.source_id);
+              return (
+                <Space direction="vertical" size={0} style={{ width: "100%" }}>
+                  <Space size={6} wrap>
+                    <Tooltip title={d.tooltip}>
+                      <Text strong style={{ fontSize: 14 }}>{d.primary}</Text>
+                    </Tooltip>
+                    {p.risk_hint && (
+                      <Tag color={RISK_COLOR[p.risk_hint] ?? "default"}>
+                        {p.risk_hint.toUpperCase()}
+                      </Tag>
+                    )}
+                    {src && (
+                      <Tag style={{ marginInlineEnd: 0 }}>
+                        {src.kind.toUpperCase()} · {src.name}
+                      </Tag>
+                    )}
+                  </Space>
+                  {p.description && (
+                    <Text type="secondary" style={{ fontSize: 12 }} ellipsis>
+                      {p.description}
+                    </Text>
+                  )}
+                  {d.secondary && (
+                    <Text type="secondary" style={{ fontSize: 12, fontFamily: "var(--mond-font-mono, monospace)" }} ellipsis>
+                      {d.secondary}
+                    </Text>
+                  )}
+                </Space>
+              );
+            },
+          },
+          {
+            title: "",
+            key: "action",
+            width: 110,
+            render: (_, p) => (
+              <Link to={`/access-center?permission_id=${p.id}&source_id=${p.source_id}`}>
+                <Tooltip title={locale === "ko" ? "이 권한을 신청합니다" : "Request this permission"}>
+                  <Tag
+                    color="blue"
+                    style={{ cursor: "pointer", marginInlineEnd: 0 }}
+                    icon={<PlusCircleOutlined />}
+                  >
+                    {locale === "ko" ? "권한 요청" : "Request"}
+                  </Tag>
+                </Tooltip>
+              </Link>
+            ),
+          },
+        ]}
+      />
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
외부 시스템에서 가져온 ARN·UUID·LDAP DN이 임직원에게 '이게 누구·무엇인지' 한눈에 안 보이는 문제 + Identity Center(구 AWS SSO)에서 federated된 사용자/그룹이 일반 IAM과 섞여 있는 문제 해소.

## 변경
### Backend
- `IdentityType.SSO_USER` · `SSO_GROUP` 추가 (Identity Center · Azure AD · Okta SCIM 등 외부 IdP federation 식별용)
- AWS provider stub에 Identity Center 샘플 2건 + `display_name`/`email` attributes

### Frontend
- `lib/iam-display.ts` 신규 — `identityDisplay`/`permissionDisplay` 헬퍼
  - `attributes.display_name/displayName/email/mail` 우선
  - ARN tail / GCP member prefix / UUID 짧은 표기 / LDAP DN RDN 추출
- `pages/IAMExplorer.tsx` 전면 재작성
  - 상단: Source segmented filter + 통합 검색 박스
  - Identity/Permission 카드는 2-line row — 사람이 읽는 이름(strong) + type/SSO/소스 태그 + 원본 ID(monospace 회색)
  - Permission 행에 inline **권한 요청** CTA → `/access-center?permission_id=...`
  - 하단 Alert: 식별자 의미 + SSO 태그 가이드 (한·영)
- `pages/AccessCenter.tsx` — URL 파라미터로 진입 시 자동 채움. SSO type 그룹 라벨 추가
- i18n — `identityTypes`에 sso_user/sso_group + 친화적인 `iamExplorerDesc`

## Test plan
- [x] frontend vite build clean
- [x] backend ruff clean
- [x] 로컬: `Charlie` 검색 → LDAP `charlie@corp.local` + Identity Center `Charlie Kim` 동시 노출 (display_name이 UUID 이김)
- [x] Permission 인라인 '권한 요청' → `/access-center` 자동 채움
- [ ] CI 통과