### PR TITLE
feat(policy-sim): engine + matched 노출 + 위험도 시각화

### DIFF
--- a/frontend/src/pages/PolicySimulator.tsx
+++ b/frontend/src/pages/PolicySimulator.tsx
@@ -1,18 +1,50 @@
 /**
  * Policy Simulator — 가상 finding 입력 → 어떤 정책 게이트가 차단되나
+ *
+ * builtin은 임계치 비교, opa는 Rego 평가. 결과 행에 engine + matched 메시지를
+ * expand로 노출 — 보안 담당자가 OPA deny 메시지나 차단된 finding을 즉시 확인.
  */
 
-import { DeleteOutlined, PlusOutlined, ThunderboltOutlined } from "@ant-design/icons";
+import {
+  DeleteOutlined,
+  PlusOutlined,
+  RobotOutlined,
+  ThunderboltOutlined,
+} from "@ant-design/icons";
 import { useMutation } from "@tanstack/react-query";
-import { Alert, Button, Card, Input, Select, Space, Table, Tag, Typography } from "antd";
+import {
+  Alert,
+  Button,
+  Card,
+  Empty,
+  Input,
+  Select,
+  Space,
+  Table,
+  Tag,
+  Typography,
+} from "antd";
 import { useState } from "react";
 
 import { useI18n } from "@/i18n";
 import { api, type Severity } from "@/lib/api";
 
-const { Title, Paragraph } = Typography;
+const { Title, Paragraph, Text } = Typography;
 
 const SEVERITIES: Severity[] = ["critical", "high", "medium", "low", "info"];
+
+const SEVERITY_COLOR: Record<string, string> = {
+  critical: "#e8484a",
+  high: "#f29142",
+  medium: "#eab308",
+  low: "#4ad28d",
+  info: "#8a8aff",
+};
+
+const ENGINE_COLOR: Record<string, string> = {
+  builtin: "default",
+  opa: "geekblue",
+};
 
 interface SimRow {
   rule_id: string;
@@ -28,6 +60,7 @@ interface SimResultRow {
   blocked: boolean;
   reason: string;
   matched: string[];
+  engine?: string;
 }
 
 interface SimResponse {
@@ -52,9 +85,14 @@ export default function PolicySimulator() {
 
   return (
     <div>
-      <Title level={2} style={{ marginBottom: 8 }}>
-        {t.policySim.title} <Tag color="orange" style={{ verticalAlign: "middle", marginLeft: 8 }}>EXPERIMENTAL</Tag>
-      </Title>
+      <Space size={8} style={{ marginBottom: 8 }}>
+        <Title level={2} style={{ margin: 0 }}>
+          {t.policySim.title}
+        </Title>
+        <Tag color="default" style={{ fontSize: 11 }}>
+          EXPERIMENTAL
+        </Tag>
+      </Space>
       <Paragraph type="secondary">{t.policySim.desc}</Paragraph>
       <Alert
         type="info"
@@ -62,7 +100,7 @@ export default function PolicySimulator() {
         style={{ marginBottom: 12 }}
         message={
           locale === "ko"
-            ? "이 화면은 정책 변경 영향만 가상으로 보여줍니다. 실제 자산·발견에 적용하지 않습니다."
+            ? "가상 finding을 입력해 현재 정책 게이트가 어떻게 동작할지 미리 봅니다. 실제 자산/발견에 변화는 없습니다."
             : "Simulation only — does not modify real assets or findings."
         }
       />
@@ -88,8 +126,24 @@ export default function PolicySimulator() {
                     rows.map((row, i) => (i === idx ? { ...row, severity: v } : row)),
                   )
                 }
-                options={SEVERITIES.map((s) => ({ value: s, label: s.toUpperCase() }))}
-                style={{ width: 140 }}
+                options={SEVERITIES.map((s) => ({
+                  value: s,
+                  label: (
+                    <Space size={6}>
+                      <span
+                        style={{
+                          display: "inline-block",
+                          width: 8,
+                          height: 8,
+                          borderRadius: "50%",
+                          background: SEVERITY_COLOR[s],
+                        }}
+                      />
+                      <span>{s.toUpperCase()}</span>
+                    </Space>
+                  ),
+                }))}
+                style={{ width: 160 }}
               />
               <Button
                 icon={<DeleteOutlined />}
@@ -125,11 +179,9 @@ export default function PolicySimulator() {
             type={result.summary.blocked > 0 ? "error" : "success"}
             showIcon
             message={
-              <>
-                {result.summary.blocked > 0
-                  ? `${result.summary.blocked} ${t.policySim.blocked}`
-                  : `${result.summary.passed} ${t.policySim.passed}`}
-              </>
+              locale === "ko"
+                ? `${result.summary.blocked}건 차단 · ${result.summary.passed}건 통과 · 총 ${result.summary.total_policies}개 정책`
+                : `${result.summary.blocked} blocked · ${result.summary.passed} passed · ${result.summary.total_policies} policies total`
             }
           />
           <Table
@@ -137,32 +189,107 @@ export default function PolicySimulator() {
             rowKey="policy_id"
             size="small"
             pagination={false}
+            rowClassName={(r) => (r.blocked ? "mond-row-high" : "")}
+            locale={{
+              emptyText: <Empty description={locale === "ko" ? "정책 없음" : "No policies"} />,
+            }}
+            expandable={{
+              rowExpandable: (r) => r.matched.length > 0 || !r.enabled,
+              expandedRowRender: (r) => (
+                <Space direction="vertical" size={6} style={{ paddingBlock: 4, width: "100%" }}>
+                  {!r.enabled && (
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      {locale === "ko"
+                        ? "비활성 정책 — 게이트에 적용되지 않습니다."
+                        : "Disabled policy — gate not applied."}
+                    </Text>
+                  )}
+                  {r.matched.length > 0 && (
+                    <>
+                      <Text strong style={{ fontSize: 12 }}>
+                        {r.engine === "opa"
+                          ? locale === "ko"
+                            ? "OPA deny 메시지"
+                            : "OPA deny messages"
+                          : locale === "ko"
+                            ? "차단된 발견사항"
+                            : "Findings that blocked"}
+                      </Text>
+                      <ul style={{ marginBottom: 0, paddingInlineStart: 18 }}>
+                        {r.matched.map((m, i) => (
+                          <li key={i}>
+                            <Text style={{ fontSize: 12 }}>{m}</Text>
+                          </li>
+                        ))}
+                      </ul>
+                    </>
+                  )}
+                </Space>
+              ),
+            }}
             columns={[
-              { title: "Policy", dataIndex: "policy_name" },
+              { title: locale === "ko" ? "정책" : "Policy", dataIndex: "policy_name" },
               {
-                title: "Type",
+                title: locale === "ko" ? "유형" : "Type",
                 dataIndex: "policy_type",
                 render: (v: string) => <Tag color="purple">{v}</Tag>,
                 width: 110,
               },
               {
-                title: "Threshold",
-                dataIndex: "threshold",
-                render: (v: string) => <Tag>{v}</Tag>,
+                title: "engine",
+                dataIndex: "engine",
+                render: (v: string) =>
+                  v === "opa" ? (
+                    <Tag color={ENGINE_COLOR.opa} icon={<RobotOutlined />} style={{ marginInlineEnd: 0 }}>
+                      opa
+                    </Tag>
+                  ) : (
+                    <Tag color={ENGINE_COLOR.builtin} style={{ marginInlineEnd: 0 }}>
+                      builtin
+                    </Tag>
+                  ),
                 width: 110,
               },
               {
-                title: t.policySim.result,
+                title: locale === "ko" ? "임계치" : "Threshold",
+                dataIndex: "threshold",
+                render: (v: string) => (
+                  <Space size={6}>
+                    <span
+                      style={{
+                        display: "inline-block",
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        background: SEVERITY_COLOR[v] ?? "#999",
+                      }}
+                    />
+                    <span>{v}</span>
+                  </Space>
+                ),
+                width: 130,
+              },
+              {
+                title: locale === "ko" ? "결과" : "Verdict",
                 dataIndex: "blocked",
                 render: (b: boolean, row) => (
-                  <Tag color={b ? "red" : "green"}>
-                    {b ? t.policySim.blocked : t.policySim.passed}
-                    {!row.enabled && " (disabled)"}
+                  <Tag color={!row.enabled ? "default" : b ? "red" : "green"} style={{ marginInlineEnd: 0 }}>
+                    {!row.enabled
+                      ? locale === "ko"
+                        ? "비활성"
+                        : "disabled"
+                      : b
+                        ? t.policySim.blocked
+                        : t.policySim.passed}
                   </Tag>
                 ),
-                width: 120,
+                width: 110,
               },
-              { title: "Reason", dataIndex: "reason", ellipsis: true },
+              {
+                title: locale === "ko" ? "사유" : "Reason",
+                dataIndex: "reason",
+                ellipsis: true,
+              },
             ]}
           />
         </Card>


### PR DESCRIPTION
## Summary
OPA Rego 정책(PR #57) 도입 후 PolicySimulator 결과에 `engine` 정보와 OPA `deny` 메시지가 빠져 있어서 보안 담당자가 '왜 차단됐는지'를 한 화면에서 못 봤음.

## 변경
`PolicySimulator.tsx`:
- `SimResultRow`에 `engine` · `matched` 타입 추가 (backend 응답에 이미 있음)
- **engine 컬럼** — `opa` 청보라 + 🤖, `builtin` 회색
- **임계치 색 dot** — Admin Policies와 일관성
- **결과 verdict** — 비활성/통과/차단 Tag 색 구분
- **행 expand**:
  - `opa`면 'OPA deny 메시지', `builtin`이면 '차단된 발견사항' 리스트
  - 비활성 정책 안내
- **blocked 행 좌측 색띠** — `mond-row-high` 재사용
- severity Select option도 색 dot 적용
- Summary Alert — '차단 N건 · 통과 M건 · 총 K개 정책'로 구체화
- EXPERIMENTAL 배지 톤다운 (orange → default)

## Test plan
- [x] vite build clean
- [x] backend 응답에 engine/matched 정상
- [ ] CI 통과