### PR TITLE
feat(audit-log): v0.3 #6 — admin 감사 로그 검색 UI

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -5,6 +5,7 @@ API v1 라우터
 from fastapi import APIRouter
 
 from app.api.v1.endpoints import (
+    admin_audit_log,
     admin_github_sync,
     admin_slack,
     ai,
@@ -51,6 +52,7 @@ api_router.include_router(ai.router, prefix="/ai", tags=["AI"])
 api_router.include_router(ai_providers.router, prefix="/admin/ai-providers", tags=["AI Providers (Admin)"])
 api_router.include_router(admin_slack.router, prefix="/admin/slack", tags=["Slack Channels (Admin)"])
 api_router.include_router(admin_github_sync.router, prefix="/admin/github-sync", tags=["GitHub Sync (Admin)"])
+api_router.include_router(admin_audit_log.router, prefix="/admin/audit-log", tags=["Audit Log (Admin)"])
 api_router.include_router(digest.router, prefix="/admin/digest", tags=["Daily Digest (Admin)"])
 api_router.include_router(integrations.router, prefix="/integrations", tags=["Integrations"])
 api_router.include_router(webhooks.router, prefix="/webhooks", tags=["Webhooks"])

--- a/backend/app/api/v1/endpoints/admin_audit_log.py
+++ b/backend/app/api/v1/endpoints/admin_audit_log.py
@@ -1,0 +1,78 @@
+"""감사 로그 검색 — ADMIN 전용.
+
+access_audit_logs 테이블을 시계열로 조회. 필터: 기간 · actor · event · request_id.
+"""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.deps import require_role
+from app.core.database import get_db
+from app.models.iam import AccessAuditLog, AccessRequest, AuditEvent
+from app.models.user import Role
+
+router = APIRouter(dependencies=[Depends(require_role(Role.ADMIN))])
+
+
+@router.get("")
+async def list_audit_log(
+    start: datetime | None = Query(None, description="ISO 8601, created_at >= start"),
+    end: datetime | None = Query(None, description="ISO 8601, created_at < end"),
+    actor: str | None = Query(None, description="actor email substring (case-insensitive)"),
+    event: AuditEvent | None = Query(None),
+    request_id: int | None = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    stmt = select(AccessAuditLog).order_by(AccessAuditLog.created_at.desc())
+    if start:
+        stmt = stmt.where(AccessAuditLog.created_at >= start)
+    if end:
+        stmt = stmt.where(AccessAuditLog.created_at < end)
+    if actor:
+        stmt = stmt.where(AccessAuditLog.actor.ilike(f"%{actor}%"))
+    if event:
+        stmt = stmt.where(AccessAuditLog.event == event)
+    if request_id:
+        stmt = stmt.where(AccessAuditLog.request_id == request_id)
+
+    rows = (await db.execute(stmt.limit(limit).offset(offset))).scalars().all()
+
+    # request_id별 requester/permission/identity 1회 fetch로 노출
+    req_ids = sorted({r.request_id for r in rows})
+    req_map: dict[int, dict] = {}
+    if req_ids:
+        reqs = (
+            (await db.execute(select(AccessRequest).where(AccessRequest.id.in_(req_ids))))
+            .scalars()
+            .all()
+        )
+        for r in reqs:
+            req_map[r.id] = {
+                "requester": r.requester,
+                "identity_id": r.target_identity_id,
+                "permission_id": r.permission_id,
+                "status": r.status.value,
+            }
+
+    return {
+        "items": [
+            {
+                "id": r.id,
+                "request_id": r.request_id,
+                "event": r.event.value,
+                "actor": r.actor,
+                "detail": r.detail,
+                "created_at": r.created_at.isoformat(),
+                "request": req_map.get(r.request_id),
+            }
+            for r in rows
+        ],
+        "limit": limit,
+        "offset": offset,
+        "count": len(rows),
+    }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ const AdminConnections = lazy(() => import("@/pages/admin/AdminConnections"));
 const AdminPolicies = lazy(() => import("@/pages/admin/AdminPolicies"));
 const AdminSlack = lazy(() => import("@/pages/admin/AdminSlack"));
 const AdminUsers = lazy(() => import("@/pages/admin/AdminUsers"));
+const AdminAuditLog = lazy(() => import("@/pages/admin/AdminAuditLog"));
 
 // 페이지 chunk 로딩 중 빈 화면 대신 옅은 placeholder. 다크 테마 배경에 자연스럽게 녹는다.
 function RouteFallback() {
@@ -144,6 +145,14 @@ export default function App() {
             element={
               <RequireAuth minRole="admin">
                 <AdminUsers />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="admin/audit-log"
+            element={
+              <RequireAuth minRole="admin">
+                <AdminAuditLog />
               </RequireAuth>
             }
           />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -97,6 +97,7 @@ export default function Layout() {
     { key: "/admin/connections", icon: <ApiOutlined />, label: t.adminArea.menuConnections, minRole: "admin" as const },
     { key: "/admin/slack", icon: <BulbOutlined />, label: t.adminArea.menuSlack, minRole: "admin" as const },
     { key: "/admin/users", icon: <TeamOutlined />, label: t.adminArea.menuUsers, minRole: "admin" as const },
+    { key: "/admin/audit-log", icon: <FileTextOutlined />, label: t.adminArea.menuAuditLog, minRole: "admin" as const },
   ].filter((i) => hasRole(user, i.minRole));
 
   const items = isAdminRoute ? adminFlat : userMenu;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -47,6 +47,7 @@ export const en: Dict = {
     menuSlack: "Slack Integration",
     menuPolicies: "Policy Management",
     menuUsers: "Users & Roles",
+    menuAuditLog: "Audit Log",
     connectionsTitle: "Connections",
     connectionsDesc:
       "Manage external integrations in one place — cloud IAM sources, SSO IdPs, and external webhooks. ADMIN role required.",

--- a/frontend/src/i18n/ko.ts
+++ b/frontend/src/i18n/ko.ts
@@ -45,6 +45,7 @@ export const ko = {
     menuSlack: "Slack 연동",
     menuPolicies: "정책 관리",
     menuUsers: "사용자·역할",
+    menuAuditLog: "감사 로그",
     connectionsTitle: "연동 관리",
     connectionsDesc:
       "클라우드 IAM 소스, SSO IdP, 외부 Webhook 같은 외부 시스템 연동을 한 곳에서 관리합니다. ADMIN 권한이 필요합니다.",

--- a/frontend/src/pages/admin/AdminAuditLog.tsx
+++ b/frontend/src/pages/admin/AdminAuditLog.tsx
@@ -1,0 +1,292 @@
+/**
+ * Admin · Audit Log — access_audit_logs 검색·필터·시계열 뷰 (ADMIN 전용).
+ *
+ * 필터: 기간 · actor · event · request_id.
+ * 시계열 timeline 표 — actor + event 색 chip + detail JSON expand.
+ */
+
+import { FileSearchOutlined, ReloadOutlined } from "@ant-design/icons";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Button,
+  Card,
+  DatePicker,
+  Empty,
+  Input,
+  Select,
+  Space,
+  Table,
+  Tag,
+  Typography,
+} from "antd";
+import type { Dayjs } from "dayjs";
+import { useMemo, useState } from "react";
+
+import { useI18n } from "@/i18n";
+import { api } from "@/lib/api";
+
+const { Title, Paragraph, Text } = Typography;
+const { RangePicker } = DatePicker;
+
+type AuditEvent =
+  | "ai_decided"
+  | "human_decided"
+  | "granted"
+  | "grant_failed"
+  | "expired_revoked"
+  | "revoke_failed"
+  | "manual_revoked";
+
+interface AuditRow {
+  id: number;
+  request_id: number;
+  event: AuditEvent;
+  actor: string;
+  detail: Record<string, unknown>;
+  created_at: string;
+  request: null | {
+    requester: string;
+    identity_id: number;
+    permission_id: number;
+    status: string;
+  };
+}
+
+interface AuditResp {
+  items: AuditRow[];
+  limit: number;
+  offset: number;
+  count: number;
+}
+
+const EVENT_COLOR: Record<AuditEvent, string> = {
+  ai_decided: "purple",
+  human_decided: "geekblue",
+  granted: "green",
+  grant_failed: "red",
+  expired_revoked: "default",
+  revoke_failed: "magenta",
+  manual_revoked: "orange",
+};
+
+const EVENT_LABEL_KO: Record<AuditEvent, string> = {
+  ai_decided: "AI 결정",
+  human_decided: "담당자 결정",
+  granted: "권한 부여",
+  grant_failed: "부여 실패",
+  expired_revoked: "만료 회수",
+  revoke_failed: "회수 실패",
+  manual_revoked: "수동 회수",
+};
+
+const EVENT_OPTIONS: AuditEvent[] = [
+  "ai_decided",
+  "human_decided",
+  "granted",
+  "grant_failed",
+  "expired_revoked",
+  "revoke_failed",
+  "manual_revoked",
+];
+
+export default function AdminAuditLog() {
+  const { locale } = useI18n();
+  const [range, setRange] = useState<[Dayjs, Dayjs] | null>(null);
+  const [actor, setActor] = useState("");
+  const [event, setEvent] = useState<AuditEvent | undefined>(undefined);
+  const [requestId, setRequestId] = useState("");
+
+  const params = useMemo(() => {
+    const p: Record<string, string | number> = { limit: 200 };
+    if (range?.[0]) p.start = range[0].toISOString();
+    if (range?.[1]) p.end = range[1].toISOString();
+    if (actor.trim()) p.actor = actor.trim();
+    if (event) p.event = event;
+    const rid = Number(requestId);
+    if (rid && Number.isFinite(rid)) p.request_id = rid;
+    return p;
+  }, [range, actor, event, requestId]);
+
+  const { data, isLoading, refetch, isFetching } = useQuery({
+    queryKey: ["admin-audit-log", params],
+    queryFn: async () => (await api.get<AuditResp>("/admin/audit-log", { params })).data,
+  });
+
+  return (
+    <div>
+      <Title level={2} style={{ marginBottom: 8 }}>
+        <Space>
+          <FileSearchOutlined />
+          <span>{locale === "ko" ? "감사 로그" : "Audit Log"}</span>
+        </Space>
+      </Title>
+      <Paragraph type="secondary">
+        {locale === "ko"
+          ? "권한 요청 흐름의 모든 결정(AI/담당자), 부여, 회수 이벤트를 시계열로 검색합니다. ADMIN 권한 필요."
+          : "Search access-request audit events (AI/human decisions, grants, revokes). ADMIN only."}
+      </Paragraph>
+
+      <Card style={{ marginBottom: 12 }}>
+        <Space wrap size={[8, 8]}>
+          <RangePicker
+            showTime
+            value={range ?? undefined}
+            onChange={(v) => setRange(v as [Dayjs, Dayjs] | null)}
+            allowClear
+          />
+          <Input
+            placeholder={locale === "ko" ? "actor (이메일·system·ai)" : "actor email/system/ai"}
+            value={actor}
+            onChange={(e) => setActor(e.target.value)}
+            style={{ width: 220 }}
+            allowClear
+          />
+          <Select
+            placeholder={locale === "ko" ? "event 전체" : "All events"}
+            value={event}
+            onChange={(v) => setEvent(v)}
+            options={EVENT_OPTIONS.map((e) => ({
+              value: e,
+              label: (
+                <Space size={4}>
+                  <Tag color={EVENT_COLOR[e]} style={{ marginInlineEnd: 0 }}>
+                    {EVENT_LABEL_KO[e]}
+                  </Tag>
+                </Space>
+              ),
+            }))}
+            style={{ width: 200 }}
+            allowClear
+          />
+          <Input
+            placeholder="request_id"
+            value={requestId}
+            onChange={(e) => setRequestId(e.target.value.replace(/\D/g, ""))}
+            style={{ width: 130 }}
+            allowClear
+          />
+          <Button
+            icon={<ReloadOutlined />}
+            loading={isFetching}
+            onClick={() => refetch()}
+          >
+            {locale === "ko" ? "새로고침" : "Refresh"}
+          </Button>
+        </Space>
+      </Card>
+
+      <Card>
+        <Table
+          loading={isLoading}
+          dataSource={data?.items ?? []}
+          rowKey="id"
+          size="small"
+          pagination={{ pageSize: 50, showSizeChanger: false }}
+          locale={{
+            emptyText: (
+              <Empty
+                description={
+                  locale === "ko" ? "조건에 맞는 감사 이벤트가 없습니다" : "No audit events match"
+                }
+              />
+            ),
+          }}
+          expandable={{
+            rowExpandable: (r) => Object.keys(r.detail || {}).length > 0,
+            expandedRowRender: (r) => (
+              <pre
+                style={{
+                  background: "var(--mond-surface-2, #0d1421)",
+                  padding: 10,
+                  borderRadius: 6,
+                  fontSize: 11,
+                  marginBottom: 0,
+                  overflowX: "auto",
+                }}
+              >
+                {JSON.stringify(r.detail, null, 2)}
+              </pre>
+            ),
+          }}
+          columns={[
+            {
+              title: locale === "ko" ? "시각" : "When",
+              dataIndex: "created_at",
+              width: 180,
+              render: (v: string) => (
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  {new Date(v).toLocaleString()}
+                </Text>
+              ),
+            },
+            {
+              title: "Event",
+              dataIndex: "event",
+              width: 140,
+              render: (e: AuditEvent) => (
+                <Tag color={EVENT_COLOR[e]} style={{ marginInlineEnd: 0 }}>
+                  {EVENT_LABEL_KO[e]}
+                </Tag>
+              ),
+            },
+            {
+              title: locale === "ko" ? "Actor" : "Actor",
+              dataIndex: "actor",
+              width: 220,
+              render: (a: string) => {
+                const isAi = a === "ai" || a === "claude";
+                const isSystem = a === "system";
+                return (
+                  <Tag
+                    color={isAi ? "purple" : isSystem ? "default" : "geekblue"}
+                    style={{ marginInlineEnd: 0 }}
+                  >
+                    {a}
+                  </Tag>
+                );
+              },
+            },
+            {
+              title: "Request",
+              dataIndex: "request_id",
+              width: 130,
+              render: (rid: number, r: AuditRow) => (
+                <Space size={4}>
+                  <Text strong>#{rid}</Text>
+                  {r.request?.requester && (
+                    <Text type="secondary" style={{ fontSize: 11 }}>
+                      {r.request.requester}
+                    </Text>
+                  )}
+                </Space>
+              ),
+            },
+            {
+              title: locale === "ko" ? "요약" : "Summary",
+              key: "summary",
+              render: (_: unknown, r: AuditRow) => {
+                const d = r.detail || {};
+                const bits: string[] = [];
+                if (typeof d.decision === "string") bits.push(`decision=${d.decision}`);
+                if (typeof d.risk_level === "string") bits.push(`risk=${d.risk_level}`);
+                if (typeof d.reason === "string") bits.push(d.reason as string);
+                if (bits.length === 0 && Object.keys(d).length > 0) {
+                  return (
+                    <Text type="secondary" style={{ fontSize: 11 }}>
+                      {Object.keys(d).join(" · ")}
+                    </Text>
+                  );
+                }
+                return (
+                  <Text type="secondary" style={{ fontSize: 12 }} ellipsis>
+                    {bits.join(" · ")}
+                  </Text>
+                );
+              },
+            },
+          ]}
+        />
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
v0.3 첫 항목. `access_audit_logs` 테이블은 v0.1부터 access_request 흐름의 모든 결정/부여/회수 이벤트를 시계열로 보관해왔지만 UI가 없어 admin이 DB에 직접 접근해야 했음.

## 변경

### Backend
`admin_audit_log.py` (신규):
- `GET /admin/audit-log` — 필터 `start`/`end`/`actor`(ILIKE)/`event`/`request_id`, pagination `limit`/`offset` (≤500)
- 응답에 request_id별 AccessRequest의 requester/identity/permission/status 1회 fetch 포함
- `require_role(ADMIN)`

### Frontend (AdminAuditLog)
- 필터 카드 — RangePicker(시간 포함) · actor · event · request_id · 새로고침
- **Event 색** — AI 결정(보라) · 담당자 결정(청보라) · 부여(녹색) · 실패(빨강) · 만료 회수(회색) · 수동 회수(주황)
- **Actor 색** — ai/claude(보라) · system(회색) · 기타(청보라)
- **Summary** — `detail`에서 decision/risk_level/reason 자동 추출
- **Row expand** — 원본 detail JSON pretty
- `/admin/audit-log` 라우트 + 사이드바 'audit log' 메뉴

## Test plan
- [x] ruff clean
- [x] vite build clean
- [x] MFA gating 정상
- [ ] CI 통과