### PR TITLE
feat(sbom): v0.3 #3 — CycloneDX 1.5 표준 출력 + REPOSITORY 자산 components 자동 추출

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ CI/CD에서 push 또는 PR마다 Mond 스캔을 자동 트리거. Security Setti
 | **Policy Simulation** | "이번 PR에 이 finding이 들어가면 어떤 정책이 깨질까" 미리보기 |
 | **AI Insights** | 자연어 쿼리, intent 분류, Claude 답변 |
 | **Regulations Guide** | 사업 시나리오 → 적용 규제(K-PIPA·GDPR·HIPAA·PCI-DSS·…) + 시점·의무 |
-| **Reports** | 자산별 SBOM(CycloneDX-lite) + 시나리오별 컴플라이언스 리포트 (JSON / Markdown) |
+| **Reports** | 자산별 SBOM(CycloneDX 1.5 표준 — components purl + vulnerabilities) + 시나리오별 컴플라이언스 리포트 (JSON / Markdown) |
 | **Integrations** | 스캐너 / AI / **MCP (stdio+HTTP)** / 알림 채널 / GitHub Webhook 안내 |
 | **Settings** | 헬스 / 버전 / 환경 / 언어 |
 
@@ -441,7 +441,7 @@ UX·가시화 보강:
 ### v0.3 후보 로드맵
 - [ ] **자산 자동 동기화 확장** — Kubernetes 클러스터 namespace/pod 자동 발견, AWS Auto-scaling group, GitLab/Bitbucket org sync
 - [x] **AI 멀티 프로바이더 라우팅** — 의도(`intent`)별 model 자동 라우팅 (`remediation`/`explain`/`deep_analysis`는 `model_deep`, 그 외 `model_default`)
-- [ ] **SBOM CycloneDX 정식 출력** — lite stub 대신 CycloneDX 1.5 JSON/XML, vex 포함
+- [x] **SBOM CycloneDX 정식 출력** — CycloneDX 1.5 표준 (`bomFormat: "CycloneDX"`, `serialNumber: urn:uuid:…`, `metadata.tools`, REPOSITORY 자산은 default branch에서 `components[]` 자동 추출, findings → 표준 `vulnerabilities[]`)
 - [ ] **MCP HTTP 마운트 안정화** — Claude Desktop/Code 외부 에이전트가 Mond를 도구로 자연스럽게 사용
 - [ ] **다중 워크스페이스/조직 분리** — 사내 여러 팀이 한 인스턴스를 공유할 때 자산/정책 scope
 - [x] **감사 로그 검색 UI** — `Admin → 감사 로그`에서 기간/actor/event/request_id 필터 + 시계열 timeline
@@ -454,7 +454,7 @@ UX·가시화 보강:
 
 v0.1.0 시점의 한계와 v0.2(Unreleased)에서 해소된 항목을 함께 기록합니다.
 
-- **SBOM** — ~~v0.1: CycloneDX-lite stub~~ → **v0.2 해소**: 5종 ecosystem 실 파서 + Reports UI + PR diff
+- **SBOM** — ~~v0.1: CycloneDX-lite stub~~ → **v0.2**: 5종 ecosystem 실 파서 + Reports UI + PR diff → **v0.3**: 표준 CycloneDX 1.5 (REPOSITORY 자산은 default branch에서 의존성 자동 추출해 `components[]` 채움, findings → 표준 `vulnerabilities[]`)
 - **스캐너** — ~~v0.1: 동기 인라인 실행~~ → **v0.2 해소**: Celery 큐 옵션 (`SCAN_QUEUE_ENABLED`)
 - **AI Insights** — ~~v0.1: RAG 미적용~~ → **v0.2 해소**: 4 소스 RAG + inline citation. hallucination 위험 인지·인간 검토 권장은 유지. AI 생성 카드는 ADMIN 전용
 - **IAM 어댑터** — ~~v0.1: GCP/Azure 보강 중~~ → **v0.2 해소**: 5종 모두 멱등성 + etag 재시도. capability API는 `ready`/`coming_soon`/`demo`를 그대로 노출

--- a/backend/app/api/v1/endpoints/reports.py
+++ b/backend/app/api/v1/endpoints/reports.py
@@ -15,7 +15,7 @@ from app.services import sbom_parser
 from app.services.reports import (
     compliance_report,
     compliance_report_markdown,
-    lightweight_sbom,
+    cyclonedx_sbom,
 )
 
 router = APIRouter()
@@ -72,8 +72,12 @@ async def sbom(
     _user: User = Depends(current_user),
     db: AsyncSession = Depends(get_db),
 ) -> dict:
-    """CycloneDX-lite JSON 형식의 SBOM 다운로드."""
-    result = await lightweight_sbom(db, asset_id)
+    """CycloneDX 1.5 JSON 형식의 SBOM 다운로드.
+
+    REPOSITORY 자산이면 GitHub default branch에서 의존성 파일을 fetch해
+    components[]를 채운다. vulnerabilities[]는 자산의 findings.
+    """
+    result = await cyclonedx_sbom(db, asset_id)
     if result.get("error"):
         raise HTTPException(status_code=404, detail=result["error"])
     return result

--- a/backend/app/services/reports.py
+++ b/backend/app/services/reports.py
@@ -1,62 +1,203 @@
 """
-Reports — SBOM (lightweight) + Compliance 리포트
+Reports — SBOM (CycloneDX 1.5) + Compliance 리포트
+
+cyclonedx_sbom
+  - REPOSITORY 자산이면 GitHub default branch의 의존성 파일을 fetch해
+    components[]를 채운다 (npm/pypi/go/docker). 실패하면 components는 빈 배열.
+  - vulnerabilities[]는 자산의 findings를 CycloneDX 1.5 vulnerability 객체로 변환.
+  - serialNumber/timestamp/tools 등 표준 metadata 충족.
 """
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime, timezone
 
+import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
+from app.core.logging import get_logger
 from app.data.regulations import SCENARIOS, regulation_dict
-from app.models.asset import Asset
+from app.models.asset import Asset, AssetType
 from app.models.finding import Finding, FindingStatus, Severity
+from app.services import sbom_parser
+
+logger = get_logger(__name__)
+
+MOND_TOOL_VERSION = "0.3"
+
+# GitHub repo에서 시도할 의존성 파일 후보. 발견되는 만큼 components에 합집합.
+_DEFAULT_DEP_FILES = (
+    "package.json",
+    "package-lock.json",
+    "requirements.txt",
+    "go.mod",
+    "Dockerfile",
+)
 
 
-async def lightweight_sbom(db: AsyncSession, asset_id: int) -> dict:
-    """완전한 SBOM은 아니지만, 대상 자산의 발견사항을 묶어 CycloneDX-유사 JSON 생성."""
+def _purl(eco: str, name: str, version: str | None) -> str:
+    """ecosystem → CycloneDX/SPDX 표준 Package URL.
+
+    spec: https://github.com/package-url/purl-spec
+      npm:    pkg:npm/<name>@<version>
+      pypi:   pkg:pypi/<name>@<version>
+      go:     pkg:golang/<module>@<version>
+      docker: pkg:oci/<image>@<tag>
+    """
+    scheme = {"npm": "npm", "pypi": "pypi", "go": "golang", "docker": "oci"}.get(eco, eco)
+    base = f"pkg:{scheme}/{name}"
+    return f"{base}@{version}" if version else base
+
+
+def _bom_ref(eco: str, name: str, version: str | None) -> str:
+    """components와 vulnerabilities를 잇는 참조. purl 기반이지만 짧게."""
+    v = version or "unspecified"
+    return f"{eco}:{name}@{v}"
+
+
+def _to_component(pkg: sbom_parser.Package) -> dict:
+    return {
+        "type": "library",
+        "bom-ref": _bom_ref(pkg.ecosystem, pkg.name, pkg.version),
+        "name": pkg.name,
+        "version": pkg.version or "",
+        "purl": _purl(pkg.ecosystem, pkg.name, pkg.version),
+        "properties": [
+            {"name": "mond:ecosystem", "value": pkg.ecosystem},
+            *([{"name": "mond:source", "value": pkg.source_file}] if pkg.source_file else []),
+            *([{"name": "mond:dev", "value": "true"}] if pkg.dev else []),
+        ],
+    }
+
+
+def _to_vulnerability(f: Finding) -> dict:
+    """Finding → CycloneDX 1.5 vulnerability."""
+    method = "OWASP" if f.scanner in {"semgrep", "nuclei"} else "CVSSv3"
+    return {
+        "bom-ref": f.fingerprint,
+        "id": f.rule_id or f.fingerprint,
+        "source": {"name": f.scanner},
+        "ratings": [
+            {"severity": f.severity.value, "method": method, "score": 0.0}
+        ],
+        "description": f.title,
+        "advisories": [
+            {"url": ref} for ref in (f.references or []) if isinstance(ref, str)
+        ],
+        "properties": [
+            {"name": "mond:status", "value": f.status.value},
+            *([{"name": "mond:location", "value": f.location}] if f.location else []),
+        ],
+    }
+
+
+def _parse_github_uri(uri: str | None) -> tuple[str, str] | None:
+    """https://github.com/<owner>/<repo>(.git)? 에서 owner/repo 추출."""
+    if not uri:
+        return None
+    u = uri.rstrip("/")
+    if u.endswith(".git"):
+        u = u[:-4]
+    if "github.com/" not in u:
+        return None
+    tail = u.split("github.com/", 1)[1]
+    parts = tail.split("/")
+    if len(parts) < 2:
+        return None
+    return parts[0], parts[1]
+
+
+async def _fetch_repo_components(asset: Asset) -> list[dict]:
+    """REPOSITORY 자산이면 default branch의 의존성 파일들에서 components 합집합."""
+    if asset.asset_type != AssetType.REPOSITORY:
+        return []
+    parsed = _parse_github_uri(asset.uri)
+    if parsed is None:
+        return []
+    owner, repo = parsed
+
+    token = settings.GITHUB_TOKEN
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    # default branch 조회 — 실패하면 main fallback
+    branch = "main"
+    try:
+        async with httpx.AsyncClient(timeout=10, headers=headers) as client:
+            r = await client.get(f"https://api.github.com/repos/{owner}/{repo}")
+            if r.status_code < 400:
+                branch = (r.json().get("default_branch") or "main")
+    except Exception as exc:
+        logger.info("sbom_default_branch_lookup_failed", error=str(exc))
+
+    components: list[dict] = []
+    seen_refs: set[str] = set()
+    async with httpx.AsyncClient(timeout=15, headers=headers) as client:
+        for fname in _DEFAULT_DEP_FILES:
+            url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{fname}"
+            try:
+                r = await client.get(url, follow_redirects=True)
+                if r.status_code >= 400:
+                    continue
+                _, pkgs = sbom_parser.parse(r.text, fname)
+            except Exception as exc:
+                logger.info("sbom_fetch_failed", file=fname, error=str(exc))
+                continue
+            for p in pkgs:
+                comp = _to_component(p)
+                ref = comp["bom-ref"]
+                if ref in seen_refs:
+                    continue
+                seen_refs.add(ref)
+                components.append(comp)
+    return components
+
+
+async def cyclonedx_sbom(db: AsyncSession, asset_id: int) -> dict:
+    """자산 1건의 CycloneDX 1.5 BOM. components(의존성) + vulnerabilities(findings)."""
     asset = (await db.execute(select(Asset).where(Asset.id == asset_id))).scalar_one_or_none()
     if not asset:
         return {"error": "asset_not_found"}
 
     findings = list(
-        (
-            await db.execute(select(Finding).where(Finding.asset_id == asset_id))
-        ).scalars().all()
+        (await db.execute(select(Finding).where(Finding.asset_id == asset_id))).scalars().all()
     )
+    components = await _fetch_repo_components(asset)
 
     return {
-        "$schema": "https://cyclonedx.org/docs/1.5/json/",
-        "bomFormat": "CycloneDX-lite",
+        "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+        "bomFormat": "CycloneDX",
         "specVersion": "1.5",
+        "serialNumber": f"urn:uuid:{uuid.uuid4()}",
         "version": 1,
-        "generatedAt": datetime.now(timezone.utc).isoformat(),
         "metadata": {
-            "tool": "mond",
-            "asset": {
-                "id": asset.id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "tools": [
+                {"vendor": "Mond", "name": "mond", "version": MOND_TOOL_VERSION}
+            ],
+            "component": {
+                "type": "application" if asset.asset_type != AssetType.REPOSITORY else "library",
+                "bom-ref": f"mond:asset:{asset.id}",
                 "name": asset.name,
-                "type": asset.asset_type.value,
-                "uri": asset.uri,
-                "owner": asset.owner,
-                "environment": asset.environment,
+                "properties": [
+                    {"name": "mond:asset_type", "value": asset.asset_type.value},
+                    *([{"name": "mond:uri", "value": asset.uri}] if asset.uri else []),
+                    *([{"name": "mond:owner", "value": asset.owner}] if asset.owner else []),
+                    *([{"name": "mond:environment", "value": asset.environment}] if asset.environment else []),
+                ],
             },
         },
-        "vulnerabilities": [
-            {
-                "id": f.fingerprint,
-                "ruleId": f.rule_id,
-                "title": f.title,
-                "severity": f.severity.value,
-                "scanner": f.scanner,
-                "location": f.location,
-                "status": f.status.value,
-                "references": f.references,
-            }
-            for f in findings
-        ],
+        "components": components,
+        "vulnerabilities": [_to_vulnerability(f) for f in findings],
     }
+
+
+# 하위 호환 alias — 호출처가 점진 이행할 때까지 유지.
+lightweight_sbom = cyclonedx_sbom
 
 
 async def compliance_report(

--- a/backend/tests/test_cyclonedx_sbom.py
+++ b/backend/tests/test_cyclonedx_sbom.py
@@ -1,0 +1,114 @@
+"""
+CycloneDX SBOM — 헬퍼 함수 invariant.
+
+cyclonedx_sbom 자체는 DB + GitHub 의존이라 통합 테스트가 어려워, purl/component/
+vulnerability 변환 함수와 URI 파싱을 단위로 검증한다.
+"""
+
+from app.models.finding import Finding, FindingStatus, Severity
+from app.services.reports import (
+    _bom_ref,
+    _parse_github_uri,
+    _purl,
+    _to_component,
+    _to_vulnerability,
+)
+from app.services.sbom_parser import Package
+
+
+def test_purl_npm_format():
+    assert _purl("npm", "react", "18.3.1") == "pkg:npm/react@18.3.1"
+
+
+def test_purl_pypi_format():
+    assert _purl("pypi", "fastapi", "0.115.0") == "pkg:pypi/fastapi@0.115.0"
+
+
+def test_purl_go_uses_golang_scheme():
+    # CycloneDX/purl-spec에서 go는 golang scheme.
+    assert _purl("go", "github.com/gin-gonic/gin", "v1.10.0").startswith("pkg:golang/")
+
+
+def test_purl_docker_uses_oci_scheme():
+    assert _purl("docker", "alpine", "3.20").startswith("pkg:oci/")
+
+
+def test_purl_without_version_omits_at_sign():
+    assert _purl("pypi", "requests", None) == "pkg:pypi/requests"
+
+
+def test_bom_ref_unspecified_when_no_version():
+    assert _bom_ref("npm", "left-pad", None) == "npm:left-pad@unspecified"
+
+
+def test_to_component_carries_ecosystem_property():
+    p = Package(ecosystem="npm", name="react", version="18.3.1", source_file="package.json")
+    comp = _to_component(p)
+    assert comp["type"] == "library"
+    assert comp["name"] == "react"
+    assert comp["version"] == "18.3.1"
+    assert comp["purl"] == "pkg:npm/react@18.3.1"
+    props = {x["name"]: x["value"] for x in comp["properties"]}
+    assert props["mond:ecosystem"] == "npm"
+    assert props["mond:source"] == "package.json"
+
+
+def test_to_component_dev_dependency_flag():
+    p = Package(ecosystem="npm", name="vitest", version="2.0", dev=True)
+    comp = _to_component(p)
+    props = {x["name"]: x["value"] for x in comp["properties"]}
+    assert props.get("mond:dev") == "true"
+
+
+def test_to_vulnerability_basic_shape():
+    f = Finding(
+        asset_id=1,
+        rule_id="CVE-2024-1234",
+        title="injection in foo",
+        severity=Severity.CRITICAL,
+        status=FindingStatus.NEW,
+        scanner="trivy",
+        references=["https://nvd.nist.gov/vuln/detail/CVE-2024-1234"],
+        extra={},
+        fingerprint="fp-abc",
+    )
+    v = _to_vulnerability(f)
+    assert v["id"] == "CVE-2024-1234"
+    assert v["bom-ref"] == "fp-abc"
+    assert v["source"]["name"] == "trivy"
+    assert v["ratings"][0]["severity"] == "critical"
+    # CycloneDX 1.5: CVSSv3 method
+    assert v["ratings"][0]["method"] == "CVSSv3"
+    assert v["advisories"][0]["url"].startswith("https://nvd")
+
+
+def test_to_vulnerability_semgrep_method_owasp():
+    f = Finding(
+        asset_id=1,
+        rule_id="js.lang.security.audit.unsafe-formatstring",
+        title="format string",
+        severity=Severity.HIGH,
+        status=FindingStatus.TRIAGED,
+        scanner="semgrep",
+        references=[],
+        extra={},
+        fingerprint="fp-sg",
+    )
+    v = _to_vulnerability(f)
+    assert v["ratings"][0]["method"] == "OWASP"
+
+
+def test_parse_github_uri_https():
+    assert _parse_github_uri("https://github.com/jland-93/mond") == ("jland-93", "mond")
+
+
+def test_parse_github_uri_with_dot_git_suffix():
+    assert _parse_github_uri("https://github.com/jland-93/mond.git") == ("jland-93", "mond")
+
+
+def test_parse_github_uri_non_github_returns_none():
+    assert _parse_github_uri("https://gitlab.com/user/repo") is None
+
+
+def test_parse_github_uri_none():
+    assert _parse_github_uri(None) is None

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -98,8 +98,8 @@ export default function Reports() {
               style={{ marginBottom: 12 }}
               message={
                 locale === "ko"
-                  ? "자산의 발견사항을 묶어 만든 CycloneDX-lite 요약본입니다. 실제 의존성 트리를 추출하려면 아래 'SBOM 파일 파싱' 카드에 package.json · go.mod · Dockerfile 같은 파일을 붙여넣으세요."
-                  : "Finding-based CycloneDX-lite summary. For real dependency parsing, paste package.json / go.mod / Dockerfile into the 'SBOM File Parsing' card below."
+                  ? "CycloneDX 1.5 표준 형식. REPOSITORY 자산이면 GitHub default branch의 package.json · requirements.txt · go.mod · Dockerfile 등을 자동으로 fetch해 components[]를 채우고, 발견사항은 표준 vulnerabilities[]로 변환합니다."
+                  : "CycloneDX 1.5 standard format. For REPOSITORY assets, dependency files (package.json, requirements.txt, go.mod, Dockerfile) are auto-fetched from the default branch to populate components[]. Findings are emitted as standard vulnerabilities[]."
               }
             />
             <Paragraph type="secondary">{t.reports.sbomDesc}</Paragraph>


### PR DESCRIPTION
## Summary
v0.1의 'CycloneDX-lite stub' SBOM을 정식 CycloneDX 1.5로 보강. REPOSITORY 자산이면 GitHub default branch에서 의존성 파일을 자동 fetch해 `components[]`를 채움.

## 변경
### `reports.py` — `cyclonedx_sbom` 신규
- `bomFormat: CycloneDX` · `serialNumber: urn:uuid:…` · `metadata.timestamp/tools/component`
- `_fetch_repo_components` — default branch에서 5종 의존성 파일 시도, 중복 bom-ref 제거 후 합집합
- `_to_vulnerability` — finding → 표준 vulnerability (ratings[severity, method=CVSSv3|OWASP] · advisories)
- `_purl` helper — npm/pypi/go/docker (purl-spec 준수)
- REPOSITORY 아니거나 fetch 실패 → `components: []` graceful

### 14 단위 테스트
purl 4 ecosystem + bom-ref + component property + vulnerability shape + URI 파싱

### UI · 문서
- Reports.tsx 안내문 (ko/en)
- README features + 로드맵 #3 + Known Limitations

## 운영
- GITHUB_TOKEN 있으면 private repo + rate 5000/h
- Trivy/Syft/Dependency-Track 등이 `bomFormat=CycloneDX` 인식

## Test plan
- [x] pytest 14/14 + 전체 81 passed
- [x] ruff clean · frontend build OK
- [ ] CI 통과