### PR TITLE
feat(ai): v0.3 #2 — intent별 model 자동 라우팅

### DIFF
--- a/backend/app/ai/client.py
+++ b/backend/app/ai/client.py
@@ -187,6 +187,21 @@ async def current_model_label(db: AsyncSession) -> str:
     return f"{rt.provider}:{rt.model_default}"
 
 
+# intent별 라우팅 규칙 — model_default(빠르고 저비용) vs model_deep(추론 정확도).
+# remediation/explain/deep_analysis 같은 '깊이가 필요한' intent는 자동으로 deep 모델로.
+# 그 외(triage/route/list_findings/scan)는 default 모델로 비용/지연 최소화.
+_DEEP_INTENTS = {"remediation", "explain", "deep_analysis"}
+
+
+def _pick_model(rt: ProviderRuntime, *, deep: bool, intent: str | None) -> tuple[str, str]:
+    """라우팅 결정. (model, tier='default'|'deep') 반환."""
+    if deep:
+        return rt.model_deep, "deep"
+    if intent and intent in _DEEP_INTENTS:
+        return rt.model_deep, "deep"
+    return rt.model_default, "default"
+
+
 async def complete_json(
     db: AsyncSession,
     system: str,
@@ -194,12 +209,21 @@ async def complete_json(
     *,
     deep: bool = False,
     max_tokens: int | None = None,
+    intent: str | None = None,
 ) -> CompletionResult | None:
-    """provider별 LLM 호출. 실패하면 None — 호출부는 fallback 처리."""
+    """provider별 LLM 호출. 실패하면 None — 호출부는 fallback 처리.
+
+    intent별 라우팅:
+      - 'remediation' / 'explain' / 'deep_analysis' → model_deep (느리지만 정확)
+      - 그 외(triage/route 등) → model_default (빠르고 저비용)
+      - `deep=True`는 intent와 무관하게 deep 강제 (하위 호환)
+    """
     rt = await get_runtime(db)
     if rt is None:
         return None
-    model = rt.model_deep if deep else rt.model_default
+    model, tier = _pick_model(rt, deep=deep, intent=intent)
+    if intent:
+        logger.info("ai_intent_routed", provider=rt.provider, intent=intent, tier=tier, model=model)
     max_tokens = max_tokens or settings.AI_MAX_TOKENS
 
     try:

--- a/backend/app/ai/insights.py
+++ b/backend/app/ai/insights.py
@@ -62,7 +62,10 @@ async def analyze_finding(db: AsyncSession, finding: Finding, *, deep: bool = Fa
         return _fallback(finding)
 
     user_prompt = _build_user_prompt(finding)
-    result = await complete_json(db, SYSTEM_PROMPT, user_prompt, deep=deep)
+    # intent — deep=True면 'remediation'(코드 패치 제안 포함), 아니면 'triage'(분류만).
+    # client._pick_model이 'remediation'은 자동으로 model_deep으로 라우팅.
+    finding_intent = "remediation" if deep else "triage"
+    result = await complete_json(db, SYSTEM_PROMPT, user_prompt, deep=deep, intent=finding_intent)
     if result is None:
         logger.warning("ai_analyze_failed_or_disabled", finding_id=finding.id)
         return _fallback(finding)
@@ -129,7 +132,8 @@ async def route_query(db: AsyncSession, query: str) -> dict:
     if context_block:
         system = f"{system}\n\n{context_block}"
 
-    result = await complete_json(db, system, user_prompt, max_tokens=600)
+    # route_query는 자연어 → intent 분류이므로 model_default(빠른 모델)로 라우팅.
+    result = await complete_json(db, system, user_prompt, max_tokens=600, intent="route")
     if result is None:
         fallback = _heuristic_route(query)
         fallback["citations"] = [c.to_dict() for c in citations]

--- a/backend/tests/test_ai_intent_routing.py
+++ b/backend/tests/test_ai_intent_routing.py
@@ -1,0 +1,69 @@
+"""
+AI multi-provider 라우팅 — intent별 model 선택 invariant.
+
+complete_json 자체는 외부 LLM 호출이라 단위 테스트가 어려워, 라우팅 결정
+함수 _pick_model을 직접 검증한다.
+"""
+
+from app.ai.client import ProviderRuntime, _pick_model
+
+
+def _rt() -> ProviderRuntime:
+    return ProviderRuntime(
+        provider="anthropic",
+        api_key="k",
+        base_url=None,
+        region=None,
+        model_default="claude-3-5-haiku-latest",
+        model_deep="claude-sonnet-4-latest",
+        source="db",
+    )
+
+
+def test_default_when_no_intent_no_deep():
+    model, tier = _pick_model(_rt(), deep=False, intent=None)
+    assert tier == "default"
+    assert "haiku" in model.lower()
+
+
+def test_explicit_deep_flag_wins():
+    model, tier = _pick_model(_rt(), deep=True, intent=None)
+    assert tier == "deep"
+    assert "sonnet" in model.lower()
+
+
+def test_remediation_intent_uses_deep():
+    model, tier = _pick_model(_rt(), deep=False, intent="remediation")
+    assert tier == "deep"
+    assert "sonnet" in model.lower()
+
+
+def test_explain_intent_uses_deep():
+    _, tier = _pick_model(_rt(), deep=False, intent="explain")
+    assert tier == "deep"
+
+
+def test_deep_analysis_intent_uses_deep():
+    _, tier = _pick_model(_rt(), deep=False, intent="deep_analysis")
+    assert tier == "deep"
+
+
+def test_triage_intent_keeps_default():
+    _, tier = _pick_model(_rt(), deep=False, intent="triage")
+    assert tier == "default"
+
+
+def test_route_intent_keeps_default():
+    _, tier = _pick_model(_rt(), deep=False, intent="route")
+    assert tier == "default"
+
+
+def test_unknown_intent_falls_back_to_default():
+    _, tier = _pick_model(_rt(), deep=False, intent="something_unknown")
+    assert tier == "default"
+
+
+def test_deep_flag_overrides_lightweight_intent():
+    # 명시적 deep=True는 intent가 triage여도 deep으로.
+    _, tier = _pick_model(_rt(), deep=True, intent="triage")
+    assert tier == "deep"


### PR DESCRIPTION
## Summary
같은 LLM provider 안에서 intent에 따라 `model_default`(빠르고 저비용) vs `model_deep`(정확도)을 자동 선택. `deep=True`를 명시적으로 지정하지 않아도 'remediation/explain' 같은 깊이 필요한 의도는 자동 승급.

## 변경
`client.py`:
- `_DEEP_INTENTS = {'remediation', 'explain', 'deep_analysis'}`
- `_pick_model(rt, *, deep, intent) → (model, tier)`
- `complete_json(..., intent=None)` 파라미터 추가
- `ai_intent_routed` 로그 (provider/intent/tier/model)

`insights.py`:
- `analyze_finding(deep=False)` → `intent='triage'` (default model)
- `analyze_finding(deep=True)` → `intent='remediation'` (deep model)
- `route_query` → `intent='route'` (default model)

`tests/test_ai_intent_routing.py` — 9 케이스 모두 통과

## 운영 효과
같은 Anthropic provider에서:
- 'AI 분석 실행' = Haiku로 빠른 triage
- '심층 분석' = Sonnet으로 코드 패치까지
→ 토큰 비용 자동 절감 + 첫 응답 latency 개선

## Test plan
- [x] pytest 9/9 통과
- [x] backend ruff clean
- [ ] CI 통과