### PR TITLE
feat(scans): 스캔 이력 가시화 — 자산 이름 + router_decision 노출

### DIFF
--- a/backend/app/api/v1/endpoints/scans.py
+++ b/backend/app/api/v1/endpoints/scans.py
@@ -12,11 +12,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.deps import current_user, require_role
 from app.core.database import get_db
 from app.models.user import Role, User
+from app.models.scan import Scan
 from app.schemas.scan import ScanCreate, ScanRead
 from app.services import asset as asset_service
 from app.services import scan as scan_service
 
 router = APIRouter()
+
+
+def _to_read(s: Scan) -> ScanRead:
+    """Scan ORM → ScanRead. asset.name까지 nested로 채워서 응답에 노출."""
+    payload = ScanRead.model_validate(s).model_dump()
+    payload["asset_name"] = s.asset.name if s.asset else None
+    return ScanRead.model_validate(payload)
 
 
 @router.get("", response_model=list[ScanRead])
@@ -28,7 +36,7 @@ async def list_scans(
     db: AsyncSession = Depends(get_db),
 ) -> list[ScanRead]:
     scans = await scan_service.list_scans(db, limit=limit, offset=offset, asset_id=asset_id)
-    return [ScanRead.model_validate(s) for s in scans]
+    return [_to_read(s) for s in scans]
 
 
 @router.post(
@@ -43,7 +51,7 @@ async def trigger_scan(payload: ScanCreate, db: AsyncSession = Depends(get_db)) 
     scan = await scan_service.trigger_scan(
         db, asset=asset, scanner_name=payload.scanner, trigger=payload.trigger
     )
-    return ScanRead.model_validate(scan)
+    return _to_read(scan)
 
 
 @router.get("/{scan_id}", response_model=ScanRead)
@@ -55,4 +63,4 @@ async def get_scan(
     scan = await scan_service.get_scan(db, scan_id)
     if not scan:
         raise HTTPException(status_code=404, detail="Scan not found")
-    return ScanRead.model_validate(scan)
+    return _to_read(scan)

--- a/backend/app/api/v1/endpoints/webhooks.py
+++ b/backend/app/api/v1/endpoints/webhooks.py
@@ -151,6 +151,7 @@ async def github_webhook(
         asset=asset,
         scanner_name=scanner_name,
         trigger=ScanTrigger.WEBHOOK,
+        router_decision=decision,
     )
     return {
         "matched": True,

--- a/backend/app/models/scan.py
+++ b/backend/app/models/scan.py
@@ -62,6 +62,10 @@ class Scan(Base, TimestampMixin):
     raw_output: Mapped[dict | None] = mapped_column(JSON)
     error_message: Mapped[str | None] = mapped_column(Text)
 
+    # webhook push에서 자동 스캐너 선택이 발생한 경우 라우터 결정 근거(reason/counts/fallback).
+    # router_decision이 None이면 사용자가 명시적으로 scanner를 지정한 manual/AI 트리거.
+    router_decision: Mapped[dict | None] = mapped_column(JSON)
+
     asset: Mapped["Asset"] = relationship(back_populates="scans", lazy="joined")
     findings: Mapped[list["Finding"]] = relationship(
         back_populates="scan",

--- a/backend/app/schemas/scan.py
+++ b/backend/app/schemas/scan.py
@@ -19,6 +19,7 @@ class ScanCreate(BaseModel):
 class ScanRead(Timestamped):
     id: int
     asset_id: int
+    asset_name: str | None = None  # 화면에서 ID 대신 이름으로 노출
     scanner: str
     trigger: ScanTrigger
     status: ScanStatus
@@ -27,3 +28,5 @@ class ScanRead(Timestamped):
     duration_ms: int | None = None
     findings_count: int = 0
     error_message: str | None = None
+    # webhook 자동 스캐너 선택의 근거 (reason / counts / fallback). manual/AI에는 None.
+    router_decision: dict | None = None

--- a/backend/app/services/scan.py
+++ b/backend/app/services/scan.py
@@ -48,12 +48,16 @@ async def trigger_scan(
     asset: Asset,
     scanner_name: str,
     trigger: ScanTrigger = ScanTrigger.MANUAL,
+    router_decision: dict | None = None,
 ) -> Scan:
     """스캔을 시작한다.
 
     기본은 인라인 동기 실행 — 빠르게 끝나는 단일 자산 스캔에 적합.
     `SCAN_QUEUE_ENABLED=true`면 PENDING 상태로 Scan만 만들고 Celery 큐에 enqueue,
     worker가 비동기로 실행. 운영의 대용량/장시간 스캔에서 backend 타임아웃 회피.
+
+    router_decision은 webhook push가 자동 스캐너 선택을 한 경우의 근거
+    (reason/counts/fallback). manual/AI 트리거에는 None.
     """
     adapter = get_scanner(scanner_name)
     if adapter is None:
@@ -63,6 +67,7 @@ async def trigger_scan(
             trigger=trigger,
             status=ScanStatus.FAILED,
             error_message=f"Unknown scanner: {scanner_name}",
+            router_decision=router_decision,
         )
         db.add(scan)
         await db.commit()
@@ -75,6 +80,7 @@ async def trigger_scan(
             scanner=scanner_name,
             trigger=trigger,
             status=ScanStatus.FAILED,
+            router_decision=router_decision,
             error_message=(
                 f"Scanner '{scanner_name}'은 자산 타입 '{asset.asset_type.value}'을 지원하지 않습니다."
             ),
@@ -91,6 +97,7 @@ async def trigger_scan(
             scanner=scanner_name,
             trigger=trigger,
             status=ScanStatus.PENDING,
+            router_decision=router_decision,
         )
         db.add(scan)
         await db.commit()
@@ -108,6 +115,7 @@ async def trigger_scan(
         trigger=trigger,
         status=ScanStatus.RUNNING,
         started_at=datetime.now(timezone.utc),
+        router_decision=router_decision,
     )
     db.add(scan)
     await db.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -40,6 +40,7 @@ async def lifespan(app: FastAPI):
             "ALTER TABLE access_requests ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMP WITH TIME ZONE",
             "ALTER TABLE access_requests ADD COLUMN IF NOT EXISTS revoke_result JSON DEFAULT '{}'::json NOT NULL",
             "ALTER TABLE policies ADD COLUMN IF NOT EXISTS engine VARCHAR(16) DEFAULT 'builtin' NOT NULL",
+            "ALTER TABLE scans ADD COLUMN IF NOT EXISTS router_decision JSON",
         ):
             await conn.execute(text(ddl))
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -67,9 +67,16 @@ export interface Finding {
   updated_at: string;
 }
 
+export interface RouterDecision {
+  reason: string;
+  counts: { sca: number; container: number; iac: number; sast: number; unknown: number };
+  fallback: boolean;
+}
+
 export interface Scan {
   id: number;
   asset_id: number;
+  asset_name?: string | null;
   scanner: string;
   trigger: string;
   status: ScanStatus;
@@ -78,6 +85,7 @@ export interface Scan {
   duration_ms?: number | null;
   findings_count: number;
   error_message?: string | null;
+  router_decision?: RouterDecision | null;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -2,15 +2,17 @@
  * Scans — 스캔 이력 + 트리거
  */
 
-import { ThunderboltOutlined } from "@ant-design/icons";
+import { RobotOutlined, ThunderboltOutlined } from "@ant-design/icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Button,
   Form,
   Modal,
   Select,
+  Space,
   Table,
   Tag,
+  Tooltip,
   Typography,
   message,
 } from "antd";
@@ -19,9 +21,16 @@ import { useState } from "react";
 import { useI18n } from "@/i18n";
 import { api, type Asset, type Page, type Scan } from "@/lib/api";
 
-const { Title } = Typography;
+const { Title, Text } = Typography;
 
 const SCANNERS = ["trivy", "semgrep", "nuclei"];
+
+const TRIGGER_COLOR: Record<string, string> = {
+  manual: "default",
+  scheduled: "blue",
+  webhook: "purple",
+  ai: "magenta",
+};
 
 async function fetchScans(): Promise<Scan[]> {
   const { data } = await api.get<Scan[]>("/scans", { params: { limit: 100 } });
@@ -82,10 +91,48 @@ export default function Scans() {
         loading={isLoading}
         dataSource={data ?? []}
         rowKey="id"
+        expandable={{
+          rowExpandable: (r) => !!r.router_decision || !!r.error_message,
+          expandedRowRender: (r) => (
+            <Space direction="vertical" size={6} style={{ paddingBlock: 4 }}>
+              {r.router_decision && (
+                <Space size={6} wrap>
+                  <Tag color="purple" icon={<RobotOutlined />}>
+                    auto-router
+                  </Tag>
+                  <Text>{r.router_decision.reason}</Text>
+                  <Text type="secondary" style={{ fontSize: 12 }}>
+                    SAST {r.router_decision.counts.sast} · SCA {r.router_decision.counts.sca} ·
+                    Container {r.router_decision.counts.container} · IaC {r.router_decision.counts.iac} ·
+                    기타 {r.router_decision.counts.unknown}
+                  </Text>
+                  {r.router_decision.fallback && (
+                    <Tag color="default" style={{ fontSize: 11 }}>
+                      fallback
+                    </Tag>
+                  )}
+                </Space>
+              )}
+              {r.error_message && (
+                <Text type="danger" style={{ fontSize: 12 }}>
+                  {r.error_message}
+                </Text>
+              )}
+            </Space>
+          ),
+        }}
         columns={[
           { title: "ID", dataIndex: "id", width: 70 },
-          { title: t.common.asset, dataIndex: "asset_id", width: 110 },
-          { title: t.common.scanner, dataIndex: "scanner", width: 140 },
+          {
+            title: t.common.asset,
+            dataIndex: "asset_name",
+            render: (name: string | null | undefined, r: Scan) => (
+              <Tooltip title={`asset_id=${r.asset_id}`}>
+                <Text>{name || `#${r.asset_id}`}</Text>
+              </Tooltip>
+            ),
+          },
+          { title: t.common.scanner, dataIndex: "scanner", width: 120 },
           {
             title: t.common.status,
             dataIndex: "status",
@@ -94,20 +141,33 @@ export default function Scans() {
                 {s}
               </Tag>
             ),
-            width: 120,
+            width: 110,
           },
           {
             title: t.scans.trigger,
             dataIndex: "trigger",
-            render: (v: string) => <Tag>{v}</Tag>,
-            width: 110,
+            render: (v: string, r: Scan) => (
+              <Space size={4}>
+                <Tag color={TRIGGER_COLOR[v] ?? "default"} style={{ marginInlineEnd: 0 }}>
+                  {v}
+                </Tag>
+                {r.router_decision && (
+                  <Tooltip title={r.router_decision.reason}>
+                    <Tag color="purple" style={{ marginInlineEnd: 0 }} icon={<RobotOutlined />}>
+                      auto
+                    </Tag>
+                  </Tooltip>
+                )}
+              </Space>
+            ),
+            width: 150,
           },
-          { title: t.scans.findingsCount, dataIndex: "findings_count", width: 110 },
+          { title: t.scans.findingsCount, dataIndex: "findings_count", width: 100 },
           {
             title: t.scans.duration,
             dataIndex: "duration_ms",
             render: (v: number | null) => (v ? `${v} ms` : "—"),
-            width: 110,
+            width: 100,
           },
           {
             title: t.common.when,


### PR DESCRIPTION
## Problem
- Scans 페이지의 자산 컬럼이 ID(`6`)만 표시 — readable name 없음
- webhook smart-router(#59)가 자동 선택한 스캐너의 이유는 응답에만 있고 어디에도 노출 안 됨
- trigger 태그는 모두 같은 회색

## 변경

### Backend
- `Scan.router_decision` (JSON, nullable) 추가 — webhook push 자동 선택 근거 저장
- lightweight migration: `ALTER TABLE scans ADD COLUMN IF NOT EXISTS router_decision JSON`
- `trigger_scan(router_decision=None)` 파라미터, 모든 분기 전파
- webhook 핸들러에서 `router_decision=decision` 전달
- `ScanRead`에 `asset_name` + `router_decision` 필드. `_to_read` 헬퍼로 `scan.asset.name` 채움

### Frontend
- 자산 컬럼: ID → `asset_name` (tooltip에 ID 보존)
- trigger 색 구분: `manual`=회색 · `webhook`=보라 · `scheduled`=청 · `ai`=자홍
- webhook + router_decision 있으면 `auto` 청보라 태그
- row expand: `auto-router` chip + reason + SAST/SCA/Container/IaC/기타 카운트 + fallback 여부. 에러 있으면 빨강

## Test plan
- [x] SAST 우세 push → /scans에 `mond-test-router` + `semgrep` + `webhook` + `auto` 태그
- [x] expand: 'SAST 파일 3건이 다른 카테고리 합(1)보다 많음' + 카테고리 카운트
- [x] manual 트리거는 `auto` 태그 없이 회색 `manual`만
- [x] backend ruff clean · frontend vite build clean
- [ ] CI 통과