### PR TITLE
feat(my-mond): 빈 상태 카드 친화화 + CTA

### DIFF
--- a/frontend/src/pages/MyMond.tsx
+++ b/frontend/src/pages/MyMond.tsx
@@ -131,7 +131,21 @@ export default function MyMond() {
             {(data?.my_assets?.length ?? 0) === 0 ? (
               <Empty
                 description={
-                  locale === "ko" ? "owner=내 이메일인 자산이 없습니다" : "No assets owned by you"
+                  <Space direction="vertical" align="center" size={4}>
+                    <Text strong>
+                      {locale === "ko" ? "담당 중인 자산이 없습니다" : "No assets owned by you"}
+                    </Text>
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      {locale === "ko"
+                        ? "자산의 owner 필드에 본인 이메일을 등록하면 이 카드에 표시됩니다."
+                        : "Set owner=your email on an asset to see it here."}
+                    </Text>
+                    <Link to="/assets">
+                      <Button size="small" type="primary">
+                        {locale === "ko" ? "자산 보기" : "View assets"}
+                      </Button>
+                    </Link>
+                  </Space>
                 }
               />
             ) : (
@@ -166,7 +180,20 @@ export default function MyMond() {
             style={{ marginBottom: 12 }}
           >
             {(data?.recent_findings?.length ?? 0) === 0 ? (
-              <Empty description={locale === "ko" ? "조용한 하루입니다" : "Quiet day"} />
+              <Empty
+                description={
+                  <Space direction="vertical" align="center" size={4}>
+                    <Text strong>
+                      {locale === "ko" ? "조용한 하루입니다" : "Quiet day"}
+                    </Text>
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      {locale === "ko"
+                        ? "본인이 owner인 자산에 새 발견사항이 생기면 여기에 표시됩니다."
+                        : "Findings on assets you own will appear here."}
+                    </Text>
+                  </Space>
+                }
+              />
             ) : (
               <List
                 size="small"
@@ -192,7 +219,20 @@ export default function MyMond() {
             extra={<Link to="/access-center">{locale === "ko" ? "갱신 요청" : "Renew"}</Link>}
           >
             {(data?.expiring_soon?.length ?? 0) === 0 ? (
-              <Empty description={locale === "ko" ? "임박한 만료 없음" : "Nothing expiring soon"} />
+              <Empty
+                description={
+                  <Space direction="vertical" align="center" size={4}>
+                    <Text strong>
+                      {locale === "ko" ? "7일 안에 만료될 권한 없음" : "Nothing expiring in 7 days"}
+                    </Text>
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      {locale === "ko"
+                        ? "만료가 가까워지면 갱신 요청 버튼이 여기에 보입니다."
+                        : "When permissions are nearing expiry, you'll be able to request renewal here."}
+                    </Text>
+                  </Space>
+                }
+              />
             ) : (
               <List
                 size="small"
@@ -232,7 +272,25 @@ export default function MyMond() {
             extra={<Link to="/access-center">{locale === "ko" ? "센터" : "Center"}</Link>}
           >
             {(data?.my_requests?.length ?? 0) === 0 ? (
-              <Empty description={locale === "ko" ? "권한 요청 없음" : "No requests"} />
+              <Empty
+                description={
+                  <Space direction="vertical" align="center" size={4}>
+                    <Text strong>
+                      {locale === "ko" ? "아직 요청한 권한이 없습니다" : "You haven't requested any access yet"}
+                    </Text>
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      {locale === "ko"
+                        ? "필요한 IAM 권한을 셀프서비스로 신청 — AI가 안전한 건은 즉시 자동 승인합니다."
+                        : "Request IAM access — AI auto-approves low-risk items instantly."}
+                    </Text>
+                    <Link to="/access-center">
+                      <Button size="small" type="primary">
+                        {locale === "ko" ? "권한 요청 시작" : "Start a request"}
+                      </Button>
+                    </Link>
+                  </Space>
+                }
+              />
             ) : (
               <List
                 size="small"


### PR DESCRIPTION
## Summary
신규 임직원이 `/me`에 처음 들어오면 4 카드가 모두 빈 상태. '없습니다'만 보이면 다음 액션을 모르므로 친절한 설명 + 적합한 CTA를 함께 노출.

| 카드 | 빈 상태 표기 | CTA |
|---|---|---|
| 내 자산 | '담당 중인 자산이 없습니다' + owner=내 이메일 안내 | **자산 보기** → /assets |
| 최근 발견사항 | '조용한 하루입니다' + 'owner 자산에 새 발견 시 표시' | — |
| 만료 임박 권한 | '7일 안에 만료될 권한 없음' + 만료 임박 안내 | — |
| 내 권한 요청 | '아직 요청한 권한이 없습니다' + AI 자동 승인 안내 | **권한 요청 시작** → /access-center |

기존 'owner=내 이메일인 자산이 없습니다' 같은 개발자 톤 문구 제거.

## Test plan
- [x] /me 빈 상태에서 CTA + 설명 노출 확인
- [x] vite build clean
- [ ] CI 통과