### PR TITLE
feat(admin-users): MFA 등록 상태 + SSO 출처 + 최근 로그인 시각화

### DIFF
--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -23,10 +23,26 @@ class UserRead(Timestamped):
     role: Role
     sso_provider: str | None = None
     last_login_at_iso: str | None = None
+    mfa_enrolled: bool = False
 
 
 class UpdateRoleIn(BaseModel):
     role: Role
+
+
+def _to_read(u: User) -> UserRead:
+    return UserRead(
+        id=u.id,
+        email=u.email,
+        name=u.name,
+        picture_url=u.picture_url,
+        role=u.role,
+        sso_provider=u.sso_provider,
+        last_login_at_iso=u.last_login_at.isoformat() if u.last_login_at else None,
+        mfa_enrolled=bool(u.mfa_enrolled),
+        created_at=u.created_at,
+        updated_at=u.updated_at,
+    )
 
 
 @router.get(
@@ -36,22 +52,7 @@ class UpdateRoleIn(BaseModel):
 )
 async def list_users(db: AsyncSession = Depends(get_db)) -> list[UserRead]:
     items = list((await db.execute(select(User).order_by(User.id))).scalars().all())
-    out: list[UserRead] = []
-    for u in items:
-        out.append(
-            UserRead(
-                id=u.id,
-                email=u.email,
-                name=u.name,
-                picture_url=u.picture_url,
-                role=u.role,
-                sso_provider=u.sso_provider,
-                last_login_at_iso=u.last_login_at.isoformat() if u.last_login_at else None,
-                created_at=u.created_at,
-                updated_at=u.updated_at,
-            )
-        )
-    return out
+    return [_to_read(u) for u in items]
 
 
 @router.patch(
@@ -75,17 +76,7 @@ async def update_role(
     target.role = payload.role
     await db.commit()
     await db.refresh(target)
-    return UserRead(
-        id=target.id,
-        email=target.email,
-        name=target.name,
-        picture_url=target.picture_url,
-        role=target.role,
-        sso_provider=target.sso_provider,
-        last_login_at_iso=target.last_login_at.isoformat() if target.last_login_at else None,
-        created_at=target.created_at,
-        updated_at=target.updated_at,
-    )
+    return _to_read(target)
 
 
 @router.get("/me/refresh", response_model=UserRead)
@@ -93,14 +84,4 @@ async def me_refresh(
     user: User = Depends(current_user),
 ) -> UserRead:
     """최신 role/메타 재조회용."""
-    return UserRead(
-        id=user.id,
-        email=user.email,
-        name=user.name,
-        picture_url=user.picture_url,
-        role=user.role,
-        sso_provider=user.sso_provider,
-        last_login_at_iso=user.last_login_at.isoformat() if user.last_login_at else None,
-        created_at=user.created_at,
-        updated_at=user.updated_at,
-    )
+    return _to_read(user)

--- a/frontend/src/lib/users-api.ts
+++ b/frontend/src/lib/users-api.ts
@@ -13,6 +13,7 @@ export interface AdminUser {
   role: Role;
   sso_provider?: string | null;
   last_login_at_iso?: string | null;
+  mfa_enrolled?: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/src/pages/admin/AdminUsers.tsx
+++ b/frontend/src/pages/admin/AdminUsers.tsx
@@ -3,8 +3,15 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Avatar, Button, Card, Input, Select, Space, Table, Tabs, Tag, Typography, message } from "antd";
-import { CheckOutlined, CloseOutlined, TeamOutlined, UserOutlined } from "@ant-design/icons";
+import { Avatar, Button, Card, Input, Select, Space, Table, Tabs, Tag, Tooltip, Typography, message } from "antd";
+import {
+  CheckCircleFilled,
+  CheckOutlined,
+  CloseOutlined,
+  TeamOutlined,
+  UserOutlined,
+  WarningFilled,
+} from "@ant-design/icons";
 import { useState } from "react";
 
 import { useAuth } from "@/auth/AuthContext";
@@ -23,6 +30,19 @@ const ROLE_COLOR: Record<Role, string> = {
   reviewer: "purple",
   admin: "red",
 };
+
+function relativeKo(iso: string, locale: "ko" | "en"): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 0) return new Date(iso).toLocaleString();
+  const min = Math.floor(ms / 60_000);
+  if (min < 1) return locale === "ko" ? "방금" : "now";
+  if (min < 60) return locale === "ko" ? `${min}분 전` : `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return locale === "ko" ? `${hr}시간 전` : `${hr}h ago`;
+  const d = Math.floor(hr / 24);
+  if (d < 30) return locale === "ko" ? `${d}일 전` : `${d}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
 
 export default function AdminUsers() {
   const { t, locale } = useI18n();
@@ -48,28 +68,94 @@ export default function AdminUsers() {
         dataSource={data ?? []}
         rowKey="id"
         columns={[
-            {
-              title: t.adminArea.user,
-              render: (_: unknown, u: AdminUser) => (
-                <Space>
-                  <Avatar size={28} src={u.picture_url ?? undefined} icon={!u.picture_url && <UserOutlined />} />
-                  <Space direction="vertical" size={0}>
-                    <span>{u.name || u.email}</span>
-                    <span style={{ color: "var(--mond-text-dim)", fontSize: 12 }}>{u.email}</span>
+          {
+            title: t.adminArea.user,
+            render: (_: unknown, u: AdminUser) => (
+              <Space>
+                <Avatar
+                  size={28}
+                  src={u.picture_url ?? undefined}
+                  icon={!u.picture_url && <UserOutlined />}
+                />
+                <Space direction="vertical" size={0}>
+                  <Space size={4}>
+                    <Text strong>{u.name || u.email}</Text>
+                    {me?.id === u.id && (
+                      <Tag color="cyan" style={{ marginInlineEnd: 0, fontSize: 11 }}>
+                        {locale === "ko" ? "본인" : "you"}
+                      </Tag>
+                    )}
                   </Space>
+                  <span style={{ color: "var(--mond-text-dim)", fontSize: 12 }}>{u.email}</span>
                 </Space>
+              </Space>
+            ),
+          },
+          {
+            title: t.adminArea.ssoProvider,
+            dataIndex: "sso_provider",
+            render: (v: string | null) =>
+              v ? (
+                <Tag color="geekblue" style={{ marginInlineEnd: 0 }}>
+                  {v}
+                </Tag>
+              ) : (
+                <Tag color="default" style={{ marginInlineEnd: 0 }}>
+                  {locale === "ko" ? "Dev Login" : "Dev"}
+                </Tag>
               ),
+            width: 130,
+          },
+          {
+            title: "MFA",
+            dataIndex: "mfa_enrolled",
+            render: (enrolled: boolean | undefined, u: AdminUser) => {
+              const needs = u.role === "admin" || u.role === "reviewer";
+              if (enrolled)
+                return (
+                  <Tooltip
+                    title={locale === "ko" ? "MFA 등록 완료" : "MFA enrolled"}
+                  >
+                    <Tag color="green" icon={<CheckCircleFilled />} style={{ marginInlineEnd: 0 }}>
+                      {locale === "ko" ? "등록" : "On"}
+                    </Tag>
+                  </Tooltip>
+                );
+              if (needs)
+                return (
+                  <Tooltip
+                    title={
+                      locale === "ko"
+                        ? `${u.role} role은 MFA 강제 — 본인이 등록할 때까지 보호 리소스 접근 불가`
+                        : `${u.role} role requires MFA`
+                    }
+                  >
+                    <Tag color="orange" icon={<WarningFilled />} style={{ marginInlineEnd: 0 }}>
+                      {locale === "ko" ? "필요" : "Required"}
+                    </Tag>
+                  </Tooltip>
+                );
+              return (
+                <Tag color="default" style={{ marginInlineEnd: 0 }}>
+                  —
+                </Tag>
+              );
             },
-            {
-              title: t.adminArea.ssoProvider,
-              dataIndex: "sso_provider",
-              render: (v: string | null) => (v ? <Tag>{v}</Tag> : "—"),
-              width: 120,
-            },
-            {
-              title: t.adminArea.role,
-              dataIndex: "role",
-              render: (r: Role, u: AdminUser) => (
+            width: 110,
+          },
+          {
+            title: t.adminArea.role,
+            dataIndex: "role",
+            render: (r: Role, u: AdminUser) => (
+              <Tooltip
+                title={
+                  me?.id === u.id && r === "admin"
+                    ? locale === "ko"
+                      ? "본인의 ADMIN 권한은 잠금 방지를 위해 직접 낮출 수 없습니다"
+                      : "Cannot demote your own ADMIN"
+                    : undefined
+                }
+              >
                 <Select
                   size="small"
                   value={r}
@@ -85,14 +171,26 @@ export default function AdminUsers() {
                   onChange={(val) => updateRole.mutate({ id: u.id, role: val })}
                   disabled={me?.id === u.id && r === "admin"}
                 />
+              </Tooltip>
+            ),
+            width: 170,
+          },
+          {
+            title: t.adminArea.lastLogin,
+            dataIndex: "last_login_at_iso",
+            render: (v: string | null) =>
+              v ? (
+                <Tooltip title={new Date(v).toLocaleString()}>
+                  <Text type="secondary" style={{ fontSize: 12 }}>
+                    {relativeKo(v, locale)}
+                  </Text>
+                </Tooltip>
+              ) : (
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  {locale === "ko" ? "로그인 기록 없음" : "Never"}
+                </Text>
               ),
-              width: 180,
-            },
-            {
-              title: t.adminArea.lastLogin,
-              dataIndex: "last_login_at_iso",
-              render: (v: string | null) => (v ? new Date(v).toLocaleString() : "—"),
-              width: 200,
+            width: 170,
           },
         ]}
       />


### PR DESCRIPTION
## Summary
기존 사용자 테이블은 role 변경만 가능 + SSO/last_login 정보가 약하고 MFA 등록 상태는 노출 안 됨. admin이 'MFA 강제 대상 미등록자 찾기', '휴면 계정 식별'을 한 화면에서 못 했음.

## 변경

### Backend
- `UserRead`에 `mfa_enrolled: bool` 필드 추가
- `_to_read` 헬퍼로 list/update_role/me_refresh 직렬화 일원화

### Frontend (AdminUsers)
- **사용자 셀**: 본인 행에 `you` 청록 태그
- **SSO**: provider 청보라 / `Dev Login` 회색
- **MFA 컬럼 신규**:
  - `enrolled=true` → 녹색 `등록` + ✓
  - `enrolled=false` + role∈{admin,reviewer} → 주황 `필요` + ⚠️
  - 그 외 → `—`
  - 각각 tooltip 안내
- **Role**: 본인의 ADMIN demote 막힘을 tooltip 명시
- **최근 로그인**: 절대 시각 → '5분 전·3시간 전·2일 전' relative + tooltip(절대 시각). 로그인 기록 없음은 dim text

## Test plan
- [x] ruff clean
- [x] vite build clean
- [ ] CI 통과