### PR TITLE
feat(admin-policies): engine 컬럼 + 임계치 색 dot 표시

### DIFF
--- a/frontend/src/pages/admin/AdminPolicies.tsx
+++ b/frontend/src/pages/admin/AdminPolicies.tsx
@@ -38,6 +38,19 @@ const { Title, Paragraph, Text } = Typography;
 const ALL = "__all__";
 const SEVERITIES = ["critical", "high", "medium", "low", "info"];
 
+const SEVERITY_COLOR: Record<string, string> = {
+  critical: "#e8484a",
+  high: "#f29142",
+  medium: "#eab308",
+  low: "#4ad28d",
+  info: "#8a8aff",
+};
+
+const ENGINE_COLOR: Record<string, string> = {
+  builtin: "default",
+  opa: "geekblue",
+};
+
 async function fetchPolicies(): Promise<Policy[]> {
   const { data } = await api.get<Policy[]>("/policies");
   return data;
@@ -190,11 +203,35 @@ export default function AdminPolicies() {
                   size="small"
                   value={v}
                   style={{ width: "100%" }}
-                  options={SEVERITIES.map((s) => ({ value: s, label: s }))}
+                  options={SEVERITIES.map((s) => ({
+                    value: s,
+                    label: (
+                      <Space size={6}>
+                        <span
+                          style={{
+                            display: "inline-block",
+                            width: 8,
+                            height: 8,
+                            borderRadius: "50%",
+                            background: SEVERITY_COLOR[s],
+                          }}
+                        />
+                        <span>{s}</span>
+                      </Space>
+                    ),
+                  }))}
                   onChange={(val) =>
                     updatePolicy.mutate({ id: r.id, patch: { severity_threshold: val } as Partial<Policy> })
                   }
                 />
+              ),
+            },
+            {
+              title: "engine",
+              dataIndex: "engine",
+              width: 100,
+              render: (v: string) => (
+                <Tag color={ENGINE_COLOR[v] ?? "default"}>{v || "builtin"}</Tag>
               ),
             },
             {
@@ -455,7 +492,25 @@ function CustomPolicyModal({
             <Select options={TYPES.map((v) => ({ value: v, label: v }))} />
           </Form.Item>
           <Form.Item label={t.policies.fieldThreshold} name="severity_threshold" style={{ width: 200 }}>
-            <Select options={SEVERITIES.map((v) => ({ value: v, label: v }))} />
+            <Select
+              options={SEVERITIES.map((s) => ({
+                value: s,
+                label: (
+                  <Space size={6}>
+                    <span
+                      style={{
+                        display: "inline-block",
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        background: SEVERITY_COLOR[s],
+                      }}
+                    />
+                    <span>{s}</span>
+                  </Space>
+                ),
+              }))}
+            />
           </Form.Item>
         </Space>
 


### PR DESCRIPTION
## Summary
PR #57(OPA Rego) 머지 후 read-only Policies 페이지엔 engine 배지가 있는데 Admin Policies 관리 페이지엔 없어서 보안 담당자가 OPA 정책과 builtin 정책을 한눈에 구분할 수 없었음. 임계치 dropdown도 회색만이라 위험도가 시각적으로 안 들어왔음.

## 변경
`AdminPolicies.tsx`:
- `SEVERITY_COLOR` — critical 빨강 · high 주황 · medium 노랑 · low 녹색 · info 보라
- 임계치 Select option label에 8x8 색 **dot** + 텍스트로 위험도 시각화
- 정책 작성 모달의 `severity_threshold` Select에도 동일 적용
- 'engine' 컬럼 추가 — `engine='opa'`면 청보라 태그

## Test plan
- [x] build clean
- [x] API 응답에 engine 필드 정상
- [ ] CI 통과