### PR TITLE
chore(deps): pytest 8.4.2 + pytest-asyncio 1.4.0 동반 bump

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -66,7 +66,7 @@ structlog==24.4.0
 prometheus-client==0.25.0
 
 # 개발 / 테스트
-pytest==8.3.4
-pytest-asyncio==0.24.0
+pytest==8.4.2
+pytest-asyncio==1.4.0
 black==24.10.0
 ruff==0.15.17


### PR DESCRIPTION
## Summary
Dependabot PR #25(`pytest-asyncio 0.24→1.4`)가 `pytest<10 and >=8.4` 요구로 CI에서 dependency resolution 실패. `pytest`를 8.4.2로 함께 올려 해결.

#25는 머지 후 dependabot이 superseded 처리.

## Test plan
- [x] 로컬 backend pytest 48/48 통과
- [ ] CI Backend pytest 통과