### PR TITLE
feat(findings): drawer 가시화 — 자산 카드 + AI 인사이트 시각화 보강

### DIFF
--- a/backend/app/api/v1/endpoints/findings.py
+++ b/backend/app/api/v1/endpoints/findings.py
@@ -21,6 +21,16 @@ from app.services import finding as finding_service
 router = APIRouter()
 
 
+def _to_read(f: Finding) -> FindingRead:
+    """Finding ORM → FindingRead. nested asset 정보까지 응답에 노출."""
+    payload = FindingRead.model_validate(f).model_dump()
+    if f.asset:
+        payload["asset_name"] = f.asset.name
+        payload["asset_type"] = f.asset.asset_type.value
+        payload["asset_environment"] = f.asset.environment
+    return FindingRead.model_validate(payload)
+
+
 @router.get("", response_model=Page[FindingRead])
 async def list_findings(
     limit: int = Query(50, ge=1, le=500),
@@ -42,7 +52,7 @@ async def list_findings(
         scanner=scanner,
     )
     return Page(
-        items=[FindingRead.model_validate(i) for i in items],
+        items=[_to_read(i) for i in items],
         total=total,
         limit=limit,
         offset=offset,
@@ -58,7 +68,7 @@ async def get_finding(
     f = await finding_service.get_finding(db, finding_id)
     if not f:
         raise HTTPException(status_code=404, detail="Finding not found")
-    return FindingRead.model_validate(f)
+    return _to_read(f)
 
 
 @router.patch(
@@ -75,7 +85,7 @@ async def update_finding(
     if not f:
         raise HTTPException(status_code=404, detail="Finding not found")
     updated = await finding_service.update_finding(db, f, payload)
-    return FindingRead.model_validate(updated)
+    return _to_read(updated)
 
 
 @router.patch(

--- a/backend/app/schemas/finding.py
+++ b/backend/app/schemas/finding.py
@@ -34,3 +34,7 @@ class FindingRead(FindingBase, Timestamped):
     id: int
     status: FindingStatus
     fingerprint: str
+    # 화면에서 ID 대신 자산 이름·타입·환경을 보여주기 위한 nested 정보
+    asset_name: str | None = None
+    asset_type: str | None = None
+    asset_environment: str | None = None

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -52,6 +52,9 @@ export interface Asset {
 export interface Finding {
   id: number;
   asset_id: number;
+  asset_name?: string | null;
+  asset_type?: string | null;
+  asset_environment?: string | null;
   scan_id?: number | null;
   rule_id: string;
   title: string;

--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -2,17 +2,25 @@
  * Findings — 발견된 보안 이슈 + 상태 변경 + AI 분석
  */
 
-import { BulbOutlined, CheckOutlined } from "@ant-design/icons";
+import {
+  ArrowRightOutlined,
+  BulbOutlined,
+  CheckOutlined,
+  EnvironmentOutlined,
+  RobotOutlined,
+} from "@ant-design/icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  Alert,
   Button,
   Drawer,
+  Empty,
   Popconfirm,
+  Progress,
   Select,
   Space,
   Table,
   Tag,
+  Tooltip,
   Typography,
   message,
 } from "antd";
@@ -185,19 +193,51 @@ export default function Findings() {
       <Drawer
         open={!!selected}
         onClose={() => setSelected(null)}
-        width={560}
+        width={620}
         title={selected ? `#${selected.id} · ${selected.title}` : ""}
       >
         {selected && (
           <Space direction="vertical" size="middle" style={{ width: "100%" }}>
-            <Space>
+            {/* 자산 정보 — 어느 자산의 어느 위치에서 발견됐는지 */}
+            {selected.asset_name && (
+              <div
+                style={{
+                  border: "1px solid var(--mond-border)",
+                  borderRadius: 8,
+                  padding: 12,
+                  background: "var(--mond-surface-2, transparent)",
+                }}
+              >
+                <Space size={6} wrap>
+                  <Text type="secondary" style={{ fontSize: 11 }}>
+                    {locale === "ko" ? "발견된 자산" : "FOUND ON"}
+                  </Text>
+                  <Text strong>{selected.asset_name}</Text>
+                  {selected.asset_type && <Tag style={{ marginInlineEnd: 0 }}>{selected.asset_type}</Tag>}
+                  {selected.asset_environment && (
+                    <Tag color="blue" style={{ marginInlineEnd: 0 }}>
+                      {selected.asset_environment}
+                    </Tag>
+                  )}
+                </Space>
+                {selected.location && (
+                  <div style={{ marginTop: 6 }}>
+                    <EnvironmentOutlined style={{ marginRight: 6, color: "var(--mond-text-dim)" }} />
+                    <Text type="secondary" style={{ fontFamily: "var(--mond-font-mono, monospace)", fontSize: 12 }}>
+                      {selected.location}
+                    </Text>
+                  </div>
+                )}
+              </div>
+            )}
+
+            <Space wrap>
               <Tag color={SEVERITY_COLOR[selected.severity]}>
                 {selected.severity.toUpperCase()}
               </Tag>
               <Tag>{selected.scanner}</Tag>
               <Tag>{selected.rule_id}</Tag>
             </Space>
-            {selected.location && <Text type="secondary">📍 {selected.location}</Text>}
             {selected.description && <Paragraph>{selected.description}</Paragraph>}
             {selected.references.length > 0 && (
               <div>
@@ -214,8 +254,11 @@ export default function Findings() {
               </div>
             )}
 
-            <div style={{ display: "flex", justifyContent: "space-between" }}>
-              <Text strong>{t.menu.aiInsights}</Text>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <Space>
+                <RobotOutlined style={{ color: "var(--severity-info, #8a8aff)" }} />
+                <Text strong>{t.menu.aiInsights}</Text>
+              </Space>
               <Button
                 type="primary"
                 size="small"
@@ -228,55 +271,117 @@ export default function Findings() {
             </div>
 
             {(insights ?? []).length === 0 && (
-              <Alert type="info" showIcon message={t.findings.drawerNoInsight} />
+              <Empty
+                description={
+                  <Space direction="vertical" align="center" size={4}>
+                    <Text strong>
+                      {locale === "ko" ? "아직 AI 분석 결과가 없습니다" : "No AI insight yet"}
+                    </Text>
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      {locale === "ko"
+                        ? "위 'AI 분석 실행' 버튼을 누르면 Claude가 자산 컨텍스트로 severity 재평가 + 수정 가이드를 생성합니다."
+                        : "Click 'Run AI triage' to let Claude re-assess severity and propose a remediation."}
+                    </Text>
+                  </Space>
+                }
+              />
             )}
-            {(insights ?? []).map((i) => (
-              <div
-                key={i.id}
-                style={{
-                  border: "1px solid var(--mond-border)",
-                  borderRadius: 8,
-                  padding: 16,
-                  background: "var(--mond-surface)",
-                }}
-              >
-                <Space>
-                  <Tag color="purple">{i.kind}</Tag>
-                  <Tag>{i.model}</Tag>
-                  {i.recommended_severity && (
-                    <Tag color={SEVERITY_COLOR[i.recommended_severity as Severity]}>
-                      → {i.recommended_severity}
-                    </Tag>
+            {(insights ?? []).map((i) => {
+              const kindKo: Record<string, string> = {
+                triage: "분류",
+                remediation: "수정 가이드",
+                summary: "요약",
+                explain: "해설",
+              };
+              const isAuthored = !i.model.startsWith("rule");
+              return (
+                <div
+                  key={i.id}
+                  style={{
+                    border: "1px solid var(--mond-border)",
+                    borderRadius: 8,
+                    padding: 16,
+                    background: "var(--mond-surface)",
+                  }}
+                >
+                  <Space size={6} wrap>
+                    <Tag color="purple">{kindKo[i.kind] ?? i.kind}</Tag>
+                    <Tooltip title={isAuthored ? (locale === "ko" ? "AI provider 응답" : "From AI provider") : (locale === "ko" ? "AI provider 미설정 — 기본 규칙 모드" : "Heuristic (no AI provider)")}>
+                      <Tag color={isAuthored ? "geekblue" : "default"}>{i.model}</Tag>
+                    </Tooltip>
+                    {i.recommended_severity && i.recommended_severity !== selected.severity && (
+                      <Tooltip title={locale === "ko" ? "AI 추천 severity로 재평가" : "Severity reassessed by AI"}>
+                        <Space size={4}>
+                          <Tag color={SEVERITY_COLOR[selected.severity]} style={{ marginInlineEnd: 0 }}>
+                            {selected.severity}
+                          </Tag>
+                          <ArrowRightOutlined style={{ fontSize: 11, color: "var(--mond-text-dim)" }} />
+                          <Tag color={SEVERITY_COLOR[i.recommended_severity as Severity]} style={{ marginInlineEnd: 0 }}>
+                            {i.recommended_severity}
+                          </Tag>
+                        </Space>
+                      </Tooltip>
+                    )}
+                    {typeof i.confidence === "number" && (
+                      <Tooltip title={locale === "ko" ? `AI 신뢰도 ${(i.confidence * 100).toFixed(0)}%` : `Confidence ${(i.confidence * 100).toFixed(0)}%`}>
+                        <div style={{ minWidth: 100, display: "inline-flex", alignItems: "center", gap: 4 }}>
+                          <Text type="secondary" style={{ fontSize: 11 }}>
+                            {locale === "ko" ? "신뢰도" : "conf."}
+                          </Text>
+                          <Progress
+                            percent={Math.round(i.confidence * 100)}
+                            size="small"
+                            showInfo={false}
+                            strokeColor="var(--severity-info, #8a8aff)"
+                            style={{ width: 70, marginBottom: 0 }}
+                          />
+                          <Text style={{ fontSize: 11 }}>{Math.round(i.confidence * 100)}%</Text>
+                        </div>
+                      </Tooltip>
+                    )}
+                  </Space>
+                  <Paragraph style={{ marginTop: 12 }}>{i.summary}</Paragraph>
+                  {i.remediation?.steps && i.remediation.steps.length > 0 && (
+                    <>
+                      <Text strong>{t.findings.remediation}</Text>
+                      <ol>
+                        {i.remediation.steps.map((s: string, idx: number) => (
+                          <li key={idx}>{s}</li>
+                        ))}
+                      </ol>
+                    </>
                   )}
-                  {typeof i.confidence === "number" && (
-                    <Tag>confidence {(i.confidence * 100).toFixed(0)}%</Tag>
+                  {i.remediation?.code && (
+                    <pre
+                      style={{
+                        background: "#0d1421",
+                        padding: 12,
+                        borderRadius: 6,
+                        overflowX: "auto",
+                      }}
+                    >
+                      <code>{i.remediation.code}</code>
+                    </pre>
                   )}
-                </Space>
-                <Paragraph style={{ marginTop: 12 }}>{i.summary}</Paragraph>
-                {i.remediation?.steps && i.remediation.steps.length > 0 && (
-                  <>
-                    <Text strong>{t.findings.remediation}</Text>
-                    <ol>
-                      {i.remediation.steps.map((s: string, idx: number) => (
-                        <li key={idx}>{s}</li>
-                      ))}
-                    </ol>
-                  </>
-                )}
-                {i.remediation?.code && (
-                  <pre
-                    style={{
-                      background: "#0d1421",
-                      padding: 12,
-                      borderRadius: 6,
-                      overflowX: "auto",
-                    }}
-                  >
-                    <code>{i.remediation.code}</code>
-                  </pre>
-                )}
-              </div>
-            ))}
+                  {i.remediation?.references && i.remediation.references.length > 0 && (
+                    <div style={{ marginTop: 8 }}>
+                      <Text strong style={{ fontSize: 12 }}>
+                        {locale === "ko" ? "AI 참고" : "AI references"}
+                      </Text>
+                      <ul style={{ marginBottom: 0 }}>
+                        {i.remediation.references.map((r: string) => (
+                          <li key={r}>
+                            <a href={r} target="_blank" rel="noreferrer">
+                              {r}
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
           </Space>
         )}
       </Drawer>


### PR DESCRIPTION
## Summary
보안 담당자가 finding을 클릭하는 drawer가 단조로워서, 어느 자산의 어느 위치인지·AI가 severity를 어떻게 재평가했는지·신뢰도가 직관적으로 보이지 않던 문제를 해소.

## 변경

### Backend
- `FindingRead`에 `asset_name`/`asset_type`/`asset_environment` 필드
- `_to_read` 헬퍼로 `Finding.asset.*` nested를 응답에 채움

### Frontend
- **자산 카드** — drawer 상단에 'mond-test-router' (strong) + `repository` + env 태그 + 📍 위치 (monospace)
- **AI 인사이트 섹션** — 🤖 RobotOutlined + 친화적 빈 상태(Empty + 안내문구)
- **AI insight 카드**:
  - `kind` 영어 → 한국어 ('분류/수정 가이드/요약/해설')
  - `model` 태그 — `rule`로 시작하면 회색(휴리스틱) / 그 외 청보라(provider)
  - **severity 재평가 시각화** — recommended_severity가 다르면 `current → recommended` 화살표 + 색 chip 두 개
  - **confidence Progress bar** — 숫자만 → 70px 막대 + %
  - **remediation.references** 별도 'AI 참고' 섹션

## Test plan
- [x] /findings → row 클릭 → drawer에 자산 카드 + 위치 정상 노출
- [x] 빈 AI 상태에서 친절한 안내문구
- [x] backend ruff clean · frontend vite build clean
- [ ] CI 통과