### PR TITLE
feat(audit): v0.3 #7 — ISMS-P 인증 심사 증빙 패키지 (자동)

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ UX·가시화 보강:
 - [x] **MCP HTTP 마운트 안정화** — Bearer 토큰 미들웨어(`MCP_HTTP_AUTH_TOKEN`), `GET /integrations/mcp/health` (enabled/mounted/transport/auth_required/reason/url), 마운트 path를 `/mcp/mcp` → `/mcp/`로 단순화, Claude Desktop/Code config 예시 + 7개 tools 표 (SETUP.md)
 - [ ] **다중 워크스페이스/조직 분리** — 사내 여러 팀이 한 인스턴스를 공유할 때 자산/정책 scope
 - [x] **감사 로그 검색 UI** — `Admin → 감사 로그`에서 기간/actor/event/request_id 필터 + 시계열 timeline
-- [ ] **한국 규제 인증 심사 패키지** — ISMS-P 자동 증빙 자료 출력 (실제 심사 대응)
+- [x] **한국 규제 인증 심사 패키지** — `GET /admin/audit-package/isms-p?format=markdown` ISMS-P 핵심 통제 10개(정책·자산·위험·접근·특수계정·접근통제·감사로그·취약점·사고대응·prod 자산)에 Mond 실 데이터를 자동 매핑. Reports 페이지에 ADMIN 전용 카드. 전체 80개 통제는 v0.4
 - [x] **알림 라우팅 다채널** — Slack 외 Discord + MS Teams webhook 추가 (severity 색상 채널별 변환)
 - [x] **온프레미스 LLM 게이트웨이 + 토큰 사용량 추적** — vLLM provider (OpenAI-호환 base_url) + `ai_usage_logs` 테이블 자동 기록 + `GET /admin/ai-providers/usage` (provider/tier/intent/일별 시계열) + Admin 연동 관리에 AI 사용량 카드
 - [x] **PR Bot — AI 분석 PR comment** — push 스캔 결과를 PR에 자동 코멘트 + AI triage 1-liner

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter
 
 from app.api.v1.endpoints import (
     admin_audit_log,
+    admin_audit_package,
     admin_bitbucket_sync,
     admin_github_sync,
     admin_gitlab_sync,
@@ -57,6 +58,7 @@ api_router.include_router(admin_github_sync.router, prefix="/admin/github-sync",
 api_router.include_router(admin_gitlab_sync.router, prefix="/admin/gitlab-sync", tags=["GitLab Sync (Admin)"])
 api_router.include_router(admin_bitbucket_sync.router, prefix="/admin/bitbucket-sync", tags=["Bitbucket Sync (Admin)"])
 api_router.include_router(admin_audit_log.router, prefix="/admin/audit-log", tags=["Audit Log (Admin)"])
+api_router.include_router(admin_audit_package.router, prefix="/admin/audit-package", tags=["Audit Package (Admin)"])
 api_router.include_router(digest.router, prefix="/admin/digest", tags=["Daily Digest (Admin)"])
 api_router.include_router(integrations.router, prefix="/integrations", tags=["Integrations"])
 api_router.include_router(webhooks.router, prefix="/webhooks", tags=["Webhooks"])

--- a/backend/app/api/v1/endpoints/admin_audit_package.py
+++ b/backend/app/api/v1/endpoints/admin_audit_package.py
@@ -1,0 +1,33 @@
+"""
+ISMS-P 인증 심사 증빙 패키지 — Admin 전용.
+
+GET /admin/audit-package/isms-p
+  format=json (기본) — 구조화된 통제별 dict
+  format=markdown  — 심사원에게 그대로 전달 가능한 텍스트
+"""
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import PlainTextResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.deps import require_role
+from app.core.database import get_db
+from app.models.user import Role
+from app.services import audit_package as audit_package_service
+
+router = APIRouter(dependencies=[Depends(require_role(Role.ADMIN))])
+
+
+@router.get("/isms-p")
+async def isms_p_package(
+    days: int = Query(90, ge=1, le=365, description="집계 기간(일). 권한 audit log 등 시계열 평가에 사용"),
+    format: str = Query("json", regex="^(json|markdown)$"),
+    db: AsyncSession = Depends(get_db),
+):
+    pkg = await audit_package_service.build_package(db, days=days)
+    if format == "markdown":
+        return PlainTextResponse(
+            content=audit_package_service.render_markdown(pkg),
+            media_type="text/markdown; charset=utf-8",
+        )
+    return pkg

--- a/backend/app/data/isms_p_controls.py
+++ b/backend/app/data/isms_p_controls.py
@@ -1,0 +1,101 @@
+"""
+ISMS-P (정보보호 및 개인정보보호 관리체계) 핵심 통제 매핑.
+
+한국 인증 심사 대응의 'V0.3 MVP' — 80여 개 통제 전체가 아니라 가장 자주
+점검되는 10개 핵심 통제만 Mond의 실 데이터(자산·접근통제·로그·발견사항·
+권한요청 흐름)에 매핑한다.
+
+각 통제는 (code, name, kisa_ref, evidence_source) 형태. evidence_source는
+audit_package 서비스가 dispatch할 수 있는 enum 문자열이다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ISMSControl:
+    code: str            # 통제 ID (ISMS-P 체계 + 내부 식별자)
+    name_ko: str
+    summary_ko: str
+    evidence_source: str  # audit_package._collectors에 등록된 키
+    kisa_ref: str         # KISA 안내서 챕터/항목 참조
+
+
+# 통제 순서는 '관리체계 → 보호대책'을 따른다.
+ISMS_P_CONTROLS: tuple[ISMSControl, ...] = (
+    ISMSControl(
+        code="1.1.5",
+        name_ko="정책 수립 — 정보보호 정책 및 책임자",
+        summary_ko="조직의 정보보호 정책 수립, 최고책임자(CISO) 지정 증빙. 본 패키지는 운영 중인 정책 카탈로그를 자동 수집한다.",
+        evidence_source="policies_catalog",
+        kisa_ref="ISMS-P 인증기준 1.1.5",
+    ),
+    ISMSControl(
+        code="1.2.1",
+        name_ko="자산 식별 및 분류",
+        summary_ko="보호 대상 자산의 식별 · 환경(prod/staging/dev) 분류 · 담당자(owner) 지정. Mond Asset 카탈로그가 1:1 매핑된다.",
+        evidence_source="assets_inventory",
+        kisa_ref="ISMS-P 인증기준 1.2.1",
+    ),
+    ISMSControl(
+        code="1.2.3",
+        name_ko="위험 평가 — open finding 위험도 집계",
+        summary_ko="자산별 잔여 위험(open finding)을 심각도별로 집계. 심사 시점의 잔여 위험 수준 증빙.",
+        evidence_source="risk_assessment",
+        kisa_ref="ISMS-P 인증기준 1.2.3",
+    ),
+    ISMSControl(
+        code="2.5.1",
+        name_ko="사용자 접근권한 부여 절차",
+        summary_ko="권한 요청 → AI 1차 검토 → 담당자 결재 → 자동 부여 → 자동 회수 흐름 전체를 audit log로 증빙.",
+        evidence_source="access_request_lifecycle",
+        kisa_ref="ISMS-P 인증기준 2.5.1",
+    ),
+    ISMSControl(
+        code="2.5.5",
+        name_ko="특수계정 관리 — ADMIN/Reviewer + MFA",
+        summary_ko="조직 내 ADMIN · Reviewer 권한자 명단과 MFA 등록 상태. ISMS-P에서 가장 민감하게 보는 항목.",
+        evidence_source="privileged_users",
+        kisa_ref="ISMS-P 인증기준 2.5.5",
+    ),
+    ISMSControl(
+        code="2.6.1",
+        name_ko="접근통제 — 네트워크/응용 통제 정책",
+        summary_ko="Mond에 등록된 정책(builtin/OPA) 중 접근통제 관련 항목의 가동 상태.",
+        evidence_source="access_control_policies",
+        kisa_ref="ISMS-P 인증기준 2.6.1",
+    ),
+    ISMSControl(
+        code="2.9.1",
+        name_ko="로그 기록 및 점검 — audit log 보존",
+        summary_ko="권한 결정/부여/회수의 시계열 audit log. 최근 N일 기간 내 이벤트 수와 sample을 첨부.",
+        evidence_source="audit_log_recent",
+        kisa_ref="ISMS-P 인증기준 2.9.1",
+    ),
+    ISMSControl(
+        code="2.10.2",
+        name_ko="패치/취약점 관리 — CVE 처리 현황",
+        summary_ko="Trivy/Semgrep/Nuclei 스캐너로 검출된 CVE의 처리 상태(triaged/fixed/wontfix). 처리율 + 잔여 critical/high.",
+        evidence_source="vulnerability_handling",
+        kisa_ref="ISMS-P 인증기준 2.10.2",
+    ),
+    ISMSControl(
+        code="2.11.1",
+        name_ko="사고 대응 — 비정상 행위 발견 시 처리",
+        summary_ko="critical/high finding의 인지 → 분류(triaged) → 진행(in_progress) → 해결(fixed) 흐름 통계 + 평균 처리 시간.",
+        evidence_source="incident_response",
+        kisa_ref="ISMS-P 인증기준 2.11.1",
+    ),
+    ISMSControl(
+        code="3.2.1",
+        name_ko="개인정보 처리 시스템 식별 — production 자산",
+        summary_ko="개인정보를 처리하는 production 자산 식별 (environment=production). 별도 보호 의무가 따른다.",
+        evidence_source="production_assets",
+        kisa_ref="ISMS-P 인증기준 3.2.1",
+    ),
+)
+
+
+CODE_TO_CONTROL: dict[str, ISMSControl] = {c.code: c for c in ISMS_P_CONTROLS}

--- a/backend/app/services/audit_package.py
+++ b/backend/app/services/audit_package.py
@@ -1,0 +1,373 @@
+"""
+ISMS-P 인증 심사 패키지 — 통제별 evidence collector.
+
+용도: KISA ISMS-P 인증 심사 시 심사원에게 제출하는 증빙 자료를 Mond가 가진
+실 데이터로부터 자동 추출. v0.3 MVP는 핵심 10개 통제만 다룬다.
+
+흐름:
+  build_package(db, days)
+    → 각 통제의 evidence_source를 dispatch
+    → 컨트롤별 dict(records + summary)을 모아 반환
+  render_markdown(package)
+    → 위 결과를 사람이 읽는 markdown으로 직렬화 (PDF 변환은 외부 도구 권장)
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.data.isms_p_controls import ISMS_P_CONTROLS, ISMSControl
+from app.models.asset import Asset
+from app.models.finding import Finding, FindingStatus, Severity
+from app.models.iam import AccessAuditLog, AccessRequest, AccessRequestStatus
+from app.models.policy import Policy
+from app.models.user import Role, User
+
+
+async def _policies_catalog(db: AsyncSession, **_: Any) -> dict:
+    rows = list((await db.execute(select(Policy))).scalars().all())
+    return {
+        "summary": f"등록된 정책 {len(rows)}건 (활성 {sum(1 for p in rows if p.enabled)})",
+        "records": [
+            {
+                "name": p.name,
+                "type": p.policy_type.value if p.policy_type else None,
+                "engine": getattr(p, "engine", "builtin"),
+                "enabled": p.enabled,
+                "threshold": getattr(p, "threshold", None),
+            }
+            for p in rows
+        ],
+    }
+
+
+async def _assets_inventory(db: AsyncSession, **_: Any) -> dict:
+    rows = list((await db.execute(select(Asset))).scalars().all())
+    by_env: Counter = Counter((a.environment or "unspecified") for a in rows)
+    by_type: Counter = Counter(a.asset_type.value for a in rows)
+    return {
+        "summary": (
+            f"총 자산 {len(rows)} · 환경 {dict(by_env)} · 유형 {dict(by_type)}"
+        ),
+        "records": [
+            {
+                "id": a.id,
+                "name": a.name,
+                "type": a.asset_type.value,
+                "environment": a.environment,
+                "owner": a.owner,
+                "uri": a.uri,
+            }
+            for a in rows
+        ],
+    }
+
+
+async def _risk_assessment(db: AsyncSession, **_: Any) -> dict:
+    open_statuses = (FindingStatus.NEW, FindingStatus.TRIAGED, FindingStatus.IN_PROGRESS)
+    q = select(Finding).where(Finding.status.in_(open_statuses))
+    rows = list((await db.execute(q)).scalars().all())
+    by_severity: Counter = Counter(f.severity.value for f in rows)
+    critical_high = sum(by_severity.get(s, 0) for s in ("critical", "high"))
+    return {
+        "summary": (
+            f"open finding {len(rows)} · severity {dict(by_severity)} · "
+            f"critical+high {critical_high}"
+        ),
+        "records": [
+            {
+                "asset_id": f.asset_id,
+                "rule_id": f.rule_id,
+                "severity": f.severity.value,
+                "status": f.status.value,
+                "scanner": f.scanner,
+                "title": f.title,
+            }
+            for f in rows
+        ],
+    }
+
+
+async def _access_request_lifecycle(db: AsyncSession, *, since: datetime, **_: Any) -> dict:
+    rows = list(
+        (
+            await db.execute(
+                select(AccessRequest).where(AccessRequest.created_at >= since).order_by(AccessRequest.created_at.desc())
+            )
+        ).scalars().all()
+    )
+    by_status: Counter = Counter(r.status.value for r in rows)
+    granted = by_status.get(AccessRequestStatus.GRANTED.value, 0)
+    denied = by_status.get(AccessRequestStatus.HUMAN_DENIED.value, 0)
+    revoked = by_status.get(AccessRequestStatus.EXPIRED_REVOKED.value, 0)
+    return {
+        "summary": (
+            f"총 요청 {len(rows)} (기간 내) · 부여 {granted} · 거부 {denied} · "
+            f"만료 자동회수 {revoked}"
+        ),
+        "records": [
+            {
+                "id": r.id,
+                "requester": r.requester,
+                "status": r.status.value,
+                "ai_decision": (r.ai_decision or {}).get("decision"),
+                "human_decision": (r.human_decision or {}).get("decision"),
+                "expires_at": r.expires_at.isoformat() if r.expires_at else None,
+                "revoked_at": r.revoked_at.isoformat() if r.revoked_at else None,
+            }
+            for r in rows[:50]  # 본문 보호
+        ],
+    }
+
+
+async def _privileged_users(db: AsyncSession, **_: Any) -> dict:
+    rows = list(
+        (
+            await db.execute(
+                select(User).where(User.role.in_([Role.ADMIN, Role.REVIEWER]))
+            )
+        ).scalars().all()
+    )
+    mfa_ok = sum(1 for u in rows if getattr(u, "mfa_enrolled", False))
+    missing_mfa = [u.email for u in rows if not getattr(u, "mfa_enrolled", False)]
+    return {
+        "summary": (
+            f"권한자 {len(rows)} (ADMIN/REVIEWER) · MFA 등록 {mfa_ok} / 미등록 {len(missing_mfa)}"
+        ),
+        "records": [
+            {
+                "email": u.email,
+                "name": u.name,
+                "role": u.role.value,
+                "mfa_enrolled": bool(getattr(u, "mfa_enrolled", False)),
+                "last_login_at": u.last_login_at.isoformat() if getattr(u, "last_login_at", None) else None,
+            }
+            for u in rows
+        ],
+        "missing_mfa": missing_mfa,  # 심사 시 우선 시정 대상
+    }
+
+
+async def _access_control_policies(db: AsyncSession, **_: Any) -> dict:
+    # 접근통제 관련 정책 — name/description에 키워드 매칭. 간단한 휴리스틱.
+    rows = list((await db.execute(select(Policy).where(Policy.enabled.is_(True)))).scalars().all())
+    keywords = ("접근", "access", "auth", "rbac", "권한", "iam")
+
+    def is_access(p: Policy) -> bool:
+        blob = " ".join(filter(None, [(p.name or ""), (p.description or "")])).lower()
+        return any(k in blob for k in keywords)
+
+    matched = [p for p in rows if is_access(p)]
+    return {
+        "summary": f"활성 접근통제 정책 {len(matched)}건 (전체 활성 {len(rows)})",
+        "records": [
+            {"name": p.name, "engine": getattr(p, "engine", "builtin"), "description": p.description}
+            for p in matched
+        ],
+    }
+
+
+async def _audit_log_recent(db: AsyncSession, *, since: datetime, **_: Any) -> dict:
+    count = (
+        await db.execute(
+            select(func.count(AccessAuditLog.id)).where(AccessAuditLog.created_at >= since)
+        )
+    ).scalar_one()
+    sample = list(
+        (
+            await db.execute(
+                select(AccessAuditLog)
+                .where(AccessAuditLog.created_at >= since)
+                .order_by(AccessAuditLog.created_at.desc())
+                .limit(20)
+            )
+        ).scalars().all()
+    )
+    return {
+        "summary": f"기간 내 audit 이벤트 {int(count or 0)}건 (sample 최대 20건 첨부)",
+        "records": [
+            {
+                "id": e.id,
+                "request_id": e.request_id,
+                "event": e.event.value,
+                "actor": e.actor,
+                "created_at": e.created_at.isoformat() if e.created_at else None,
+            }
+            for e in sample
+        ],
+    }
+
+
+async def _vulnerability_handling(db: AsyncSession, **_: Any) -> dict:
+    total = list((await db.execute(select(Finding))).scalars().all())
+    by_status: Counter = Counter(f.status.value for f in total)
+    open_critical = sum(
+        1 for f in total
+        if f.severity == Severity.CRITICAL and f.status in (FindingStatus.NEW, FindingStatus.TRIAGED, FindingStatus.IN_PROGRESS)
+    )
+    open_high = sum(
+        1 for f in total
+        if f.severity == Severity.HIGH and f.status in (FindingStatus.NEW, FindingStatus.TRIAGED, FindingStatus.IN_PROGRESS)
+    )
+    fixed = by_status.get(FindingStatus.FIXED.value, 0)
+    rate = (fixed / len(total) * 100) if total else 0.0
+    return {
+        "summary": (
+            f"총 finding {len(total)} · 상태분포 {dict(by_status)} · "
+            f"잔여 critical {open_critical} · 잔여 high {open_high} · 해결률 {rate:.1f}%"
+        ),
+        "records": [],  # 본문은 risk_assessment와 중복되니 records 생략
+    }
+
+
+async def _incident_response(db: AsyncSession, **_: Any) -> dict:
+    rows = list(
+        (
+            await db.execute(
+                select(Finding).where(Finding.severity.in_([Severity.CRITICAL, Severity.HIGH]))
+            )
+        ).scalars().all()
+    )
+    triaged = sum(1 for f in rows if f.status == FindingStatus.TRIAGED)
+    in_prog = sum(1 for f in rows if f.status == FindingStatus.IN_PROGRESS)
+    fixed = sum(1 for f in rows if f.status == FindingStatus.FIXED)
+    return {
+        "summary": (
+            f"critical+high finding {len(rows)} · triaged {triaged} · in_progress {in_prog} · fixed {fixed}"
+        ),
+        "records": [],
+    }
+
+
+async def _production_assets(db: AsyncSession, **_: Any) -> dict:
+    rows = list(
+        (
+            await db.execute(
+                select(Asset).where(Asset.environment.in_(["production", "prod"]))
+            )
+        ).scalars().all()
+    )
+    no_owner = [a.name for a in rows if not a.owner]
+    return {
+        "summary": (
+            f"production 자산 {len(rows)}건 · 담당자 미지정 {len(no_owner)}건"
+        ),
+        "records": [
+            {"id": a.id, "name": a.name, "owner": a.owner, "uri": a.uri, "type": a.asset_type.value}
+            for a in rows
+        ],
+        "missing_owner": no_owner,
+    }
+
+
+_COLLECTORS = {
+    "policies_catalog": _policies_catalog,
+    "assets_inventory": _assets_inventory,
+    "risk_assessment": _risk_assessment,
+    "access_request_lifecycle": _access_request_lifecycle,
+    "privileged_users": _privileged_users,
+    "access_control_policies": _access_control_policies,
+    "audit_log_recent": _audit_log_recent,
+    "vulnerability_handling": _vulnerability_handling,
+    "incident_response": _incident_response,
+    "production_assets": _production_assets,
+}
+
+
+async def build_package(db: AsyncSession, *, days: int = 90) -> dict:
+    """ISMS-P 통제 10개 + 각 통제별 evidence."""
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+
+    sections: list[dict] = []
+    for ctrl in ISMS_P_CONTROLS:
+        collector = _COLLECTORS.get(ctrl.evidence_source)
+        if collector is None:
+            sections.append({
+                "control": _control_to_dict(ctrl),
+                "evidence": {"summary": "(collector 미구현)", "records": []},
+            })
+            continue
+        try:
+            evidence = await collector(db, since=since)
+        except Exception as exc:  # 한 통제 실패가 패키지 전체를 막지 않게
+            evidence = {"summary": f"(수집 실패: {exc})", "records": []}
+        sections.append({"control": _control_to_dict(ctrl), "evidence": evidence})
+
+    return {
+        "framework": "ISMS-P",
+        "version": "v0.3",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "period_days": days,
+        "since": since.isoformat(),
+        "sections": sections,
+    }
+
+
+def _control_to_dict(c: ISMSControl) -> dict:
+    return {
+        "code": c.code,
+        "name_ko": c.name_ko,
+        "summary_ko": c.summary_ko,
+        "kisa_ref": c.kisa_ref,
+        "evidence_source": c.evidence_source,
+    }
+
+
+def render_markdown(package: dict) -> str:
+    """JSON 패키지를 사람이 읽는 markdown으로. 심사원에게 그대로 전달 가능."""
+    lines: list[str] = []
+    lines.append(f"# {package['framework']} 인증 심사 증빙 패키지")
+    lines.append("")
+    lines.append(f"_생성 시각: {package['generated_at']} · 집계 기간: 최근 {package['period_days']}일_")
+    lines.append("")
+    lines.append(
+        "이 문서는 Mond가 운영 중 수집·기록하는 데이터를 ISMS-P 핵심 통제 10개에 자동 매핑한 자료입니다. "
+        "심사 시점의 실 데이터를 그대로 반영하므로 별도 정리 작업 없이 1차 증빙으로 활용할 수 있습니다."
+    )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    for sec in package["sections"]:
+        c = sec["control"]
+        e = sec["evidence"]
+        lines.append(f"## {c['code']} · {c['name_ko']}")
+        lines.append("")
+        lines.append(f"_{c['kisa_ref']}_")
+        lines.append("")
+        lines.append(c["summary_ko"])
+        lines.append("")
+        lines.append(f"**집계 요약**: {e.get('summary', '—')}")
+        lines.append("")
+        recs = e.get("records") or []
+        if recs:
+            keys = list(recs[0].keys())
+            lines.append("| " + " | ".join(keys) + " |")
+            lines.append("|" + "|".join(["---"] * len(keys)) + "|")
+            for r in recs[:30]:
+                row = " | ".join(
+                    str(r.get(k) if r.get(k) is not None else "—").replace("|", "\\|") for k in keys
+                )
+                lines.append(f"| {row} |")
+            if len(recs) > 30:
+                lines.append("")
+                lines.append(f"_(전체 {len(recs)}건 중 상위 30건만 표시)_")
+            lines.append("")
+        # 보조 필드 (missing_mfa, missing_owner 등) — 시정 대상 강조
+        for k in ("missing_mfa", "missing_owner"):
+            extras = e.get(k)
+            if extras:
+                lines.append(f"**시정 권고 — {k}:** {', '.join(str(x) for x in extras[:20])}")
+                if len(extras) > 20:
+                    lines.append(f"_(총 {len(extras)}건)_")
+                lines.append("")
+        lines.append("---")
+        lines.append("")
+
+    lines.append("_본 문서는 Mond가 자동 생성한 1차 증빙입니다. 최종 심사 자료로 사용하기 전 보안담당자가 검토하세요._")
+    return "\n".join(lines)

--- a/backend/tests/test_isms_p_package.py
+++ b/backend/tests/test_isms_p_package.py
@@ -1,0 +1,120 @@
+"""
+ISMS-P 인증 심사 패키지 — 통제 매핑 + markdown 직렬화 invariant.
+
+build_package 자체는 DB 의존 통합 테스트라 여기선 통제 카탈로그가 안정적인지와
+render_markdown이 빈 records · missing_* 보조 필드를 정상 처리하는지만 검증.
+"""
+
+from app.data.isms_p_controls import CODE_TO_CONTROL, ISMS_P_CONTROLS
+from app.services.audit_package import _COLLECTORS, render_markdown
+
+
+def test_controls_have_unique_codes():
+    codes = [c.code for c in ISMS_P_CONTROLS]
+    assert len(codes) == len(set(codes))
+
+
+def test_controls_cover_10_core_areas():
+    # v0.3 MVP는 10개 핵심 통제 — 줄거나 늘면 의도적 변경
+    assert len(ISMS_P_CONTROLS) == 10
+
+
+def test_every_control_has_registered_collector():
+    """evidence_source가 모두 _COLLECTORS에 매핑되어 있어야 한다."""
+    for c in ISMS_P_CONTROLS:
+        assert c.evidence_source in _COLLECTORS, f"missing collector: {c.code} → {c.evidence_source}"
+
+
+def test_code_to_control_lookup_works():
+    assert CODE_TO_CONTROL["2.5.5"].name_ko.startswith("특수계정")
+
+
+def test_render_markdown_with_minimal_sections():
+    pkg = {
+        "framework": "ISMS-P",
+        "version": "v0.3",
+        "generated_at": "2026-06-21T00:00:00+00:00",
+        "period_days": 90,
+        "since": "2026-03-23T00:00:00+00:00",
+        "sections": [
+            {
+                "control": {
+                    "code": "1.2.1",
+                    "name_ko": "자산 식별 및 분류",
+                    "summary_ko": "test summary",
+                    "kisa_ref": "ISMS-P 1.2.1",
+                    "evidence_source": "assets_inventory",
+                },
+                "evidence": {
+                    "summary": "총 자산 3 · 환경 {'prod': 2, 'dev': 1}",
+                    "records": [
+                        {"id": 1, "name": "api", "type": "repository", "environment": "prod"},
+                    ],
+                },
+            }
+        ],
+    }
+    md = render_markdown(pkg)
+    assert "# ISMS-P 인증 심사 증빙 패키지" in md
+    assert "## 1.2.1" in md
+    assert "자산 식별" in md
+    assert "ISMS-P 1.2.1" in md
+    assert "| id | name | type | environment |" in md  # 표 헤더
+    # summary가 집계 요약 라인에 포함
+    assert "**집계 요약**: 총 자산 3" in md
+
+
+def test_render_markdown_handles_missing_mfa_list():
+    pkg = {
+        "framework": "ISMS-P",
+        "version": "v0.3",
+        "generated_at": "2026-06-21T00:00:00+00:00",
+        "period_days": 30,
+        "since": "2026-05-22T00:00:00+00:00",
+        "sections": [
+            {
+                "control": {
+                    "code": "2.5.5",
+                    "name_ko": "특수계정",
+                    "summary_ko": "...",
+                    "kisa_ref": "x",
+                    "evidence_source": "privileged_users",
+                },
+                "evidence": {
+                    "summary": "권한자 2 · MFA 미등록 1",
+                    "records": [],
+                    "missing_mfa": ["alice@example.com"],
+                },
+            }
+        ],
+    }
+    md = render_markdown(pkg)
+    assert "시정 권고 — missing_mfa" in md
+    assert "alice@example.com" in md
+
+
+def test_render_markdown_escapes_pipe_in_record_values():
+    pkg = {
+        "framework": "ISMS-P",
+        "version": "v0.3",
+        "generated_at": "2026-06-21T00:00:00+00:00",
+        "period_days": 30,
+        "since": "2026-05-22T00:00:00+00:00",
+        "sections": [
+            {
+                "control": {
+                    "code": "1.2.1",
+                    "name_ko": "자산",
+                    "summary_ko": "x",
+                    "kisa_ref": "x",
+                    "evidence_source": "assets_inventory",
+                },
+                "evidence": {
+                    "summary": "1",
+                    "records": [{"name": "weird|name|with|pipes"}],
+                },
+            }
+        ],
+    }
+    md = render_markdown(pkg)
+    assert "weird\\|name\\|with\\|pipes" in md

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -898,6 +898,32 @@ RATE_LIMIT_ENABLED=true     # 기본. false로 끄면 모든 버킷 통과 (test
 
 Redis 다운 시 fail open(가용성 우선) — `rate_limit_redis_down` 경고 로그를 남기고 요청은 통과. 보안 critical 환경이면 monitor에서 이 로그를 알림으로 연결할 것.
 
+### 8-2) ISMS-P 인증 심사 증빙 패키지 (한국 조직)
+
+KISA ISMS-P 인증을 받았거나 받을 예정인 조직을 위한 v0.3 자동 증빙. 80여 개 통제 중 가장 자주 점검되는 **핵심 10개**를 Mond의 실 운영 데이터(자산·접근통제·로그·발견사항·권한요청 흐름)에 매핑해 markdown / JSON으로 추출한다.
+
+```http
+GET /api/v1/admin/audit-package/isms-p?days=90&format=markdown   # 심사원 전달용
+GET /api/v1/admin/audit-package/isms-p?days=90&format=json       # 자동화/2차 가공
+```
+
+매핑된 통제 10개:
+
+| 통제 | 항목 | Mond 데이터 |
+|---|---|---|
+| 1.1.5 | 정보보호 정책 + CISO | Policy 카탈로그 |
+| 1.2.1 | 자산 식별·분류 | Asset (환경/유형/owner) |
+| 1.2.3 | 위험 평가 | open Finding severity 분포 |
+| 2.5.1 | 권한 부여 절차 | AccessRequest 흐름 + AI/담당자 결정 |
+| 2.5.5 | 특수계정 + MFA | ADMIN/Reviewer 명단 + 등록 상태 |
+| 2.6.1 | 접근통제 정책 | 접근 키워드 Policy |
+| 2.9.1 | 로그 기록 | access_audit_logs 시계열 |
+| 2.10.2 | 패치/취약점 | Finding 상태별 + 해결률 |
+| 2.11.1 | 사고 대응 | critical/high finding 처리 흐름 |
+| 3.2.1 | 개인정보 처리 자산 | environment=production Asset |
+
+Admin → **Reports → ISMS-P 인증 심사 증빙** 카드에서 1-click 다운로드. 1차 증빙용이며 최종 심사 자료 제출 전 보안담당자 검토를 권장. 전체 80개 통제 매핑은 v0.4 예정.
+
 ### 9) 데모 시드 끄기
 
 ```bash

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -2,11 +2,12 @@
  * Reports — SBOM / Compliance 다운로드
  */
 
-import { DownloadOutlined, ExperimentOutlined, FileSearchOutlined } from "@ant-design/icons";
+import { DownloadOutlined, ExperimentOutlined, FileSearchOutlined, SafetyOutlined } from "@ant-design/icons";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { Alert, Button, Card, Col, Input, Row, Select, Space, Table, Tag, Typography, message } from "antd";
+import { Alert, Button, Card, Col, Input, InputNumber, Row, Select, Space, Table, Tag, Typography, message } from "antd";
 import { useState } from "react";
 
+import { useAuth } from "@/auth/AuthContext";
 import { useI18n } from "@/i18n";
 import { api, type Asset, type Page } from "@/lib/api";
 
@@ -33,6 +34,8 @@ interface ScenarioLite {
 
 export default function Reports() {
   const { t, locale } = useI18n();
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
   const [assetId, setAssetId] = useState<number | undefined>(undefined);
   const [scenarioId, setScenarioId] = useState<string | undefined>(undefined);
 
@@ -40,6 +43,9 @@ export default function Reports() {
   const [filename, setFilename] = useState("package.json");
   const [content, setContent] = useState("");
   const [parsed, setParsed] = useState<ParseResult | null>(null);
+
+  // ISMS-P 인증 심사 패키지 (ADMIN 전용)
+  const [ismsDays, setIsmsDays] = useState(90);
 
   const parseSbom = useMutation({
     mutationFn: async () => {
@@ -173,6 +179,64 @@ export default function Reports() {
             </Space>
           </Card>
         </Col>
+
+        {isAdmin && (
+          <Col xs={24}>
+            <Card
+              title={
+                <Space>
+                  <SafetyOutlined style={{ color: "#722ed1" }} />
+                  <span>{locale === "ko" ? "ISMS-P 인증 심사 증빙" : "ISMS-P Audit Package"}</span>
+                  <Tag color="purple">{locale === "ko" ? "ADMIN" : "ADMIN"}</Tag>
+                  <Tag>10 controls</Tag>
+                </Space>
+              }
+            >
+              <Paragraph type="secondary">
+                {locale === "ko"
+                  ? "KISA ISMS-P 핵심 통제 10개를 Mond 실 데이터(자산·접근통제·로그·발견사항·권한요청 흐름)에 자동 매핑해 1차 증빙 자료를 만듭니다. 심사원에게 그대로 전달 가능."
+                  : "Maps 10 core KISA ISMS-P controls onto Mond's live data (assets, access control, logs, findings, access requests) — first-pass evidence ready to share with auditors."}
+              </Paragraph>
+              <Space wrap>
+                <Space size={4}>
+                  <Text>{locale === "ko" ? "집계 기간(일)" : "Period (days)"}</Text>
+                  <InputNumber
+                    min={1}
+                    max={365}
+                    value={ismsDays}
+                    onChange={(v) => setIsmsDays(Number(v) || 90)}
+                    style={{ width: 90 }}
+                  />
+                </Space>
+                <Button
+                  type="primary"
+                  icon={<DownloadOutlined />}
+                  href={`/api/v1/admin/audit-package/isms-p?days=${ismsDays}&format=markdown`}
+                  target="_blank"
+                >
+                  {locale === "ko" ? "Markdown 다운로드" : "Download Markdown"}
+                </Button>
+                <Button
+                  icon={<DownloadOutlined />}
+                  href={`/api/v1/admin/audit-package/isms-p?days=${ismsDays}&format=json`}
+                  target="_blank"
+                >
+                  {locale === "ko" ? "JSON 다운로드" : "Download JSON"}
+                </Button>
+              </Space>
+              <Alert
+                type="info"
+                showIcon
+                style={{ marginTop: 12 }}
+                message={
+                  locale === "ko"
+                    ? "1차 증빙으로 자동 생성됩니다. 심사 자료로 사용하기 전 보안담당자 검토를 권장합니다. v0.3은 핵심 10개 통제만 다루며, 전체 80여 통제는 v0.4에서 확장 예정."
+                    : "Auto-generated first-pass evidence. Have a security lead review before submitting. v0.3 covers 10 core controls; full 80-control coverage in v0.4."
+                }
+              />
+            </Card>
+          </Col>
+        )}
 
         <Col xs={24}>
           <Card


### PR DESCRIPTION
## Summary
KISA ISMS-P 인증을 받는 한국 조직이 Mond를 운영하면 1차 증빙이 자연스럽게 쌓이도록, 80여 개 통제 중 가장 자주 점검되는 **핵심 10개**를 Mond 실 데이터에 매핑해 markdown/JSON으로 추출하는 endpoint를 추가.

## 변경

### 매핑된 통제 10
| 통제 | 항목 | Mond 데이터 |
|---|---|---|
| 1.1.5 | 정보보호 정책 + CISO | Policy 카탈로그 |
| 1.2.1 | 자산 식별·분류 | Asset (환경/유형/owner) |
| 1.2.3 | 위험 평가 | open Finding severity 분포 |
| 2.5.1 | 권한 부여 절차 | AccessRequest 흐름 |
| 2.5.5 | 특수계정 + MFA | ADMIN/Reviewer 명단 + 등록 상태 (`missing_mfa` 시정 권고) |
| 2.6.1 | 접근통제 정책 | 접근 키워드 Policy |
| 2.9.1 | 로그 기록 | access_audit_logs 시계열 + sample |
| 2.10.2 | 패치/취약점 | Finding 상태별 + 해결률 |
| 2.11.1 | 사고 대응 | critical/high finding 처리 흐름 |
| 3.2.1 | 개인정보 처리 자산 | environment=production Asset (`missing_owner` 시정 권고) |

### Backend
- `data/isms_p_controls.py` — 10 통제 카탈로그 (code/name_ko/summary_ko/evidence_source/kisa_ref)
- `services/audit_package.py` — `_COLLECTORS` dispatch, `build_package(days)`, `render_markdown` (표 형식 + pipe escape + 시정 권고 섹션)
- `endpoints/admin_audit_package.py` — `GET /admin/audit-package/isms-p?days=N&format=(json|markdown)` ADMIN 전용

### Frontend
`Reports.tsx` ADMIN 분기 — compliance 카드 다음에 ISMS-P 카드 (days InputNumber + Markdown/JSON 다운로드, '1차 증빙' Alert)

### 7 단위 테스트
통제 unique/고정 + evidence_source 전부 collector 매핑 + render_markdown 표/시정 권고/pipe escape

## 검증
- pytest 104/104 (test_isms_p_package 7건 포함)
- ruff clean · frontend build OK
- 통합: `curl /admin/audit-package/isms-p?format=markdown` → 시드 데이터 기준 정상 markdown 출력 (정책 5건, 자산 N건, 권한자 등 통제별 표 + 집계 요약)

## 운영
- 1차 증빙으로 자동 생성. 심사 자료 제출 전 보안담당자 검토 권장
- 통제 1건 collector 실패해도 패키지 전체는 계속 (해당 통제만 '(수집 실패)' 표기)
- 매핑 휴리스틱은 보수적 — false positive 우선
- v0.4: 전체 80개 통제 확장 + PDF/ZIP 출력

## Test plan
- [x] pytest 104/104
- [x] ruff clean · frontend build
- [x] markdown endpoint 통합 검증
- [ ] CI 통과