### PR TITLE
feat(ai): v0.3 #9 — vLLM provider + AI 토큰 사용량 추적

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,10 +53,18 @@ BEDROCK_REGION=us-east-1
 BEDROCK_MODEL_DEFAULT=anthropic.claude-3-5-haiku-20241022-v1:0
 BEDROCK_MODEL_DEEP=anthropic.claude-3-5-sonnet-20241022-v2:0
 
-# Ollama / vLLM (로컬 LLM — 폐쇄망·데이터 외부 유출 금지 조직용)
+# Ollama (로컬 LLM)
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL_DEFAULT=llama3.1:8b
 OLLAMA_MODEL_DEEP=llama3.1:70b
+
+# vLLM (사내 GPU 게이트웨이 — OpenAI 호환 API)
+# AI_PROVIDER=vllm 으로 설정하면 OpenAI 호출 흐름을 그대로 재사용한다.
+# 예: vllm serve meta-llama/Meta-Llama-3.1-70B-Instruct --port 8000
+# VLLM_BASE_URL=http://gpu-01.internal:8000/v1
+# VLLM_API_KEY=EMPTY                 # vLLM은 인증 미요구. openai SDK placeholder.
+# VLLM_MODEL_DEFAULT=meta-llama/Meta-Llama-3.1-8B-Instruct
+# VLLM_MODEL_DEEP=meta-llama/Meta-Llama-3.1-70B-Instruct
 
 # ─── 스캐너 바이너리 (없으면 stub 모드) ─────────────────────
 SCANNER_TRIVY_BIN=trivy

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ UX·가시화 보강:
 - [x] **감사 로그 검색 UI** — `Admin → 감사 로그`에서 기간/actor/event/request_id 필터 + 시계열 timeline
 - [ ] **한국 규제 인증 심사 패키지** — ISMS-P 자동 증빙 자료 출력 (실제 심사 대응)
 - [x] **알림 라우팅 다채널** — Slack 외 Discord + MS Teams webhook 추가 (severity 색상 채널별 변환)
-- [ ] **온프레미스 LLM 게이트웨이 표준화** — 사내 vLLM 어댑터 + 토큰 사용량 추적
+- [x] **온프레미스 LLM 게이트웨이 + 토큰 사용량 추적** — vLLM provider (OpenAI-호환 base_url) + `ai_usage_logs` 테이블 자동 기록 + `GET /admin/ai-providers/usage` (provider/tier/intent/일별 시계열) + Admin 연동 관리에 AI 사용량 카드
 - [x] **PR Bot — AI 분석 PR comment** — push 스캔 결과를 PR에 자동 코멘트 + AI triage 1-liner
 
 ## 🧪 Known Limitations

--- a/backend/app/ai/client.py
+++ b/backend/app/ai/client.py
@@ -138,6 +138,18 @@ def _runtime_from_env() -> ProviderRuntime | None:
             model_deep=settings.OLLAMA_MODEL_DEEP,
             source="env",
         )
+    if provider == "vllm" and settings.VLLM_BASE_URL:
+        # vLLM은 OpenAI-호환 server이므로 _call_openai 흐름을 그대로 탄다.
+        # provider 라벨은 'vllm'으로 유지해 usage log/대시보드 구분 가능.
+        return ProviderRuntime(
+            provider="vllm",
+            api_key=settings.VLLM_API_KEY or "EMPTY",
+            base_url=settings.VLLM_BASE_URL,
+            region=None,
+            model_default=settings.VLLM_MODEL_DEFAULT,
+            model_deep=settings.VLLM_MODEL_DEEP,
+            source="env",
+        )
     return None
 
 
@@ -147,7 +159,7 @@ def _has_credentials(rt: ProviderRuntime) -> bool:
     if rt.provider == "bedrock":
         # boto3가 IAM 자격을 자동 감지 — region만 있으면 OK
         return bool(rt.region)
-    if rt.provider == "ollama":
+    if rt.provider in {"ollama", "vllm"}:
         return bool(rt.base_url)
     return False
 
@@ -226,19 +238,48 @@ async def complete_json(
         logger.info("ai_intent_routed", provider=rt.provider, intent=intent, tier=tier, model=model)
     max_tokens = max_tokens or settings.AI_MAX_TOKENS
 
+    result: CompletionResult | None = None
+    failed = False
     try:
         if rt.provider == "anthropic":
-            return await _call_anthropic(rt, system, user, model, max_tokens)
-        if rt.provider == "openai":
-            return await _call_openai(rt, system, user, model, max_tokens)
-        if rt.provider == "bedrock":
-            return await _call_bedrock(rt, system, user, model, max_tokens)
-        if rt.provider == "ollama":
-            return await _call_ollama(rt, system, user, model, max_tokens)
+            result = await _call_anthropic(rt, system, user, model, max_tokens)
+        elif rt.provider == "openai":
+            result = await _call_openai(rt, system, user, model, max_tokens)
+        elif rt.provider == "bedrock":
+            result = await _call_bedrock(rt, system, user, model, max_tokens)
+        elif rt.provider == "ollama":
+            result = await _call_ollama(rt, system, user, model, max_tokens)
+        elif rt.provider == "vllm":
+            # vLLM은 OpenAI-호환 API. 같은 호출 흐름 재사용, provider 라벨만 vllm.
+            r = await _call_openai(rt, system, user, model, max_tokens)
+            result = CompletionResult(
+                text=r.text,
+                provider="vllm",
+                model=r.model,
+                input_tokens=r.input_tokens,
+                output_tokens=r.output_tokens,
+            )
     except Exception as exc:
         logger.warning("ai_complete_failed", provider=rt.provider, model=model, error=str(exc))
-        return None
-    return None
+        failed = True
+
+    # 사용량 기록 — 실패해도 행 1건 남겨 호출수가 비용 0로 카운트되게.
+    try:
+        from app.services import ai_usage as ai_usage_service
+        await ai_usage_service.record(
+            db,
+            provider=rt.provider,
+            model=model,
+            tier=tier,
+            intent=intent,
+            input_tokens=result.input_tokens if result else 0,
+            output_tokens=result.output_tokens if result else 0,
+            failed=failed or result is None,
+        )
+    except Exception as exc:  # usage 기록 실패가 호출을 막지 않게
+        logger.warning("ai_usage_record_failed", error=str(exc))
+
+    return result
 
 
 # ── Anthropic ───────────────────────────────────────────────────

--- a/backend/app/api/v1/endpoints/ai_providers.py
+++ b/backend/app/api/v1/endpoints/ai_providers.py
@@ -21,7 +21,7 @@ from app.models.user import Role
 
 router = APIRouter()
 
-SUPPORTED = {"anthropic", "openai", "bedrock", "ollama"}
+SUPPORTED = {"anthropic", "openai", "bedrock", "ollama", "vllm"}
 
 
 class AIProviderRead(BaseModel):
@@ -214,7 +214,8 @@ async def test_provider(payload: TestRequest) -> TestResponse:
     try:
         if provider == "anthropic":
             result = await ai_client._call_anthropic(rt, system, user, rt.model_default, 64)
-        elif provider == "openai":
+        elif provider in {"openai", "vllm"}:
+            # vLLM은 OpenAI-호환 server라 같은 호출 흐름
             result = await ai_client._call_openai(rt, system, user, rt.model_default, 64)
         elif provider == "bedrock":
             result = await ai_client._call_bedrock(rt, system, user, rt.model_default, 64)
@@ -224,3 +225,19 @@ async def test_provider(payload: TestRequest) -> TestResponse:
         return TestResponse(ok=False, provider=provider, model=rt.model_default, detail=str(exc)[:300])
 
     return TestResponse(ok=True, provider=result.provider, model=result.model, detail="connected")
+
+
+# ── AI 토큰 사용량 ─────────────────────────────────────────────
+@router.get(
+    "/usage",
+    dependencies=[Depends(require_role(Role.ADMIN))],
+)
+async def get_ai_usage(
+    db: AsyncSession = Depends(get_db),
+    days: int = 7,
+):
+    """최근 N일 AI 호출 사용량 집계. provider/tier/intent/일별 시계열."""
+    from app.services import ai_usage as ai_usage_service
+
+    days = max(1, min(days, 90))
+    return await ai_usage_service.summary(db, days=days)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -89,6 +89,14 @@ class Settings(BaseSettings):
     OLLAMA_MODEL_DEFAULT: str = "llama3.1:8b"
     OLLAMA_MODEL_DEEP: str = "llama3.1:70b"
 
+    # vLLM — 사내 GPU 서버에 vLLM을 OpenAI-호환 API로 띄운 경우.
+    # 기본값은 ENV가 비어 있으면 OpenAI provider + base_url 흐름을 그대로 재사용.
+    # AI_PROVIDER=vllm 으로 지정해도 OpenAI 호출 경로로 라우팅된다.
+    VLLM_BASE_URL: Optional[str] = None
+    VLLM_API_KEY: Optional[str] = "EMPTY"            # vLLM은 대개 token 미요구, openai SDK 호환을 위해 placeholder
+    VLLM_MODEL_DEFAULT: str = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    VLLM_MODEL_DEEP: str = "meta-llama/Meta-Llama-3.1-70B-Instruct"
+
     # 스캐너 통합 토글 (없으면 stub 모드로 동작)
     SCANNER_TRIVY_BIN: Optional[str] = "trivy"
     SCANNER_SEMGREP_BIN: Optional[str] = "semgrep"

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ create_all 호출 전에 모든 모델 모듈이 임포트되어야 메타데이
 
 from app.models.ai_insight import AIInsight, InsightKind
 from app.models.ai_provider import AIProviderConfig
+from app.models.ai_usage import AIUsageLog
 from app.models.role_request import RoleChangeRequest, RoleRequestStatus
 from app.models.webhook_token import WebhookToken
 from app.models.asset import Asset, AssetType
@@ -55,6 +56,7 @@ __all__ = [
     "AIInsight",
     "InsightKind",
     "AIProviderConfig",
+    "AIUsageLog",
     "WebhookToken",
     "RoleChangeRequest",
     "RoleRequestStatus",

--- a/backend/app/models/ai_usage.py
+++ b/backend/app/models/ai_usage.py
@@ -1,0 +1,44 @@
+"""
+AI 토큰 사용량 로그 — provider/model/intent별 누적 입출력 토큰.
+
+추적 목적
+--------
+- 외부 LLM 비용 가시화 (Anthropic/OpenAI/Bedrock)
+- 사내 vLLM/Ollama 게이트웨이의 호출량 + 효율 검증
+- intent별 라우팅(PR #87)이 model_default/model_deep 어디로 가는지 사후 검증
+
+설계
+----
+- complete_json 직후 입력/출력 토큰을 그대로 기록 (None이면 0 fallback)
+- 외부 LLM이 토큰 정보를 안 주는 경우(ollama 일부)도 0으로 행을 남겨 호출수 카운트
+- failed=true는 호출이 실패한 경우(text 비어 있거나 예외) — 비용 0
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+
+
+class AIUsageLog(Base):
+    __tablename__ = "ai_usage_logs"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    provider: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    model: Mapped[str] = mapped_column(String(128), nullable=False)
+    tier: Mapped[str] = mapped_column(String(16), nullable=False)  # 'default' | 'deep'
+    intent: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    input_tokens: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    output_tokens: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    failed: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+        index=True,
+    )

--- a/backend/app/services/ai_usage.py
+++ b/backend/app/services/ai_usage.py
@@ -1,0 +1,151 @@
+"""
+AI 토큰 사용량 — record + 집계.
+
+record는 complete_json 직후 호출되고, 집계는 Admin UI/대시보드용.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.logging import get_logger
+from app.models.ai_usage import AIUsageLog
+
+logger = get_logger(__name__)
+
+
+async def record(
+    db: AsyncSession,
+    *,
+    provider: str,
+    model: str,
+    tier: str,
+    intent: str | None,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    failed: bool,
+) -> None:
+    """호출 1건의 토큰 사용량을 기록. None은 0으로 fallback."""
+    row = AIUsageLog(
+        provider=provider,
+        model=model,
+        tier=tier,
+        intent=intent,
+        input_tokens=int(input_tokens or 0),
+        output_tokens=int(output_tokens or 0),
+        failed=failed,
+    )
+    db.add(row)
+    await db.commit()
+
+
+async def summary(db: AsyncSession, *, days: int = 7) -> dict[str, Any]:
+    """최근 N일 집계 — provider/tier/intent별 합계 + 일별 시계열."""
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+
+    # 전체 카운트
+    total_q = select(
+        func.count(AIUsageLog.id),
+        func.coalesce(func.sum(AIUsageLog.input_tokens), 0),
+        func.coalesce(func.sum(AIUsageLog.output_tokens), 0),
+    ).where(AIUsageLog.created_at >= since)
+    total_row = (await db.execute(total_q)).one()
+    total_calls, total_in, total_out = total_row
+
+    failed_q = select(func.count(AIUsageLog.id)).where(
+        AIUsageLog.created_at >= since, AIUsageLog.failed.is_(True)
+    )
+    total_failed = (await db.execute(failed_q)).scalar_one()
+
+    # provider별
+    by_provider_q = (
+        select(
+            AIUsageLog.provider,
+            func.count(AIUsageLog.id),
+            func.coalesce(func.sum(AIUsageLog.input_tokens), 0),
+            func.coalesce(func.sum(AIUsageLog.output_tokens), 0),
+        )
+        .where(AIUsageLog.created_at >= since)
+        .group_by(AIUsageLog.provider)
+        .order_by(func.count(AIUsageLog.id).desc())
+    )
+    by_provider = [
+        {"provider": p, "calls": c, "input_tokens": int(i), "output_tokens": int(o)}
+        for p, c, i, o in (await db.execute(by_provider_q)).all()
+    ]
+
+    # tier별 (default vs deep)
+    by_tier_q = (
+        select(
+            AIUsageLog.tier,
+            func.count(AIUsageLog.id),
+            func.coalesce(func.sum(AIUsageLog.input_tokens), 0),
+            func.coalesce(func.sum(AIUsageLog.output_tokens), 0),
+        )
+        .where(AIUsageLog.created_at >= since)
+        .group_by(AIUsageLog.tier)
+    )
+    by_tier = [
+        {"tier": t, "calls": c, "input_tokens": int(i), "output_tokens": int(o)}
+        for t, c, i, o in (await db.execute(by_tier_q)).all()
+    ]
+
+    # intent별
+    by_intent_q = (
+        select(
+            AIUsageLog.intent,
+            func.count(AIUsageLog.id),
+            func.coalesce(func.sum(AIUsageLog.input_tokens), 0),
+            func.coalesce(func.sum(AIUsageLog.output_tokens), 0),
+        )
+        .where(AIUsageLog.created_at >= since)
+        .group_by(AIUsageLog.intent)
+        .order_by(func.count(AIUsageLog.id).desc())
+        .limit(20)
+    )
+    by_intent = [
+        {"intent": i or "—", "calls": c, "input_tokens": int(inp), "output_tokens": int(out)}
+        for i, c, inp, out in (await db.execute(by_intent_q)).all()
+    ]
+
+    # 일별 시계열
+    day_expr = func.date_trunc("day", AIUsageLog.created_at)
+    by_day_q = (
+        select(
+            day_expr.label("day"),
+            func.count(AIUsageLog.id),
+            func.coalesce(func.sum(AIUsageLog.input_tokens), 0),
+            func.coalesce(func.sum(AIUsageLog.output_tokens), 0),
+        )
+        .where(AIUsageLog.created_at >= since)
+        .group_by(day_expr)
+        .order_by(day_expr)
+    )
+    by_day = [
+        {
+            "day": d.isoformat() if hasattr(d, "isoformat") else str(d),
+            "calls": c,
+            "input_tokens": int(i),
+            "output_tokens": int(o),
+        }
+        for d, c, i, o in (await db.execute(by_day_q)).all()
+    ]
+
+    return {
+        "days": days,
+        "since": since.isoformat(),
+        "total": {
+            "calls": int(total_calls or 0),
+            "input_tokens": int(total_in or 0),
+            "output_tokens": int(total_out or 0),
+            "failed": int(total_failed or 0),
+        },
+        "by_provider": by_provider,
+        "by_tier": by_tier,
+        "by_intent": by_intent,
+        "by_day": by_day,
+    }

--- a/backend/tests/test_vllm_provider.py
+++ b/backend/tests/test_vllm_provider.py
@@ -1,0 +1,58 @@
+"""
+vLLM provider — env-based runtime 인식 + credentials 분기.
+
+토큰 사용량 record/summary는 DB 의존이라 통합 테스트가 필요해 이 파일에선
+순수 분기 로직만 검증한다.
+"""
+
+from app.ai.client import ProviderRuntime, _has_credentials, _runtime_from_env
+from app.core.config import settings
+
+
+def test_vllm_runtime_when_base_url_set(monkeypatch):
+    monkeypatch.setattr(settings, "AI_PROVIDER", "vllm")
+    monkeypatch.setattr(settings, "VLLM_BASE_URL", "http://gpu-01:8000/v1")
+    monkeypatch.setattr(settings, "VLLM_API_KEY", "EMPTY")
+    monkeypatch.setattr(settings, "VLLM_MODEL_DEFAULT", "meta-llama/Meta-Llama-3.1-8B-Instruct")
+    monkeypatch.setattr(settings, "VLLM_MODEL_DEEP", "meta-llama/Meta-Llama-3.1-70B-Instruct")
+    rt = _runtime_from_env()
+    assert rt is not None
+    assert rt.provider == "vllm"
+    assert rt.base_url == "http://gpu-01:8000/v1"
+    assert rt.model_default.endswith("-8B-Instruct")
+    assert rt.model_deep.endswith("-70B-Instruct")
+
+
+def test_vllm_runtime_returns_none_without_base_url(monkeypatch):
+    monkeypatch.setattr(settings, "AI_PROVIDER", "vllm")
+    monkeypatch.setattr(settings, "VLLM_BASE_URL", None)
+    # 다른 provider 키도 없음
+    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", None)
+    monkeypatch.setattr(settings, "OPENAI_API_KEY", None)
+    assert _runtime_from_env() is None
+
+
+def test_has_credentials_vllm_needs_base_url():
+    rt = ProviderRuntime(
+        provider="vllm",
+        api_key="EMPTY",
+        base_url="http://gpu-01:8000/v1",
+        region=None,
+        model_default="m",
+        model_deep="m",
+        source="env",
+    )
+    assert _has_credentials(rt) is True
+
+
+def test_has_credentials_vllm_missing_base_url_fails():
+    rt = ProviderRuntime(
+        provider="vllm",
+        api_key="EMPTY",
+        base_url=None,
+        region=None,
+        model_default="m",
+        model_deep="m",
+        source="env",
+    )
+    assert _has_credentials(rt) is False

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -14,7 +14,7 @@ In English — everything you need to go from `docker compose up` to a Helm-depl
   - 2-A. DB / Redis 선택 — in-cluster vs 외부 매니지드
   - 2-B. Ingress 선택 — ALB / Nginx / Cloudflare / 사내 GW
   - 2-C. 시크릿 관리 선택 — kubectl / External-Secrets / Sealed-Secrets
-- [Part 3. AI provider 세팅 (Anthropic · OpenAI · Bedrock · Ollama)](#part-3-ai-provider-세팅) — 4종 선택 기준 + 한국어 성능 비고
+- [Part 3. AI provider 세팅 (Anthropic · OpenAI · Bedrock · Ollama · vLLM)](#part-3-ai-provider-세팅) — 5종 선택 기준 + 한국어 성능 비고 + 토큰 사용량 추적
 - [Part 4. 로그인 — Dev / SSO / MFA](#part-4-로그인--dev--sso--mfa) — SSO IdP 선택 기준 + MFA 환경별 권장
 - [Part 5. 관리자 초기 세팅 10단계 체크리스트](#part-5-관리자-초기-세팅-체크리스트) — 각 단계 "옵션 A/B/Skip" 명시
 - [Part 6. 업그레이드 · 백업 · 모니터링](#part-6-업그레이드--백업--모니터링)
@@ -333,7 +333,8 @@ SESSION_SECURE=true
 | **Anthropic 직접** (권장) | `AI_PROVIDER=anthropic` + `ANTHROPIC_API_KEY` | `claude-haiku-4-5-20251001` · `claude-sonnet-4-6` | B / C | ★★★★★ |
 | **OpenAI / Azure OpenAI** | `AI_PROVIDER=openai` + `OPENAI_API_KEY` (+`OPENAI_BASE_URL` for Azure) | `gpt-4o-mini` · `gpt-4o` | C | ★★★★☆ |
 | **AWS Bedrock** | `AI_PROVIDER=bedrock` + IAM 자격 | `anthropic.claude-3-5-sonnet-20241022-v2:0` | C (AWS heavy) | ★★★★★ |
-| **Ollama / vLLM (로컬)** | `AI_PROVIDER=ollama` + `OLLAMA_BASE_URL` | `llama3.1:8b` · `llama3.1:70b` · `qwen2.5:32b` | **D (폐쇄망)** | ★★★☆☆ (모델 따라) |
+| **Ollama (로컬)** | `AI_PROVIDER=ollama` + `OLLAMA_BASE_URL` | `llama3.1:8b` · `llama3.1:70b` · `qwen2.5:32b` | **D (폐쇄망)** | ★★★☆☆ (모델 따라) |
+| **vLLM (사내 GPU)** | `AI_PROVIDER=vllm` + `VLLM_BASE_URL` (OpenAI 호환) | `meta-llama/Meta-Llama-3.1-70B-Instruct` 등 vLLM 서버에 띄운 모델 | **D (폐쇄망 + 고처리량)** | 모델 따라 |
 
 ### 3-2. 설정 예시
 
@@ -377,13 +378,40 @@ OLLAMA_MODEL_DEFAULT=llama3.1:8b
 OLLAMA_MODEL_DEEP=llama3.1:70b
 ```
 
-### 3-3. 키 없을 때 (Heuristic 모드)
+#### vLLM (사내 GPU 게이트웨이 — OpenAI 호환)
+
+사내 GPU 서버에 vLLM을 OpenAI 호환 모드로 띄운 환경. Ollama보다 처리량/배치 효율이 높고, 같은 OpenAI SDK 호출 경로를 그대로 재사용한다.
+
+```bash
+# vllm serve meta-llama/Meta-Llama-3.1-70B-Instruct \
+#   --host 0.0.0.0 --port 8000 --tensor-parallel-size 4
+
+AI_PROVIDER=vllm
+VLLM_BASE_URL=http://gpu-01.internal:8000/v1
+VLLM_API_KEY=EMPTY        # vLLM은 인증 미요구. openai SDK placeholder.
+VLLM_MODEL_DEFAULT=meta-llama/Meta-Llama-3.1-8B-Instruct
+VLLM_MODEL_DEEP=meta-llama/Meta-Llama-3.1-70B-Instruct
+```
+
+> 폐쇄망에 vLLM/Ollama를 동시에 두는 패턴도 가능합니다. UI Admin → 연동 관리에서 default provider만 토글하세요.
+
+### 3-3. 토큰 사용량 추적
+
+모든 `complete_json` 호출은 `ai_usage_logs` 테이블에 provider · model tier · intent · 입출력 토큰을 기록합니다. Admin → 연동 관리에 `AI 토큰 사용량` 카드가 최근 1/7/30/90일 호출수, 입출력 토큰 합, provider/tier/intent 분포를 보여줍니다.
+
+```http
+GET /api/v1/admin/ai-providers/usage?days=7
+```
+
+응답 JSON: `total` (호출수·입·출·실패) · `by_provider` · `by_tier` (default/deep) · `by_intent` (상위 20) · `by_day` 시계열.
+
+### 3-4. 키 없을 때 (Heuristic 모드)
 
 - 화면 상단에 `ANTHROPIC_API_KEY 미설정 — 기본 규칙 모드` 안내
 - AI Insights / Findings 트리아지는 **휴리스틱 규칙**으로 동작 (severity 매핑·키워드 기반)
 - 사용감을 정확히 확인할 수 있음 → 의사결정 후 키 추가 ✅
 
-### 3-4. 응답 출처 추적
+### 3-5. 응답 출처 추적
 
 모든 AI 응답에는 `{provider}:{model}` 라벨이 함께 저장되어 감사 가능합니다:
 

--- a/frontend/src/lib/ai-providers-api.ts
+++ b/frontend/src/lib/ai-providers-api.ts
@@ -4,7 +4,7 @@
 
 import { api } from "@/lib/api";
 
-export type AIProviderName = "anthropic" | "openai" | "bedrock" | "ollama";
+export type AIProviderName = "anthropic" | "openai" | "bedrock" | "ollama" | "vllm";
 
 export interface AIProviderRow {
   id: number;

--- a/frontend/src/pages/admin/AdminConnections.tsx
+++ b/frontend/src/pages/admin/AdminConnections.tsx
@@ -15,6 +15,7 @@ import { useState } from "react";
 import { useI18n } from "@/i18n";
 
 import AIProvidersCard from "./connections/AIProvidersCard";
+import AIUsageCard from "./connections/AIUsageCard";
 import DailyDigestCard from "./connections/DailyDigestCard";
 import GitHubOrgSyncCard from "./connections/GitHubOrgSyncCard";
 import IAMSourceCard from "./connections/IAMSourceCard";
@@ -38,6 +39,7 @@ export default function AdminConnections() {
       <IAMSourceCard onAdd={() => setModalOpen(true)} />
       <SSOCard />
       <AIProvidersCard />
+      <AIUsageCard />
       <DailyDigestCard />
       <GitHubOrgSyncCard />
       <WebhookCard />

--- a/frontend/src/pages/admin/connections/AIUsageCard.tsx
+++ b/frontend/src/pages/admin/connections/AIUsageCard.tsx
@@ -1,0 +1,211 @@
+/**
+ * AI 토큰 사용량 — 최근 N일 호출수 + 입출력 토큰 + provider/tier/intent 분포.
+ *
+ * 외부 LLM 비용 가시화와 사내 vLLM 게이트웨이의 호출량 검증이 목적.
+ * complete_json이 호출될 때마다 ai_usage_logs 테이블에 행 1건 기록되고,
+ * 이 카드는 그 집계를 admin이 보도록 노출한다.
+ */
+
+import { BarChartOutlined } from "@ant-design/icons";
+import { useQuery } from "@tanstack/react-query";
+import { Card, Empty, Select, Space, Statistic, Table, Tag, Typography } from "antd";
+import { useState } from "react";
+
+import { useI18n } from "@/i18n";
+import { api } from "@/lib/api";
+
+const { Paragraph, Text } = Typography;
+
+interface UsageSummary {
+  days: number;
+  since: string;
+  total: { calls: number; input_tokens: number; output_tokens: number; failed: number };
+  by_provider: { provider: string; calls: number; input_tokens: number; output_tokens: number }[];
+  by_tier: { tier: string; calls: number; input_tokens: number; output_tokens: number }[];
+  by_intent: { intent: string; calls: number; input_tokens: number; output_tokens: number }[];
+  by_day: { day: string; calls: number; input_tokens: number; output_tokens: number }[];
+}
+
+const PROVIDER_COLOR: Record<string, string> = {
+  anthropic: "purple",
+  openai: "green",
+  bedrock: "orange",
+  ollama: "geekblue",
+  vllm: "magenta",
+};
+
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return n.toLocaleString();
+}
+
+export default function AIUsageCard() {
+  const { locale } = useI18n();
+  const [days, setDays] = useState(7);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["ai-usage", days],
+    queryFn: async () =>
+      (await api.get<UsageSummary>("/admin/ai-providers/usage", { params: { days } })).data,
+  });
+
+  const total = data?.total ?? { calls: 0, input_tokens: 0, output_tokens: 0, failed: 0 };
+  const empty = total.calls === 0;
+
+  return (
+    <Card
+      title={
+        <Space>
+          <BarChartOutlined />
+          <span>{locale === "ko" ? "AI 토큰 사용량" : "AI Token Usage"}</span>
+        </Space>
+      }
+      extra={
+        <Select
+          value={days}
+          onChange={setDays}
+          style={{ width: 120 }}
+          options={[
+            { value: 1, label: locale === "ko" ? "오늘" : "Today" },
+            { value: 7, label: locale === "ko" ? "최근 7일" : "Last 7d" },
+            { value: 30, label: locale === "ko" ? "최근 30일" : "Last 30d" },
+            { value: 90, label: locale === "ko" ? "최근 90일" : "Last 90d" },
+          ]}
+        />
+      }
+      style={{ marginBottom: 16 }}
+    >
+      <Paragraph type="secondary" style={{ marginBottom: 12 }}>
+        {locale === "ko"
+          ? "complete_json 호출 단위로 provider · 모델 tier · intent · 입출력 토큰을 기록합니다. 사내 vLLM/Ollama 게이트웨이 사용량과 외부 LLM 비용을 한 화면에."
+          : "Every complete_json call records provider · model tier · intent · token counts. Track both on-prem (vLLM/Ollama) and external LLM cost in one view."}
+      </Paragraph>
+
+      {empty && !isLoading ? (
+        <Empty
+          description={
+            locale === "ko"
+              ? "기록된 호출이 없습니다. AI Insights / 권한 평가 / RAG 검색을 한 번 실행하면 여기에 누적됩니다."
+              : "No recorded calls yet. Trigger AI Insights / access review / RAG to populate."
+          }
+        />
+      ) : (
+        <>
+          <Space size={32} wrap style={{ marginBottom: 16 }}>
+            <Statistic
+              title={locale === "ko" ? "호출수" : "Calls"}
+              value={total.calls}
+              loading={isLoading}
+            />
+            <Statistic
+              title={locale === "ko" ? "입력 토큰" : "Input tokens"}
+              value={fmt(total.input_tokens)}
+              loading={isLoading}
+            />
+            <Statistic
+              title={locale === "ko" ? "출력 토큰" : "Output tokens"}
+              value={fmt(total.output_tokens)}
+              loading={isLoading}
+            />
+            <Statistic
+              title={locale === "ko" ? "실패" : "Failed"}
+              value={total.failed}
+              valueStyle={{ color: total.failed > 0 ? "#cf1322" : undefined }}
+              loading={isLoading}
+            />
+          </Space>
+
+          <Space direction="vertical" size={12} style={{ width: "100%" }}>
+            <div>
+              <Text strong>{locale === "ko" ? "Provider별" : "By provider"}</Text>
+              <Table
+                size="small"
+                rowKey="provider"
+                pagination={false}
+                dataSource={data?.by_provider ?? []}
+                columns={[
+                  {
+                    title: locale === "ko" ? "Provider" : "Provider",
+                    dataIndex: "provider",
+                    render: (p: string) => (
+                      <Tag color={PROVIDER_COLOR[p] ?? "default"} style={{ marginInlineEnd: 0 }}>
+                        {p}
+                      </Tag>
+                    ),
+                  },
+                  { title: locale === "ko" ? "호출" : "Calls", dataIndex: "calls", width: 90 },
+                  {
+                    title: locale === "ko" ? "입력" : "In",
+                    dataIndex: "input_tokens",
+                    width: 100,
+                    render: (n: number) => fmt(n),
+                  },
+                  {
+                    title: locale === "ko" ? "출력" : "Out",
+                    dataIndex: "output_tokens",
+                    width: 100,
+                    render: (n: number) => fmt(n),
+                  },
+                ]}
+                style={{ marginTop: 6 }}
+              />
+            </div>
+
+            <Space size={32} wrap>
+              <div style={{ minWidth: 220 }}>
+                <Text strong>{locale === "ko" ? "Tier별" : "By tier"}</Text>
+                <Table
+                  size="small"
+                  rowKey="tier"
+                  pagination={false}
+                  dataSource={data?.by_tier ?? []}
+                  columns={[
+                    {
+                      title: "Tier",
+                      dataIndex: "tier",
+                      render: (t: string) => (
+                        <Tag color={t === "deep" ? "volcano" : "blue"} style={{ marginInlineEnd: 0 }}>
+                          {t}
+                        </Tag>
+                      ),
+                    },
+                    { title: locale === "ko" ? "호출" : "Calls", dataIndex: "calls", width: 80 },
+                    {
+                      title: locale === "ko" ? "입+출" : "I+O",
+                      key: "io",
+                      width: 110,
+                      render: (_: unknown, r) => fmt((r.input_tokens || 0) + (r.output_tokens || 0)),
+                    },
+                  ]}
+                  style={{ marginTop: 6 }}
+                />
+              </div>
+
+              <div style={{ flex: 1, minWidth: 280 }}>
+                <Text strong>{locale === "ko" ? "Intent별 (상위 20)" : "By intent (top 20)"}</Text>
+                <Table
+                  size="small"
+                  rowKey="intent"
+                  pagination={false}
+                  dataSource={data?.by_intent ?? []}
+                  columns={[
+                    { title: "Intent", dataIndex: "intent" },
+                    { title: locale === "ko" ? "호출" : "Calls", dataIndex: "calls", width: 80 },
+                    {
+                      title: locale === "ko" ? "입+출" : "I+O",
+                      key: "io",
+                      width: 110,
+                      render: (_: unknown, r) => fmt((r.input_tokens || 0) + (r.output_tokens || 0)),
+                    },
+                  ]}
+                  style={{ marginTop: 6 }}
+                />
+              </div>
+            </Space>
+          </Space>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/pages/admin/connections/constants.ts
+++ b/frontend/src/pages/admin/connections/constants.ts
@@ -41,5 +41,6 @@ export const AI_PROVIDERS: {
   { name: "anthropic", label: "Anthropic Claude", needsKey: true, placeholder: "sk-ant-..." },
   { name: "openai", label: "OpenAI / Azure OpenAI", needsKey: true, placeholder: "sk-proj-..." },
   { name: "bedrock", label: "AWS Bedrock (IAM 자격)", needsKey: false, placeholder: "(boto3가 IAM 자격 자동 감지)" },
-  { name: "ollama", label: "Ollama / vLLM (로컬)", needsKey: false, placeholder: "(base_url로 호출)" },
+  { name: "ollama", label: "Ollama (로컬 LLM)", needsKey: false, placeholder: "(base_url로 호출)" },
+  { name: "vllm", label: "vLLM (사내 GPU 게이트웨이)", needsKey: false, placeholder: "(OpenAI 호환 API · base_url 필수)" },
 ];


### PR DESCRIPTION
## Summary
폐쇄망/데이터 외부 유출 금지 조직이 사내 GPU에 vLLM을 띄워 Mond를 그대로 쓸 수 있도록 vLLM provider를 추가하고, 모든 LLM 호출의 토큰 사용량을 DB에 누적해 비용·사용패턴을 가시화.

## 변경

### backend
- `models/ai_usage.py` — `AIUsageLog` 테이블 (provider/model/tier/intent/입출력 토큰/failed/timestamp). 인덱스 3개로 집계 쿼리 효율
- `services/ai_usage.py` — `record` + `summary(days)` (total · by_provider · by_tier · by_intent · by_day)
- `ai/client.py` — vllm provider 분기 (OpenAI 호환 server라 `_call_openai` 재사용, 라벨만 vllm 유지). `complete_json` 끝에 usage 기록 (try/except로 호출 차단 없음)
- `core/config.py` — `VLLM_BASE_URL/API_KEY/MODEL_DEFAULT/MODEL_DEEP`
- `endpoints/ai_providers.py` — SUPPORTED에 vllm + `GET /admin/ai-providers/usage?days=N` (ADMIN 전용, days 1~90)
- `tests/test_vllm_provider.py` — 4 케이스 (runtime 생성/None/credentials 분기)

### frontend
- `AIUsageCard.tsx` — days select (1/7/30/90) + 호출/입/출/실패 Statistic + provider/tier/intent 표. 빈 상태 가이드
- `AdminConnections.tsx` — AIProvidersCard 다음에 마운트
- `constants.ts` + `ai-providers-api.ts` — vllm 추가 (라벨 'vLLM (사내 GPU 게이트웨이)')

### 문서
- `.env.example` — VLLM_* 변수 가이드
- `docs/SETUP.md` — provider 매트릭스 행 추가 + vllm serve 예시 + 3-3 토큰 사용량 섹션 (3-3/3-4 재번호)
- README v0.3 로드맵 #9 체크박스

## 검증
- pytest 85/85 통과 (test_vllm_provider 4건 포함)
- ruff clean · frontend build OK
- 시각 검증 — `/admin/connections`에서 vLLM provider 카드 + AI 토큰 사용량 카드 정상 렌더(시드 4건으로 호출수 4·입력 8.0k·출력 3.0k·실패 1 표시)

## 운영
- DB migration 불필요 — `Base.metadata.create_all`로 자동 생성
- 사용량 기록 실패는 LLM 호출을 막지 않음 (warning만)
- vLLM은 OpenAI SDK의 base_url 표준 흐름이라 추가 의존성 0

## Test plan
- [x] pytest 85/85
- [x] ruff clean · frontend build OK
- [x] 시각 검증 (Admin 연동 관리)
- [ ] CI 통과