### PR TITLE
feat(pr-bot): v0.3 #10 — push 스캔 결과를 PR 코멘트로

### DIFF
--- a/backend/app/api/v1/endpoints/webhooks.py
+++ b/backend/app/api/v1/endpoints/webhooks.py
@@ -153,6 +153,24 @@ async def github_webhook(
         trigger=ScanTrigger.WEBHOOK,
         router_decision=decision,
     )
+
+    # PR Bot — scan이 인라인으로 완료된 경우(Celery off) head_sha에 매칭되는
+    # open PR이 있으면 코멘트 작성. async 큐 모드에선 worker가 별도 처리(v0.4).
+    pr_bot_result: dict | None = None
+    head_sha = (payload.get("after") or "").strip()
+    if head_sha and scan.status.value == "completed":
+        full_name = (repo.get("full_name") or "").strip()
+        if full_name:
+            from app.services import pr_bot as pr_bot_service
+
+            pr_bot_result = await pr_bot_service.notify_pr_for_scan(
+                db,
+                scan=scan,
+                asset=asset,
+                repo_full_name=full_name,
+                head_sha=head_sha,
+            )
+
     return {
         "matched": True,
         "asset_id": asset.id,
@@ -160,6 +178,7 @@ async def github_webhook(
         "status": scan.status.value,
         "scanner": scanner_name,
         "router_decision": decision,
+        "pr_bot": pr_bot_result,
     }
 
 

--- a/backend/app/services/pr_bot.py
+++ b/backend/app/services/pr_bot.py
@@ -1,0 +1,183 @@
+"""
+PR Bot — push 스캔 결과를 PR 코멘트로.
+
+흐름:
+  1) GitHub push webhook → scan_service.trigger_scan (인라인) 완료
+  2) head_sha → /repos/{owner}/{repo}/commits/{sha}/pulls 로 open PR 검색
+  3) finding 요약 + (AI 활성 시) top critical 1건 AI triage 1-liner를 markdown으로
+  4) post_pr_comment로 작성 (SBOM diff와 같은 라우트 재사용)
+
+운영:
+  - GITHUB_TOKEN 필요. 없으면 silent skip.
+  - inline scan 완료 후에만 동작. Celery 비동기 큐는 worker가 별도로 트리거해야 함 (v0.4).
+  - 자산이 GitHub repo 자산일 때만 동작.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import httpx
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.ai.client import is_enabled as ai_enabled
+from app.ai.insights import analyze_finding
+from app.core.config import settings
+from app.models.asset import Asset, AssetType
+from app.models.finding import Finding, Severity
+from app.models.scan import Scan
+from app.services import sbom_diff as sbom_diff_service
+
+logger = structlog.get_logger(__name__)
+
+SEVERITY_RANK = {
+    Severity.CRITICAL: 4,
+    Severity.HIGH: 3,
+    Severity.MEDIUM: 2,
+    Severity.LOW: 1,
+    Severity.INFO: 0,
+}
+
+
+async def find_open_prs(owner: str, repo: str, head_sha: str) -> list[int]:
+    """given head sha에 열린 PR 번호 목록 (보통 0~1건)."""
+    token = settings.GITHUB_TOKEN
+    if not token:
+        return []
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+    }
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits/{head_sha}/pulls"
+    try:
+        async with httpx.AsyncClient(timeout=10, headers=headers) as client:
+            r = await client.get(url)
+            if r.status_code >= 400:
+                logger.info("pr_bot_lookup_failed", status=r.status_code, sha=head_sha[:8])
+                return []
+            data = r.json()
+            return [
+                int(item["number"])
+                for item in data
+                if isinstance(item, dict) and item.get("state") == "open" and item.get("number")
+            ]
+    except Exception as exc:
+        logger.info("pr_bot_lookup_exception", error=str(exc))
+        return []
+
+
+def _severity_summary(findings: list[Finding]) -> tuple[Counter, list[Finding]]:
+    """severity별 카운트 + critical/high 우선 정렬 top 5."""
+    counter: Counter = Counter(f.severity.value for f in findings)
+    by_rank = sorted(findings, key=lambda f: -SEVERITY_RANK.get(f.severity, 0))
+    return counter, by_rank[:5]
+
+
+async def _ai_one_liner(db: AsyncSession, finding: Finding) -> str | None:
+    """top critical에 대한 AI 1-liner. provider 없으면 None."""
+    if not await ai_enabled(db):
+        return None
+    try:
+        result = await analyze_finding(db, finding, deep=False)
+        text = (result.summary or "").strip()
+        if not text:
+            return None
+        # 1줄로 (~140자)
+        first = text.splitlines()[0]
+        return first[:140] + ("…" if len(first) > 140 else "")
+    except Exception as exc:
+        logger.info("pr_bot_ai_oneliner_failed", error=str(exc))
+        return None
+
+
+def format_pr_comment(
+    *,
+    scan: Scan,
+    asset_name: str,
+    findings: list[Finding],
+    ai_oneliner: str | None,
+) -> str:
+    counter, top = _severity_summary(findings)
+    total = sum(counter.values())
+
+    parts: list[str] = []
+    parts.append("## 🌙 Mond — scan summary")
+    parts.append("")
+    parts.append(
+        f"`{asset_name}` · scanner=`{scan.scanner}` · status=`{scan.status.value}` · {scan.duration_ms or 0} ms"
+    )
+    if total == 0:
+        parts.append("")
+        parts.append("✅ No findings.")
+        return "\n".join(parts)
+
+    parts.append("")
+    sev_line = " · ".join(f"{k}: **{v}**" for k, v in counter.most_common())
+    parts.append(f"**{total}** finding(s) — {sev_line}")
+
+    if top:
+        parts.append("")
+        parts.append("### Top findings")
+        parts.append("| sev | rule | title |")
+        parts.append("|---|---|---|")
+        for f in top:
+            title = (f.title or "").replace("|", "\\|")
+            rule = (f.rule_id or "").replace("|", "\\|")
+            parts.append(f"| `{f.severity.value}` | `{rule}` | {title} |")
+
+    if ai_oneliner:
+        parts.append("")
+        parts.append(f"🤖 **AI triage** — {ai_oneliner}")
+
+    parts.append("")
+    parts.append("> Open Mond → Findings to see remediation guides + severity reassessment.")
+    return "\n".join(parts)
+
+
+async def notify_pr_for_scan(
+    db: AsyncSession,
+    *,
+    scan: Scan,
+    asset: Asset,
+    repo_full_name: str,
+    head_sha: str,
+) -> dict:
+    """scan 완료 직후 호출. 매칭 PR이 있고 GITHUB_TOKEN이 있으면 코멘트 작성."""
+    if asset.asset_type != AssetType.REPOSITORY:
+        return {"skipped": "asset_not_repository"}
+    if "/" not in repo_full_name:
+        return {"skipped": "invalid_repo"}
+    if not settings.GITHUB_TOKEN:
+        return {"skipped": "no_github_token"}
+
+    owner, repo = repo_full_name.split("/", 1)
+    prs = await find_open_prs(owner, repo, head_sha)
+    if not prs:
+        return {"skipped": "no_open_pr"}
+
+    findings = list(
+        (await db.execute(select(Finding).where(Finding.scan_id == scan.id))).scalars().all()
+    )
+
+    top_critical = next(
+        (f for f in findings if f.severity in (Severity.CRITICAL, Severity.HIGH)),
+        None,
+    )
+    ai_one = await _ai_one_liner(db, top_critical) if top_critical else None
+
+    body = format_pr_comment(
+        scan=scan,
+        asset_name=asset.name,
+        findings=findings,
+        ai_oneliner=ai_one,
+    )
+
+    posted: list[int] = []
+    for pr_number in prs:
+        ok = await sbom_diff_service.post_pr_comment(owner, repo, pr_number, body)
+        if ok:
+            posted.append(pr_number)
+
+    return {"posted_to_prs": posted, "finding_count": len(findings)}

--- a/backend/tests/test_pr_bot_format.py
+++ b/backend/tests/test_pr_bot_format.py
@@ -1,0 +1,99 @@
+"""
+PR Bot 코멘트 포맷 — 외부 호출 없는 순수 함수만.
+"""
+
+from app.models.finding import Finding, FindingStatus, Severity
+from app.models.scan import Scan, ScanStatus, ScanTrigger
+from app.services.pr_bot import _severity_summary, format_pr_comment
+
+
+def _f(severity: Severity, rule_id: str, title: str) -> Finding:
+    return Finding(
+        asset_id=1,
+        rule_id=rule_id,
+        title=title,
+        severity=severity,
+        status=FindingStatus.NEW,
+        scanner="trivy",
+        references=[],
+        extra={},
+        fingerprint="fp",
+    )
+
+
+def _scan() -> Scan:
+    return Scan(
+        asset_id=1,
+        scanner="trivy",
+        trigger=ScanTrigger.WEBHOOK,
+        status=ScanStatus.COMPLETED,
+        duration_ms=42,
+    )
+
+
+def test_severity_summary_ranks_critical_first():
+    fs = [
+        _f(Severity.LOW, "L1", "low one"),
+        _f(Severity.CRITICAL, "C1", "crit one"),
+        _f(Severity.HIGH, "H1", "high one"),
+    ]
+    counter, top = _severity_summary(fs)
+    assert counter["critical"] == 1
+    assert counter["high"] == 1
+    assert top[0].severity == Severity.CRITICAL
+    assert top[1].severity == Severity.HIGH
+
+
+def test_comment_no_findings():
+    body = format_pr_comment(
+        scan=_scan(),
+        asset_name="my-repo",
+        findings=[],
+        ai_oneliner=None,
+    )
+    assert "No findings" in body
+    assert "my-repo" in body
+
+
+def test_comment_top_findings_table():
+    fs = [
+        _f(Severity.CRITICAL, "CVE-2024-0001", "critical pkg"),
+        _f(Severity.HIGH, "CVE-2024-0002", "high pkg"),
+        _f(Severity.MEDIUM, "RULE-3", "medium issue"),
+    ]
+    body = format_pr_comment(
+        scan=_scan(),
+        asset_name="my-repo",
+        findings=fs,
+        ai_oneliner=None,
+    )
+    assert "**3** finding" in body
+    assert "Top findings" in body
+    assert "CVE-2024-0001" in body
+    # severity 표시
+    assert "critical" in body
+    assert "high" in body
+
+
+def test_comment_includes_ai_oneliner_when_provided():
+    fs = [_f(Severity.CRITICAL, "X", "critical pkg")]
+    body = format_pr_comment(
+        scan=_scan(),
+        asset_name="my-repo",
+        findings=fs,
+        ai_oneliner="실제 호출이 lb 뒤에 있어 severity high로 강등 가능",
+    )
+    assert "🤖" in body
+    assert "lb 뒤" in body
+
+
+def test_comment_pipe_escaped_in_title():
+    fs = [_f(Severity.HIGH, "rule|x", "title|with|pipes")]
+    body = format_pr_comment(
+        scan=_scan(),
+        asset_name="my-repo",
+        findings=fs,
+        ai_oneliner=None,
+    )
+    # 마크다운 표를 깨지 않도록 escape
+    assert "\\|" in body


### PR DESCRIPTION
## Summary
v0.2의 SBOM diff는 `pull_request` 이벤트에만 코멘트를 작성했음. push 이벤트로 스캔이 트리거된 후, head_sha 매칭 open PR이 있으면 finding 요약 + (AI 활성 시) AI triage 1-liner를 같은 코멘트 라우트로 작성.

## 변경

### `backend/app/services/pr_bot.py` (신규)
- `find_open_prs(owner, repo, head_sha)` — `GET /repos/.../commits/{sha}/pulls` state='open'
- `_severity_summary` — Counter + critical/high 우선 top 5
- `_ai_one_liner(db, finding)` — `analyze_finding(deep=False)` 1줄. PR #87의 intent='triage' 라우팅 → `model_default`로 빠르게
- `format_pr_comment` — 🌙 Mond — scan summary + severity 카운트 + top 5 표 + AI triage 라인. no findings → ✅ short. pipe(`|`) escape
- `notify_pr_for_scan` — REPOSITORY 자산 + `GITHUB_TOKEN` 있을 때만, 모든 open PR에 코멘트

### Webhook handler
push 이벤트 끝에서 `scan.status=='completed'` + head_sha 매칭 시 `notify_pr_for_scan` 호출. 응답에 `pr_bot` 필드 추가.

### Tests
`tests/test_pr_bot_format.py` 5 케이스 통과.

## 운영
- `GITHUB_TOKEN` 없으면 silent skip
- Celery 비동기 모드는 worker가 별도 처리 (v0.4)
- AI 미설정 시 rule-based finding 요약만

## Test plan
- [x] pytest 5/5
- [x] ruff clean
- [ ] CI 통과