### PR TITLE
fix(compose): worker 컨테이너 healthcheck를 Celery ping으로 교체

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,14 @@ services:
     command: celery -A app.celery_app:celery_app worker --loglevel=info --concurrency=2
     volumes:
       - ./backend:/app
+    # backend Dockerfile의 HTTP healthcheck를 상속하지 않고, Celery ping으로 교체.
+    # worker 컨테이너에는 8000 포트 HTTP 서버가 없으므로 기본값을 따르면 영원히 unhealthy.
+    healthcheck:
+      test: ["CMD-SHELL", "celery -A app.celery_app:celery_app inspect ping -d celery@$$HOSTNAME -t 5 || exit 1"]
+      interval: 30s
+      timeout: 8s
+      start_period: 20s
+      retries: 3
     restart: unless-stopped
 
   frontend:


### PR DESCRIPTION
## Problem
worker 컨테이너가 backend Dockerfile의 HTTP healthcheck(`curl :8000/health`)를 상속해 영원히 `unhealthy` 표시. Celery worker는 HTTP 서버가 없어 포트가 안 열림.

## Fix
`docker-compose.yml` worker 서비스에 명시적 healthcheck 추가:
```
celery -A app.celery_app:celery_app inspect ping -d celery@$HOSTNAME -t 5
```
Redis 큐에 ping 보내고 worker가 응답하면 정상. `start_period: 20s`로 부팅 여유.

## Test plan
- [x] `docker compose up -d worker` 후 30초 시점 `Up 30 seconds (healthy)` 확인
- [ ] CI 통과