### PR TITLE
feat(notify): v0.3 #8 — Discord + MS Teams webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,7 +70,11 @@ PROMETHEUS_ENABLED=true
 # ─── 알림 채널 (URL 비어있으면 no-op) ──────────────────
 # Slack Incoming Webhook URL — Critical/High finding을 즉시 전송
 SLACK_WEBHOOK_URL=
-# 자체 시스템 수신용 (PagerDuty, Discord, Lark, 커스텀)
+# Discord Incoming Webhook — Server Settings → Integrations → Webhooks
+DISCORD_WEBHOOK_URL=
+# MS Teams Incoming Webhook — channel … → Connectors → Incoming Webhook
+TEAMS_WEBHOOK_URL=
+# 자체 시스템 수신용 (PagerDuty, Lark, 커스텀 JSON 핸들러)
 GENERIC_WEBHOOK_URL=
 # 알림 임계치: critical / high / medium / low / info
 NOTIFY_MIN_SEVERITY=high

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ UI는 한국어를 기본으로 표시하며, 우측 상단 토글로 영어로 
 | 기능 | 방식 |
 |---|---|
 | **자동 스캔 (GitHub push)** | `POST /api/v1/webhooks/github` → 매칭 레포 자산 자동 trivy 스캔 |
-| **Slack/Generic 알림** | 임계치 이상 finding을 ENV의 Webhook URL로 자동 전송 |
+| **알림 다채널** | 임계치 이상 finding을 Slack/Discord/Teams/Generic webhook으로 자동 전송 (채널별 형식 변환) |
 | **MCP — Claude Desktop/Code** | stdio: `python -m mcp_server`. HTTP+SSE: `/mcp` 마운트 |
 
 ---
@@ -394,7 +394,7 @@ class MyAdapter(ScannerAdapter):
 - [x] Policy Simulation (PR diff 미리보기)
 - [x] SBOM / Compliance 리포트 (JSON · Markdown)
 - [x] GitHub Webhook 자동 스캔
-- [x] Slack / Generic Webhook 알림
+- [x] Slack / Discord / MS Teams / Generic Webhook 알림 (채널별 포맷 변환)
 - [x] MCP 서버 (stdio + HTTP/SSE)
 - [x] 멀티유저 + RBAC + OIDC SSO (Keycloak · Okta · Google)
 - [x] MFA — 패스키(WebAuthn/FIDO2) + TOTP + 백업 코드
@@ -440,15 +440,15 @@ UX·가시화 보강:
 
 ### v0.3 후보 로드맵
 - [ ] **자산 자동 동기화 확장** — Kubernetes 클러스터 namespace/pod 자동 발견, AWS Auto-scaling group, GitLab/Bitbucket org sync
-- [ ] **AI 멀티 프로바이더 라우팅** — 의도(`intent`)별로 다른 model 사용 (e.g. triage=Haiku, deep-explain=Sonnet)
+- [x] **AI 멀티 프로바이더 라우팅** — 의도(`intent`)별 model 자동 라우팅 (`remediation`/`explain`/`deep_analysis`는 `model_deep`, 그 외 `model_default`)
 - [ ] **SBOM CycloneDX 정식 출력** — lite stub 대신 CycloneDX 1.5 JSON/XML, vex 포함
 - [ ] **MCP HTTP 마운트 안정화** — Claude Desktop/Code 외부 에이전트가 Mond를 도구로 자연스럽게 사용
 - [ ] **다중 워크스페이스/조직 분리** — 사내 여러 팀이 한 인스턴스를 공유할 때 자산/정책 scope
-- [ ] **감사 로그 검색 UI** — 현재 access_audit_logs DB만, UI에서 시계열 + 필터
+- [x] **감사 로그 검색 UI** — `Admin → 감사 로그`에서 기간/actor/event/request_id 필터 + 시계열 timeline
 - [ ] **한국 규제 인증 심사 패키지** — ISMS-P 자동 증빙 자료 출력 (실제 심사 대응)
-- [ ] **알림 라우팅 다채널** — Slack 외 Email/Teams/PagerDuty
+- [x] **알림 라우팅 다채널** — Slack 외 Discord + MS Teams webhook 추가 (severity 색상 채널별 변환)
 - [ ] **온프레미스 LLM 게이트웨이 표준화** — 사내 vLLM 어댑터 + 토큰 사용량 추적
-- [ ] **PR Bot — AI 분석 PR comment** — push 스캔 결과를 PR에 자동 코멘트 (현재는 SBOM diff만)
+- [x] **PR Bot — AI 분석 PR comment** — push 스캔 결과를 PR에 자동 코멘트 + AI triage 1-liner
 
 ## 🧪 Known Limitations
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -104,6 +104,10 @@ class Settings(BaseSettings):
     # 알림 채널 (URL 비어 있으면 no-op)
     SLACK_WEBHOOK_URL: Optional[str] = None
     GENERIC_WEBHOOK_URL: Optional[str] = None
+    # Discord/Teams는 incoming webhook URL을 등록하면 자동 활성화.
+    # payload 포맷은 채널별로 다름 → app/services/notify_channels.py에서 변환.
+    DISCORD_WEBHOOK_URL: Optional[str] = None
+    TEAMS_WEBHOOK_URL: Optional[str] = None
     NOTIFY_MIN_SEVERITY: str = "high"  # critical / high / medium / low / info
     # Daily Digest 전용 채널. 비우면 SLACK_WEBHOOK_URL을 fallback.
     DIGEST_SLACK_WEBHOOK_URL: Optional[str] = None

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -18,6 +18,7 @@ from app.models.asset import Asset
 from app.models.slack import SlackPurpose
 from app.models.user import User
 from app.models.user_slack import UserSlackPreference
+from app.services import notify_channels
 from app.services import slack as slack_service
 
 logger = get_logger(__name__)
@@ -95,12 +96,16 @@ async def notify_finding(finding) -> None:
             )
         )
 
-    if not payloads:
-        return
+    if payloads:
+        async with httpx.AsyncClient(timeout=10) as client:
+            for url, body in payloads:
+                try:
+                    await client.post(url, json=body)
+                except Exception as exc:  # 외부 채널 실패가 코어를 막지 않게
+                    logger.warning("notification_failed", url=url, error=str(exc))
 
-    async with httpx.AsyncClient(timeout=10) as client:
-        for url, body in payloads:
-            try:
-                await client.post(url, json=body)
-            except Exception as exc:  # 외부 채널 실패가 코어를 막지 않게
-                logger.warning("notification_failed", url=url, error=str(exc))
+    # Discord/Teams — 포맷이 달라 별도 어댑터로. URL 미설정이면 silent skip.
+    sev = finding.severity.value
+    short_title = f"{emoji} Mond — {sev.upper()} finding · {finding.title}"
+    await notify_channels.post_discord(base_text, title=short_title, severity=sev)
+    await notify_channels.post_teams(base_text, title=short_title, severity=sev)

--- a/backend/app/services/notify_channels.py
+++ b/backend/app/services/notify_channels.py
@@ -1,0 +1,94 @@
+"""
+알림 채널 — Discord / MS Teams 어댑터.
+
+Slack과 Generic webhook은 기존 notifications.py가 직접 처리한다. 여기서는
+*payload 포맷이 다른* Discord/Teams만 다룬다. 같은 finding이라도 채널마다
+포맷이 다르므로 변환 책임을 한 곳에 모으는 게 목적.
+
+설계 원칙
+--------
+- URL 미설정 채널은 silent skip — 운영 단계별 점진 활성화를 허용.
+- payload는 텍스트 위주(공통). severity emoji는 그대로 인계.
+- Slack 흐름과 분리되어 있어 한 채널 실패가 다른 채널을 막지 않는다.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from app.core.config import settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# 색상 코드 — Discord embed / Teams themeColor 양쪽에서 사용 (RGB hex)
+SEVERITY_COLOR_HEX = {
+    "critical": "C0392B",   # 진한 빨강
+    "high": "E67E22",       # 주황
+    "medium": "F1C40F",     # 노랑
+    "low": "3498DB",        # 파랑
+    "info": "95A5A6",       # 회색
+}
+
+
+def discord_payload(*, title: str, body: str, severity: str) -> dict:
+    """Discord webhook 형식 — embed 1건.
+
+    Discord는 `content`로 평문도 받지만 embed가 색상/필드 분리가 깔끔.
+    color는 10진수 int로 줘야 한다 (RGB 0xRRGGBB).
+    """
+    color_int = int(SEVERITY_COLOR_HEX.get(severity, "95A5A6"), 16)
+    return {
+        "embeds": [
+            {
+                "title": title,
+                "description": body,
+                "color": color_int,
+            }
+        ],
+        # embed가 막힌 환경(권한 부족)을 위한 평문 fallback.
+        "content": title,
+    }
+
+
+def teams_payload(*, title: str, body: str, severity: str) -> dict:
+    """MS Teams Incoming Webhook용 MessageCard.
+
+    Teams의 Adaptive Card는 connector 종류에 따라 안 받는 환경이 많아
+    legacy MessageCard 형식이 가장 호환성 높음.
+    """
+    return {
+        "@type": "MessageCard",
+        "@context": "https://schema.org/extensions",
+        "summary": title,
+        "themeColor": SEVERITY_COLOR_HEX.get(severity, "95A5A6"),
+        "title": title,
+        "text": body,
+    }
+
+
+async def post_discord(text: str, *, title: str, severity: str) -> bool:
+    url = settings.DISCORD_WEBHOOK_URL
+    if not url:
+        return False
+    return await _post(url, discord_payload(title=title, body=text, severity=severity), label="discord")
+
+
+async def post_teams(text: str, *, title: str, severity: str) -> bool:
+    url = settings.TEAMS_WEBHOOK_URL
+    if not url:
+        return False
+    return await _post(url, teams_payload(title=title, body=text, severity=severity), label="teams")
+
+
+async def _post(url: str, payload: dict, *, label: str) -> bool:
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            r = await client.post(url, json=payload)
+            if r.status_code >= 400:
+                logger.warning("notify_channel_failed", channel=label, status=r.status_code)
+                return False
+            return True
+    except Exception as exc:
+        logger.warning("notify_channel_exception", channel=label, error=str(exc))
+        return False

--- a/backend/tests/test_notify_channels.py
+++ b/backend/tests/test_notify_channels.py
@@ -1,0 +1,58 @@
+"""
+Discord/Teams 어댑터 — payload 포맷 invariant.
+
+실제 webhook 호출은 외부 의존이라 단위로 테스트하기 어려워, 두 가지로 검증:
+  1) payload shape (color/title/필드)
+  2) URL 미설정 시 silent skip (False 반환)
+"""
+
+import pytest
+
+from app.core.config import settings
+from app.services.notify_channels import (
+    SEVERITY_COLOR_HEX,
+    discord_payload,
+    post_discord,
+    post_teams,
+    teams_payload,
+)
+
+
+def test_discord_payload_critical_color():
+    p = discord_payload(title="t", body="b", severity="critical")
+    assert p["content"] == "t"
+    emb = p["embeds"][0]
+    assert emb["title"] == "t"
+    assert emb["description"] == "b"
+    # 0xC0392B = 12597291
+    assert emb["color"] == int(SEVERITY_COLOR_HEX["critical"], 16)
+
+
+def test_discord_payload_unknown_severity_defaults_grey():
+    p = discord_payload(title="t", body="b", severity="weird")
+    assert p["embeds"][0]["color"] == int(SEVERITY_COLOR_HEX["info"], 16)
+
+
+def test_teams_payload_message_card_shape():
+    p = teams_payload(title="t", body="b", severity="high")
+    assert p["@type"] == "MessageCard"
+    assert p["@context"].endswith("/extensions")
+    assert p["summary"] == "t"
+    assert p["title"] == "t"
+    assert p["text"] == "b"
+    # themeColor는 hex 문자열(접두사 # 없이) — Teams 스펙
+    assert p["themeColor"] == SEVERITY_COLOR_HEX["high"]
+
+
+@pytest.mark.asyncio
+async def test_post_discord_skips_when_url_missing(monkeypatch):
+    monkeypatch.setattr(settings, "DISCORD_WEBHOOK_URL", None)
+    ok = await post_discord("hello", title="t", severity="high")
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_post_teams_skips_when_url_missing(monkeypatch):
+    monkeypatch.setattr(settings, "TEAMS_WEBHOOK_URL", None)
+    ok = await post_teams("hello", title="t", severity="high")
+    assert ok is False

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -593,20 +593,27 @@ SCANNER_NUCLEI_BIN=nuclei
 ****옵션 B** — 정책 삭제 후 자체 정책 작성** — Policies 화면에서 신규 작성
 ****옵션 C** — Skip** (`SEED_ON_STARTUP=false`) — 비어있는 상태로 시작
 
-### 7) 알림 — Slack / Generic Webhook / 둘 다
+### 7) 알림 — Slack / Discord / Teams / Generic Webhook
 
 | 선택지 | 언제 쓰나 | 설정 |
 |---|---|---|
 | **Slack Webhook** (권장) | 팀이 Slack 사용 | `SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...` |
-| **Generic Webhook** | Teams · Discord · 사내 incident bot | `GENERIC_WEBHOOK_URL=https://your-bot/mond` (JSON POST) |
-| **둘 다 동시** | severity 다른 채널로 분리하고 싶을 때 | 둘 다 설정. 알림은 양쪽으로 전송 |
-| **알림 끄기** | 데모 · 조용한 환경 | 두 ENV 모두 비워두기 |
+| **Discord Webhook** | 커뮤니티/스타트업/오픈소스 팀 | `DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...` |
+| **MS Teams Webhook** | 회사 표준이 Microsoft 365 | `TEAMS_WEBHOOK_URL=https://outlook.office.com/webhook/...` |
+| **Generic Webhook** | PagerDuty · Lark · 자체 incident bot | `GENERIC_WEBHOOK_URL=https://your-bot/mond` (JSON POST) |
+| **여러 채널 동시** | 채널별로 다른 청중에게 알림 | 원하는 ENV를 모두 설정. 알림은 모든 채널에 fan-out |
+| **알림 끄기** | 데모 · 조용한 환경 | 위 ENV를 모두 비워두기 |
 
 ```bash
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/.../...
+TEAMS_WEBHOOK_URL=https://outlook.office.com/webhook/...
 GENERIC_WEBHOOK_URL=https://your-incident-bot/mond
 NOTIFY_MIN_SEVERITY=high   # critical / high / medium / low / info (threshold)
 ```
+
+> Discord/Teams는 webhook URL만 받으면 즉시 활성화 — 별도 OAuth/앱 등록 불필요.
+> severity별 색상(critical=빨강, high=주황, medium=노랑, low=파랑)은 채널별 형식으로 자동 변환.
 
 `NOTIFY_MIN_SEVERITY` 권장:
 - 운영 — `high` (default) — critical/high만 알림


### PR DESCRIPTION
## Summary
v0.2의 Slack/Generic webhook에 Discord + MS Teams를 추가. payload 포맷이 채널마다 달라 별도 어댑터 모듈로 변환 책임 분리.

## 변경
### `backend/app/services/notify_channels.py` (신규)
- `SEVERITY_COLOR_HEX` — critical 빨강 / high 주황 / medium 노랑 / low 파랑 / info 회색
- `discord_payload` — embed 1건 + content fallback, color는 0xRRGGBB int
- `teams_payload` — legacy MessageCard (connector 호환성), themeColor hex string
- `post_discord` / `post_teams` — URL 미설정 시 silent skip, 4xx/예외 모두 warning만

### `notifications.py`
`notify_finding` 끝에서 두 어댑터 호출. severity 임계치/owner DM/Slack/Generic 흐름 그대로.

### Config
`DISCORD_WEBHOOK_URL`, `TEAMS_WEBHOOK_URL` 추가.

### 문서
- `.env.example` 안내 + 발급 위치
- `docs/SETUP.md` 7절 표 확장 (4채널)
- README features + v0.3 로드맵 체크박스 (#2/#6/#8/#10 4건 완료 반영)

## 운영
- URL만 입력 → 즉시 활성화 (OAuth 불필요)
- 한 채널 실패가 다른 채널을 막지 않음 (각 client 독립)

## Test plan
- [x] pytest 5/5 (payload shape + URL skip)
- [x] 전체 67 passed
- [x] ruff clean
- [ ] CI 통과