### PR TITLE
feat(access-review): 보안 담당자 검토 UX 가시화

### DIFF
--- a/frontend/src/pages/AccessCenter.tsx
+++ b/frontend/src/pages/AccessCenter.tsx
@@ -521,7 +521,18 @@ export default function AccessCenter() {
             {
               title: t.iam.fields.identity,
               dataIndex: "target_identity_id",
-              render: (id: number) => identities?.find((x) => x.id === id)?.name ?? id,
+              render: (id: number) => {
+                const i = identities?.find((x) => x.id === id);
+                if (!i) return id;
+                const d = identityDisplay(i);
+                const src = sourceById.get(i.source_id);
+                return (
+                  <Space size={4} wrap>
+                    <Text strong>{d.primary}</Text>
+                    {src && <Tag style={{ marginInlineEnd: 0, fontSize: 11 }}>{src.kind.toUpperCase()}</Tag>}
+                  </Space>
+                );
+              },
             },
             {
               title: t.iam.fields.permission,
@@ -529,14 +540,17 @@ export default function AccessCenter() {
               render: (id: number) => {
                 const p = permissions?.find((x) => x.id === id);
                 if (!p) return id;
+                const d = permissionDisplay(p);
+                const src = sourceById.get(p.source_id);
                 return (
-                  <Space size={4}>
+                  <Space size={4} wrap>
                     {p.risk_hint && (
-                      <Tag color={RISK_COLOR[p.risk_hint]} style={{ marginRight: 0 }}>
-                        {p.risk_hint}
+                      <Tag color={RISK_COLOR[p.risk_hint]} style={{ marginInlineEnd: 0 }}>
+                        {p.risk_hint.toUpperCase()}
                       </Tag>
                     )}
-                    <span>{p.name}</span>
+                    <Text strong>{d.primary}</Text>
+                    {src && <Tag style={{ marginInlineEnd: 0, fontSize: 11 }}>{src.kind.toUpperCase()}</Tag>}
                   </Space>
                 );
               },

--- a/frontend/src/pages/AccessReview.tsx
+++ b/frontend/src/pages/AccessReview.tsx
@@ -1,16 +1,41 @@
 /**
- * Access Review — 보안 담당자가 AI가 담당자 검토로 넘긴 요청을 처리한다
+ * Access Review — 보안 담당자가 AI 1차 검토를 통과 못한 요청을 처리한다.
+ *
+ * 가시화 원칙:
+ *   - identity / permission은 readable name + 원본 ID(monospace 보조)
+ *   - AI 결정(verdict + risk + reason)을 카드처럼 강조
+ *   - critical / high 위험은 행 좌측 색띠로 즉시 인지
  */
 
-import { CheckOutlined, CloseOutlined, ClockCircleOutlined } from "@ant-design/icons";
+import {
+  CheckOutlined,
+  ClockCircleOutlined,
+  CloseOutlined,
+  RobotOutlined,
+} from "@ant-design/icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Alert, Button, Card, Form, Input, Modal, Space, Table, Tag, Typography, message } from "antd";
-import { useState } from "react";
+import {
+  Alert,
+  Button,
+  Card,
+  Empty,
+  Form,
+  Input,
+  Modal,
+  Space,
+  Table,
+  Tag,
+  Tooltip,
+  Typography,
+  message,
+} from "antd";
+import { useMemo, useState } from "react";
 
 import { useI18n } from "@/i18n";
-import { iamApi, type AccessRequest } from "@/lib/iam-api";
+import { iamApi, type AccessRequest, type IAMSourceKind } from "@/lib/iam-api";
+import { identityDisplay, permissionDisplay } from "@/lib/iam-display";
 
-const { Title, Paragraph } = Typography;
+const { Title, Paragraph, Text } = Typography;
 
 const RISK_COLOR: Record<string, string> = {
   critical: "red",
@@ -19,18 +44,37 @@ const RISK_COLOR: Record<string, string> = {
   low: "green",
 };
 
+const DECISION_COLOR: Record<string, string> = {
+  auto_approve: "green",
+  needs_human: "gold",
+  deny: "red",
+};
+
 export default function AccessReview() {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const qc = useQueryClient();
   const [decisionFor, setDecisionFor] = useState<{ req: AccessRequest; approve: boolean } | null>(null);
   const [form] = Form.useForm();
 
-  const { data: identities } = useQuery({ queryKey: ["iam-identities"], queryFn: () => iamApi.listIdentities() });
-  const { data: permissions } = useQuery({ queryKey: ["iam-permissions"], queryFn: () => iamApi.listPermissions() });
+  const { data: sources } = useQuery({ queryKey: ["iam-sources"], queryFn: iamApi.listSources });
+  const { data: identities } = useQuery({
+    queryKey: ["iam-identities"],
+    queryFn: () => iamApi.listIdentities(),
+  });
+  const { data: permissions } = useQuery({
+    queryKey: ["iam-permissions"],
+    queryFn: () => iamApi.listPermissions(),
+  });
   const { data: queue } = useQuery({
     queryKey: ["access-requests", "needs_human_review"],
     queryFn: () => iamApi.listRequests("needs_human_review"),
   });
+
+  const sourceById = useMemo(() => {
+    const m = new Map<number, { name: string; kind: IAMSourceKind }>();
+    for (const s of sources ?? []) m.set(s.id, { name: s.name, kind: s.kind });
+    return m;
+  }, [sources]);
 
   const decide = useMutation({
     mutationFn: ({ id, approve, reviewer, note }: { id: number; approve: boolean; reviewer: string; note?: string }) =>
@@ -68,42 +112,133 @@ export default function AccessReview() {
       <Paragraph type="secondary">{t.iam.accessReviewDesc}</Paragraph>
 
       <Card style={{ marginTop: 12 }}>
-        {(queue ?? []).length === 0 && (
+        {(queue ?? []).length === 0 ? (
+          <Empty
+            description={
+              <Space direction="vertical" align="center" size={4}>
+                <Text strong>
+                  {locale === "ko" ? "검토 대기 중인 요청이 없습니다" : "No requests waiting for review"}
+                </Text>
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  {locale === "ko"
+                    ? "AI가 자동 승인했거나 위험이 낮아 사람 검토가 불필요했던 건들은 권한 요청 페이지의 '내 요청' 또는 감사 로그에서 볼 수 있습니다."
+                    : "Items auto-approved by AI or low-risk requests are visible under '내 요청' or the audit log."}
+                </Text>
+              </Space>
+            }
+          />
+        ) : (
           <Alert
-            type="success"
+            type="warning"
             showIcon
+            style={{ marginBottom: 12 }}
             message={
-              t.iam.accessReviewTitle === "Access Review"
-                ? "No requests waiting for review."
-                : "검토 대기 중인 요청이 없습니다."
+              locale === "ko"
+                ? `${(queue ?? []).length}건이 사람 검토를 기다리고 있습니다. AI가 자동 결정하지 못한 회색지대 — 사유와 위험도를 확인하고 승인/거부하세요.`
+                : `${(queue ?? []).length} request(s) are waiting for human review.`
             }
           />
         )}
+
         <Table
           dataSource={queue ?? []}
           rowKey="id"
           size="small"
           pagination={false}
+          rowClassName={(r) => {
+            const risk = r.ai_decision.risk_level;
+            if (risk === "critical") return "mond-row-critical";
+            if (risk === "high") return "mond-row-high";
+            return "";
+          }}
           columns={[
             { title: "#", dataIndex: "id", width: 60 },
-            { title: t.iam.fields.requester, dataIndex: "requester" },
+            { title: t.iam.fields.requester, dataIndex: "requester", width: 200 },
             {
               title: t.iam.fields.identity,
               dataIndex: "target_identity_id",
-              render: (id: number) => identities?.find((x) => x.id === id)?.name ?? id,
+              render: (id: number) => {
+                const i = identities?.find((x) => x.id === id);
+                if (!i) return id;
+                const d = identityDisplay(i);
+                const src = sourceById.get(i.source_id);
+                const isSso = i.identity_type === "sso_user" || i.identity_type === "sso_group";
+                return (
+                  <Space direction="vertical" size={0}>
+                    <Space size={4} wrap>
+                      <Tooltip title={d.tooltip}>
+                        <Text strong>{d.primary}</Text>
+                      </Tooltip>
+                      {isSso && <Tag color="magenta" style={{ marginInlineEnd: 0 }}>SSO</Tag>}
+                      {src && <Tag style={{ marginInlineEnd: 0, fontSize: 11 }}>{src.kind.toUpperCase()}</Tag>}
+                    </Space>
+                    {d.secondary && (
+                      <Text type="secondary" style={{ fontSize: 11, fontFamily: "var(--mond-font-mono, monospace)" }} ellipsis>
+                        {d.secondary}
+                      </Text>
+                    )}
+                  </Space>
+                );
+              },
             },
             {
               title: t.iam.fields.permission,
               dataIndex: "permission_id",
-              render: (id: number) => permissions?.find((x) => x.id === id)?.name ?? id,
+              render: (id: number) => {
+                const p = permissions?.find((x) => x.id === id);
+                if (!p) return id;
+                const d = permissionDisplay(p);
+                const src = sourceById.get(p.source_id);
+                return (
+                  <Space direction="vertical" size={0}>
+                    <Space size={4} wrap>
+                      <Tooltip title={d.tooltip}>
+                        <Text strong>{d.primary}</Text>
+                      </Tooltip>
+                      {p.risk_hint && (
+                        <Tag color={RISK_COLOR[p.risk_hint] ?? "default"} style={{ marginInlineEnd: 0 }}>
+                          {p.risk_hint.toUpperCase()}
+                        </Tag>
+                      )}
+                      {src && <Tag style={{ marginInlineEnd: 0, fontSize: 11 }}>{src.kind.toUpperCase()}</Tag>}
+                    </Space>
+                    {p.description && (
+                      <Text type="secondary" style={{ fontSize: 11 }} ellipsis>
+                        {p.description}
+                      </Text>
+                    )}
+                  </Space>
+                );
+              },
             },
             {
-              title: t.iam.aiDecision,
+              title: (
+                <Space size={4}>
+                  <RobotOutlined />
+                  <span>{t.iam.aiDecision}</span>
+                </Space>
+              ),
               dataIndex: "ai_decision",
+              width: 240,
               render: (ai: AccessRequest["ai_decision"]) => (
-                <Space direction="vertical" size={2}>
-                  <Tag color={RISK_COLOR[ai.risk_level ?? "medium"]}>risk: {ai.risk_level}</Tag>
-                  <span style={{ fontSize: 12, color: "var(--mond-text-dim)" }}>{ai.reason}</span>
+                <Space direction="vertical" size={2} style={{ width: "100%" }}>
+                  <Space size={4} wrap>
+                    {ai.decision && (
+                      <Tag color={DECISION_COLOR[ai.decision as string] ?? "default"} style={{ marginInlineEnd: 0 }}>
+                        {t.iam.decisions[ai.decision as keyof typeof t.iam.decisions] ?? ai.decision}
+                      </Tag>
+                    )}
+                    {ai.risk_level && (
+                      <Tag color={RISK_COLOR[ai.risk_level as string] ?? "default"} style={{ marginInlineEnd: 0 }}>
+                        {locale === "ko" ? "위험" : "risk"}: {ai.risk_level}
+                      </Tag>
+                    )}
+                  </Space>
+                  {ai.reason && (
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      {ai.reason}
+                    </Text>
+                  )}
                 </Space>
               ),
             },
@@ -162,7 +297,7 @@ export default function AccessReview() {
           <Form.Item label={t.iam.fields.note} name="note">
             <Input.TextArea
               rows={3}
-              placeholder={t.iam.accessReviewTitle === "Access Review" ? "Reason" : "결정 이유"}
+              placeholder={locale === "ko" ? "결정 이유" : "Reason"}
             />
           </Form.Item>
         </Form>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -268,3 +268,11 @@ a:hover {
   .mond-tagline-long { display: none !important; }
   .mond-user-name { display: none !important; }
 }
+
+/* AccessReview 위험도 행 강조 — critical 빨강, high 주황 좌측 경계 색띠. */
+.mond-row-critical td:first-child {
+  box-shadow: inset 3px 0 0 0 var(--severity-critical, #e8484a);
+}
+.mond-row-high td:first-child {
+  box-shadow: inset 3px 0 0 0 var(--severity-high, #f29142);
+}


### PR DESCRIPTION
## Summary
PR #61(IAM Explorer) + #62(Access Center 폼)에서 적용한 readable name + source tag + risk highlighting 톤을 권한 검토(`/admin/access-review`)에도 적용. 보안 담당자가 한 행에서 신청자·계정·권한·AI 판단·사유를 모두 한눈에.

## 변경
`AccessReview.tsx`:
- **Identity 컬럼** — strong name + SSO 자홍 태그 + source 태그 + 원본 ARN/UUID/DN (monospace)
- **Permission 컬럼** — strong name + risk 태그(ADMIN/WRITE/READ) + source 태그 + 설명
- **AI 1차 검토** — 결정(자동 승인/담당자 검토 필요/거부) + 위험도 태그 + AI reason 본문. `RobotOutlined` 아이콘
- **위험도 색띠** — `critical`/`high` 행은 좌측 3px inset box-shadow (`.mond-row-critical`/`mond-row-high`)
- 검토 대기 건수 있으면 상단 warning Alert로 `'N건이 대기'`
- 빈 상태 Empty + 안내문구

`AccessCenter.tsx` (내 요청 테이블):
- Identity/Permission 셀에 same 헬퍼 적용 (readable name + source 태그)

`global.css`:
- `.mond-row-critical` / `.mond-row-high` 좌측 색띠 클래스

## Test plan
- [x] 검토 대기 2건(charlie SSO ReadOnly + dave AdminAccess 1주일) 시드 후 시각 확인
- [x] Charlie Kim SSO 태그 + UUID monospace 정상
- [x] AdminAccess high risk 행 좌측 주황 색띠
- [x] AI reason 본문 표시
- [x] vite build clean
- [ ] CI 통과