### PR TITLE
feat(ai): citation deep-link — ?focus=N으로 drawer 자동 오픈/행 강조

### DIFF
--- a/frontend/src/pages/Assets.tsx
+++ b/frontend/src/pages/Assets.tsx
@@ -22,7 +22,8 @@ import {
   Typography,
   message,
 } from "antd";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
 import { useAuth } from "@/auth/AuthContext";
 import { useI18n } from "@/i18n";
@@ -55,6 +56,21 @@ export default function Assets() {
     queryKey: ["assets"],
     queryFn: fetchAssets,
   });
+
+  // AI Insights citation에서 진입 시 ?focus=N → row highlight + scroll
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [focusId, setFocusId] = useState<number | null>(null);
+  useEffect(() => {
+    const id = Number(searchParams.get("focus"));
+    if (!id || !data?.items) return;
+    if (data.items.some((x) => x.id === id)) {
+      setFocusId(id);
+      setSearchParams({}, { replace: true });
+      // 8초 후 highlight 해제
+      const timer = setTimeout(() => setFocusId(null), 8000);
+      return () => clearTimeout(timer);
+    }
+  }, [data?.items, searchParams, setSearchParams]);
 
   const create = useMutation({
     mutationFn: (payload: Partial<Asset>) => api.post<Asset>("/assets", payload),
@@ -100,6 +116,7 @@ export default function Assets() {
         loading={isLoading}
         dataSource={data?.items ?? []}
         rowKey="id"
+        rowClassName={(r) => (focusId === r.id ? "mond-row-focus" : "")}
         columns={[
           { title: "ID", dataIndex: "id", width: 70 },
           { title: t.common.name, dataIndex: "name" },

--- a/frontend/src/pages/Findings.tsx
+++ b/frontend/src/pages/Findings.tsx
@@ -24,7 +24,8 @@ import {
   Typography,
   message,
 } from "antd";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
 import {
   api,
@@ -73,6 +74,18 @@ export default function Findings() {
   const [checked, setChecked] = useState<number[]>([]);
 
   const { data, isLoading } = useQuery({ queryKey: ["findings"], queryFn: fetchFindings });
+
+  // AI Insights citation에서 진입할 때 ?focus=N으로 해당 finding drawer 자동 오픈
+  const [searchParams, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    const id = Number(searchParams.get("focus"));
+    if (!id || !data?.items) return;
+    const f = data.items.find((x) => x.id === id);
+    if (f) {
+      setSelected(f);
+      setSearchParams({}, { replace: true });
+    }
+  }, [data?.items, searchParams, setSearchParams]);
 
   const { data: insights, refetch: refetchInsights } = useQuery({
     queryKey: ["finding-insights", selected?.id],

--- a/frontend/src/pages/Policies.tsx
+++ b/frontend/src/pages/Policies.tsx
@@ -6,7 +6,8 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Card, Empty, Input, Segmented, Space, Switch, Table, Tag, Typography } from "antd";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
 import { useI18n } from "@/i18n";
 import { api, type Policy } from "@/lib/api";
@@ -30,6 +31,20 @@ export default function Policies() {
   const [query, setQuery] = useState("");
 
   const { data, isLoading } = useQuery({ queryKey: ["policies"], queryFn: fetchPolicies });
+
+  // AI Insights citation에서 진입 시 ?focus=N → row highlight
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [focusId, setFocusId] = useState<number | null>(null);
+  useEffect(() => {
+    const id = Number(searchParams.get("focus"));
+    if (!id || !data) return;
+    if (data.some((p) => p.id === id)) {
+      setFocusId(id);
+      setSearchParams({}, { replace: true });
+      const timer = setTimeout(() => setFocusId(null), 8000);
+      return () => clearTimeout(timer);
+    }
+  }, [data, searchParams, setSearchParams]);
   const { data: frameworks } = useQuery({
     queryKey: ["policy-templates-frameworks"],
     queryFn: policyTemplatesApi.frameworks,
@@ -77,6 +92,7 @@ export default function Policies() {
           loading={isLoading}
           dataSource={filteredPolicies}
           rowKey="id"
+          rowClassName={(r) => (focusId === r.id ? "mond-row-focus" : "")}
           locale={{
             emptyText: <Empty description={locale === "ko" ? "정책이 없습니다" : "No policies"} />,
           }}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -276,3 +276,16 @@ a:hover {
 .mond-row-high td:first-child {
   box-shadow: inset 3px 0 0 0 var(--severity-high, #f29142);
 }
+
+/* AI Insights citation에서 deep-link 진입한 행을 8초간 강조 */
+.mond-row-focus td:first-child {
+  box-shadow: inset 3px 0 0 0 var(--mond-source-ai, #6a4cff);
+}
+.mond-row-focus td {
+  background: color-mix(in oklab, var(--mond-source-ai, #6a4cff) 8%, transparent) !important;
+  animation: mond-focus-fade 8s ease-out forwards;
+}
+@keyframes mond-focus-fade {
+  0% { background: color-mix(in oklab, var(--mond-source-ai, #6a4cff) 16%, transparent); }
+  100% { background: transparent; }
+}


### PR DESCRIPTION
## Summary
AI Insights citation chip 클릭이 페이지 이동만 하고 해당 항목을 찾아주지 않던 문제 해소. RAG가 만든 `?focus=N` URL을 각 페이지가 자동 처리.

| 페이지 | 동작 |
|---|---|
| `/findings?focus=N` | drawer 자동 오픈 (AI 인사이트 섹션까지 바로 진입) |
| `/assets?focus=N` | 행 좌측 보라 색띠 + 배경 틴트 (8초) |
| `/policies?focus=N` | 동일 |

## 변경
- 각 페이지가 `useSearchParams`로 `focus`를 읽어 처리하고 `setSearchParams({}, replace)`로 URL 정리
- `global.css`에 `.mond-row-focus` 클래스 — 8초 `mond-focus-fade` 애니메이션
- RAG citation URL은 기존 형식 그대로 (`backend/app/ai/rag.py` 변경 없음)

## Test plan
- [x] `/findings?focus=4` → drawer 자동 오픈
- [x] `/assets?focus=1` → mond-backend 행 보라 강조
- [x] vite build clean
- [ ] CI 통과