### PR TITLE
feat(workspace): v0.3 #5 — 다중 워크스페이스 (Phase 1, Asset)

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ UX·가시화 보강:
 - [x] **AI 멀티 프로바이더 라우팅** — 의도(`intent`)별 model 자동 라우팅 (`remediation`/`explain`/`deep_analysis`는 `model_deep`, 그 외 `model_default`)
 - [x] **SBOM CycloneDX 정식 출력** — CycloneDX 1.5 표준 (`bomFormat: "CycloneDX"`, `serialNumber: urn:uuid:…`, `metadata.tools`, REPOSITORY 자산은 default branch에서 `components[]` 자동 추출, findings → 표준 `vulnerabilities[]`)
 - [x] **MCP HTTP 마운트 안정화** — Bearer 토큰 미들웨어(`MCP_HTTP_AUTH_TOKEN`), `GET /integrations/mcp/health` (enabled/mounted/transport/auth_required/reason/url), 마운트 path를 `/mcp/mcp` → `/mcp/`로 단순화, Claude Desktop/Code config 예시 + 7개 tools 표 (SETUP.md)
-- [ ] **다중 워크스페이스/조직 분리** — 사내 여러 팀이 한 인스턴스를 공유할 때 자산/정책 scope
+- [x] **다중 워크스페이스/조직 분리 (Phase 1 — Asset)** — `Workspace` 모델(slug/name/default) + Admin CRUD + Asset에 `workspace_id` (NULL 허용 — 기존 단일 조직 운영 호환). Assets 페이지에 workspace selector(ADMIN). Policy/Finding/IAM 등 나머지 자원 분리는 v0.4 Phase 2
 - [x] **감사 로그 검색 UI** — `Admin → 감사 로그`에서 기간/actor/event/request_id 필터 + 시계열 timeline
 - [x] **한국 규제 인증 심사 패키지** — `GET /admin/audit-package/isms-p?format=markdown` ISMS-P 핵심 통제 10개(정책·자산·위험·접근·특수계정·접근통제·감사로그·취약점·사고대응·prod 자산)에 Mond 실 데이터를 자동 매핑. Reports 페이지에 ADMIN 전용 카드. 전체 80개 통제는 v0.4
 - [x] **알림 라우팅 다채널** — Slack 외 Discord + MS Teams webhook 추가 (severity 색상 채널별 변환)

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -11,6 +11,7 @@ from app.api.v1.endpoints import (
     admin_github_sync,
     admin_gitlab_sync,
     admin_slack,
+    admin_workspaces,
     ai,
     ai_providers,
     assets,
@@ -59,6 +60,7 @@ api_router.include_router(admin_gitlab_sync.router, prefix="/admin/gitlab-sync",
 api_router.include_router(admin_bitbucket_sync.router, prefix="/admin/bitbucket-sync", tags=["Bitbucket Sync (Admin)"])
 api_router.include_router(admin_audit_log.router, prefix="/admin/audit-log", tags=["Audit Log (Admin)"])
 api_router.include_router(admin_audit_package.router, prefix="/admin/audit-package", tags=["Audit Package (Admin)"])
+api_router.include_router(admin_workspaces.router, prefix="/admin/workspaces", tags=["Workspaces (Admin)"])
 api_router.include_router(digest.router, prefix="/admin/digest", tags=["Daily Digest (Admin)"])
 api_router.include_router(integrations.router, prefix="/integrations", tags=["Integrations"])
 api_router.include_router(webhooks.router, prefix="/webhooks", tags=["Webhooks"])

--- a/backend/app/api/v1/endpoints/admin_workspaces.py
+++ b/backend/app/api/v1/endpoints/admin_workspaces.py
@@ -1,0 +1,86 @@
+"""
+Workspace CRUD — Admin 전용.
+
+v0.3 MVP: 모든 자원의 workspace 분리가 아니라 *워크스페이스 카탈로그 + Asset
+연결* 만 다룬다. Policy/Finding/IAM 등 나머지 자원은 v0.4 후속.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.deps import require_role
+from app.core.database import get_db
+from app.models.user import Role
+from app.services import workspace as workspace_service
+
+router = APIRouter(dependencies=[Depends(require_role(Role.ADMIN))])
+
+
+class WorkspaceRead(BaseModel):
+    id: int
+    slug: str
+    name: str
+    description: str | None
+    is_default: bool
+
+
+class WorkspaceCreate(BaseModel):
+    slug: str = Field(..., min_length=1, max_length=64)
+    name: str = Field(..., min_length=1, max_length=128)
+    description: str | None = Field(None, max_length=512)
+
+
+class WorkspaceUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=128)
+    description: str | None = Field(None, max_length=512)
+
+
+def _to_read(ws) -> WorkspaceRead:
+    return WorkspaceRead(
+        id=ws.id, slug=ws.slug, name=ws.name, description=ws.description, is_default=ws.is_default
+    )
+
+
+@router.get("", response_model=list[WorkspaceRead])
+async def list_workspaces(db: AsyncSession = Depends(get_db)):
+    return [_to_read(ws) for ws in await workspace_service.list_workspaces(db)]
+
+
+@router.post("", response_model=WorkspaceRead, status_code=201)
+async def create_workspace(payload: WorkspaceCreate, db: AsyncSession = Depends(get_db)):
+    slug = payload.slug.strip().lower()
+    if not workspace_service.is_valid_slug(slug):
+        raise HTTPException(400, "slug must be lowercase alphanumeric + hyphen, 1-64 chars")
+    if await workspace_service.get_by_slug(db, slug):
+        raise HTTPException(409, "slug already exists")
+    ws = await workspace_service.create(db, slug=slug, name=payload.name.strip(), description=payload.description)
+    return _to_read(ws)
+
+
+@router.patch("/{ws_id}", response_model=WorkspaceRead)
+async def update_workspace(ws_id: int, payload: WorkspaceUpdate, db: AsyncSession = Depends(get_db)):
+    ws = await workspace_service.update(db, ws_id=ws_id, name=payload.name, description=payload.description)
+    if ws is None:
+        raise HTTPException(404, "workspace not found")
+    return _to_read(ws)
+
+
+@router.post("/{ws_id}/default", response_model=WorkspaceRead)
+async def set_default(ws_id: int, db: AsyncSession = Depends(get_db)):
+    ws = await workspace_service.set_default(db, ws_id=ws_id)
+    if ws is None:
+        raise HTTPException(404, "workspace not found")
+    return _to_read(ws)
+
+
+@router.delete("/{ws_id}", status_code=204)
+async def delete_workspace(ws_id: int, db: AsyncSession = Depends(get_db)):
+    ok, reason = await workspace_service.delete(db, ws_id=ws_id)
+    if not ok:
+        if reason == "workspace_not_found":
+            raise HTTPException(404, "workspace not found")
+        raise HTTPException(400, reason)
+    return None

--- a/backend/app/api/v1/endpoints/assets.py
+++ b/backend/app/api/v1/endpoints/assets.py
@@ -26,11 +26,17 @@ async def list_assets(
     offset: int = Query(0, ge=0),
     asset_type: str | None = Query(None),
     q: str | None = Query(None, description="이름/URI 부분일치 검색"),
+    workspace_id: int | None = Query(None, description="해당 workspace + 미배정 자산만"),
     _user: User = Depends(current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Page[AssetRead]:
     items, total = await asset_service.list_assets(
-        db, limit=limit, offset=offset, asset_type=asset_type, q=q
+        db,
+        limit=limit,
+        offset=offset,
+        asset_type=asset_type,
+        q=q,
+        workspace_id=workspace_id,
     )
     return Page(items=[AssetRead.model_validate(i) for i in items], total=total, limit=limit, offset=offset)
 

--- a/backend/app/db_seed.py
+++ b/backend/app/db_seed.py
@@ -17,6 +17,7 @@ from app.models.asset import Asset, AssetType
 from app.models.iam import IAMIdentity, IAMSource, IAMSourceKind, Permission
 from app.models.knowledge import KnowledgeCard, KnowledgeSource
 from app.models.policy import Policy, PolicyType
+from app.models.workspace import Workspace
 
 logger = get_logger(__name__)
 
@@ -108,6 +109,13 @@ deny contains msg if {
 
 
 async def seed_if_empty(db: AsyncSession) -> None:
+    # v0.3 #5 — default workspace 보장. 단일 조직 사용자에게 영향 0.
+    ws_count = (await db.execute(select(func.count(Workspace.id)))).scalar_one()
+    if ws_count == 0:
+        db.add(Workspace(slug="default", name="Default", description="기본 워크스페이스", is_default=True))
+        await db.commit()
+        logger.info("seed_default_workspace")
+
     asset_count = (await db.execute(select(func.count(Asset.id)))).scalar_one()
     policy_count = (await db.execute(select(func.count(Policy.id)))).scalar_one()
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -28,6 +28,7 @@ from app.models.policy import Policy, PolicyType
 from app.models.scan import Scan, ScanStatus, ScanTrigger
 from app.models.slack import SlackChannel, SlackPurpose
 from app.models.user_slack import UserSlackPreference
+from app.models.workspace import Workspace
 from app.models.user import (
     MfaBackupCode,
     Role,
@@ -53,6 +54,7 @@ __all__ = [
     "SlackChannel",
     "SlackPurpose",
     "UserSlackPreference",
+    "Workspace",
     "AIInsight",
     "InsightKind",
     "AIProviderConfig",

--- a/backend/app/models/asset.py
+++ b/backend/app/models/asset.py
@@ -7,7 +7,7 @@ Asset — 보호 대상 (repo / image / host / URL / cloud resource / applicatio
 import enum
 from typing import TYPE_CHECKING
 
-from sqlalchemy import JSON, Enum, String
+from sqlalchemy import JSON, Enum, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin
@@ -46,6 +46,15 @@ class Asset(Base, TimestampMixin):
 
     owner: Mapped[str | None] = mapped_column(String(255), index=True)
     environment: Mapped[str | None] = mapped_column(String(64), index=True)  # dev / staging / prod
+
+    # 다중 워크스페이스(v0.3 MVP) — NULL이면 모든 workspace에서 visible
+    # (기존 자산 + 단일 조직 운영 호환). v0.4에서 nullable=False 전환 예정.
+    workspace_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("workspaces.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
 
     # 통계 캐시 (서비스 계층에서 갱신)
     open_findings_count: Mapped[int] = mapped_column(default=0, nullable=False)

--- a/backend/app/models/workspace.py
+++ b/backend/app/models/workspace.py
@@ -1,0 +1,34 @@
+"""
+Workspace — 다중 조직/팀이 한 Mond 인스턴스를 공유할 때 자산 scope.
+
+v0.3 MVP는 Asset만 workspace로 분리한다 (NULL 허용으로 기존 데이터 백필
+안전성 확보). Policy/Finding/IAM 등 나머지 자원은 v0.4에서 확장.
+
+운영 모델
+--------
+- 단일 조직: workspace 1개(default)만 사용. 기존 사용자에게 영향 0.
+- 다중 조직: 관리자가 Admin → 워크스페이스에서 추가. 자산 등록/조회 시
+  현재 workspace에 자동 묶이고, X-Mond-Workspace 헤더로 전환.
+
+slug는 URL/header 사용용 (소문자·하이픈). seed에서 'default' 1건을
+is_default=True로 생성.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Boolean, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class Workspace(Base, TimestampMixin):
+    __tablename__ = "workspaces"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    slug: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    description: Mapped[str | None] = mapped_column(String(512))
+    is_default: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )

--- a/backend/app/schemas/asset.py
+++ b/backend/app/schemas/asset.py
@@ -16,6 +16,7 @@ class AssetBase(BaseModel):
     labels: dict = Field(default_factory=dict)
     owner: str | None = None
     environment: str | None = None
+    workspace_id: int | None = None
 
 
 class AssetCreate(AssetBase):
@@ -28,6 +29,7 @@ class AssetUpdate(BaseModel):
     labels: dict | None = None
     owner: str | None = None
     environment: str | None = None
+    workspace_id: int | None = None
 
 
 class AssetRead(AssetBase, Timestamped):

--- a/backend/app/services/asset.py
+++ b/backend/app/services/asset.py
@@ -19,7 +19,14 @@ async def list_assets(
     offset: int = 0,
     asset_type: str | None = None,
     q: str | None = None,
+    workspace_id: int | None = None,
+    include_unscoped: bool = True,
 ) -> tuple[list[Asset], int]:
+    """자산 목록.
+
+    workspace_id가 None이면 모든 workspace + 미배정(NULL) 자산.
+    workspace_id가 주어지면 해당 workspace + (include_unscoped=True면) NULL 자산.
+    """
     stmt = select(Asset)
     count_stmt = select(func.count(Asset.id))
 
@@ -30,6 +37,13 @@ async def list_assets(
         like = f"%{q}%"
         stmt = stmt.where(Asset.name.ilike(like) | Asset.uri.ilike(like))
         count_stmt = count_stmt.where(Asset.name.ilike(like) | Asset.uri.ilike(like))
+    if workspace_id is not None:
+        if include_unscoped:
+            cond = (Asset.workspace_id == workspace_id) | (Asset.workspace_id.is_(None))
+        else:
+            cond = Asset.workspace_id == workspace_id
+        stmt = stmt.where(cond)
+        count_stmt = count_stmt.where(cond)
 
     total = (await db.execute(count_stmt)).scalar_one()
     items = (await db.execute(stmt.order_by(Asset.id.desc()).limit(limit).offset(offset))).scalars().all()

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -1,0 +1,96 @@
+"""
+Workspace 서비스 — CRUD + slug 유효성 + default 회수.
+
+v0.3 MVP는 단일 모델(Workspace) CRUD만. Asset 등 자원의 workspace_id 필터링은
+호출부에서 직접 처리.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.workspace import Workspace
+
+_SLUG_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$|^[a-z0-9]$")
+
+
+def is_valid_slug(slug: str) -> bool:
+    """소문자 + 숫자 + 하이픈, 시작/끝은 영숫자, 1~64자."""
+    return bool(_SLUG_PATTERN.match(slug or ""))
+
+
+async def list_workspaces(db: AsyncSession) -> list[Workspace]:
+    return list((await db.execute(select(Workspace).order_by(Workspace.id))).scalars().all())
+
+
+async def get_by_slug(db: AsyncSession, slug: str) -> Workspace | None:
+    return (await db.execute(select(Workspace).where(Workspace.slug == slug))).scalar_one_or_none()
+
+
+async def get_by_id(db: AsyncSession, ws_id: int) -> Workspace | None:
+    return (await db.execute(select(Workspace).where(Workspace.id == ws_id))).scalar_one_or_none()
+
+
+async def get_default(db: AsyncSession) -> Workspace | None:
+    row = (
+        await db.execute(select(Workspace).where(Workspace.is_default.is_(True)).limit(1))
+    ).scalar_one_or_none()
+    if row:
+        return row
+    # default 표식이 없으면 가장 오래된 workspace를 default로 간주
+    return (
+        await db.execute(select(Workspace).order_by(Workspace.id).limit(1))
+    ).scalar_one_or_none()
+
+
+async def create(db: AsyncSession, *, slug: str, name: str, description: str | None) -> Workspace:
+    ws = Workspace(slug=slug, name=name, description=description, is_default=False)
+    db.add(ws)
+    await db.commit()
+    await db.refresh(ws)
+    return ws
+
+
+async def update(
+    db: AsyncSession, *, ws_id: int, name: str | None, description: str | None
+) -> Workspace | None:
+    ws = await get_by_id(db, ws_id)
+    if ws is None:
+        return None
+    if name is not None:
+        ws.name = name
+    if description is not None:
+        ws.description = description
+    await db.commit()
+    await db.refresh(ws)
+    return ws
+
+
+async def delete(db: AsyncSession, *, ws_id: int) -> tuple[bool, str | None]:
+    """삭제. default workspace는 삭제 불가. 마지막 1건도 삭제 불가."""
+    ws = await get_by_id(db, ws_id)
+    if ws is None:
+        return False, "workspace_not_found"
+    if ws.is_default:
+        return False, "cannot_delete_default"
+    total = (await db.execute(select(func.count(Workspace.id)))).scalar_one()
+    if int(total or 0) <= 1:
+        return False, "cannot_delete_last"
+    await db.delete(ws)
+    await db.commit()
+    return True, None
+
+
+async def set_default(db: AsyncSession, *, ws_id: int) -> Workspace | None:
+    """대상을 default로, 나머지는 false로 일괄 토글."""
+    target = await get_by_id(db, ws_id)
+    if target is None:
+        return None
+    for ws in await list_workspaces(db):
+        ws.is_default = ws.id == ws_id
+    await db.commit()
+    await db.refresh(target)
+    return target

--- a/backend/main.py
+++ b/backend/main.py
@@ -41,6 +41,9 @@ async def lifespan(app: FastAPI):
             "ALTER TABLE access_requests ADD COLUMN IF NOT EXISTS revoke_result JSON DEFAULT '{}'::json NOT NULL",
             "ALTER TABLE policies ADD COLUMN IF NOT EXISTS engine VARCHAR(16) DEFAULT 'builtin' NOT NULL",
             "ALTER TABLE scans ADD COLUMN IF NOT EXISTS router_decision JSON",
+            # v0.3 #5 — Asset에 workspace_id 추가. NULL 허용으로 기존 자산은
+            # 모든 workspace에서 visible(백필 안전). v0.4에서 NOT NULL 전환 검토.
+            "ALTER TABLE assets ADD COLUMN IF NOT EXISTS workspace_id INTEGER",
         ):
             await conn.execute(text(ddl))
 

--- a/backend/tests/test_workspace_slug.py
+++ b/backend/tests/test_workspace_slug.py
@@ -1,0 +1,41 @@
+"""
+Workspace slug 검증 — 순수 함수 invariant.
+"""
+
+import pytest
+
+from app.services.workspace import is_valid_slug
+
+
+@pytest.mark.parametrize(
+    "slug",
+    [
+        "a",
+        "default",
+        "platform",
+        "mobile-team",
+        "team-2025",
+        "abc-def-ghi",
+        "x" * 64,
+    ],
+)
+def test_valid_slugs(slug):
+    assert is_valid_slug(slug) is True
+
+
+@pytest.mark.parametrize(
+    "slug",
+    [
+        "",                  # empty
+        "A",                 # uppercase
+        "Bad-Slug",          # uppercase letter
+        "-leading",          # leading hyphen
+        "trailing-",         # trailing hyphen
+        "two..dots",         # invalid char
+        "spaces here",       # spaces
+        "x" * 65,            # 65자 — 한계 초과
+        "한글",                # 비-ASCII
+    ],
+)
+def test_invalid_slugs(slug):
+    assert is_valid_slug(slug) is False

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -898,6 +898,28 @@ RATE_LIMIT_ENABLED=true     # 기본. false로 끄면 모든 버킷 통과 (test
 
 Redis 다운 시 fail open(가용성 우선) — `rate_limit_redis_down` 경고 로그를 남기고 요청은 통과. 보안 critical 환경이면 monitor에서 이 로그를 알림으로 연결할 것.
 
+### 8-3) 다중 워크스페이스 (한 인스턴스, 여러 팀)
+
+여러 팀/조직이 한 Mond 인스턴스를 공유할 때 자산을 분리한다. v0.3은 **Phase 1 — Asset만** 다루고, Policy/Finding/IAM 등 나머지 자원 분리는 v0.4 Phase 2에서 확장.
+
+설치 직후 `default` 워크스페이스가 자동 시드되므로 단일 조직 운영자에겐 영향 0. 다중 조직이면 Admin → **연동 관리 → 워크스페이스**에서 추가:
+
+```http
+POST /api/v1/admin/workspaces        body {"slug": "platform", "name": "Platform Team", "description": "..."}
+POST /api/v1/admin/workspaces/{id}/default        # 기본 워크스페이스 토글
+DELETE /api/v1/admin/workspaces/{id}              # default · 마지막 1건은 삭제 불가
+```
+
+`slug`는 소문자 + 숫자 + 하이픈(1~64자). URL/헤더 식별자로 사용.
+
+자산 조회 시 workspace로 좁히려면:
+
+```http
+GET /api/v1/assets?workspace_id=2
+```
+
+해당 워크스페이스의 자산 + 미배정(`workspace_id=NULL`) 자산이 함께 반환됩니다. Assets 페이지(ADMIN)에는 우상단에 워크스페이스 selector가 노출돼 한 번에 전환 가능. 자산 생성/수정 시 `workspace_id`를 명시하지 않으면 NULL로 들어가고, 이후 PATCH로 언제든 분류 가능합니다.
+
 ### 8-2) ISMS-P 인증 심사 증빙 패키지 (한국 조직)
 
 KISA ISMS-P 인증을 받았거나 받을 예정인 조직을 위한 v0.3 자동 증빙. 80여 개 통제 중 가장 자주 점검되는 **핵심 10개**를 Mond의 실 운영 데이터(자산·접근통제·로그·발견사항·권한요청 흐름)에 매핑해 markdown / JSON으로 추출한다.

--- a/frontend/src/pages/Assets.tsx
+++ b/frontend/src/pages/Assets.tsx
@@ -40,9 +40,18 @@ const ASSET_TYPES: AssetType[] = [
   "application",
 ];
 
-async function fetchAssets(): Promise<Page<Asset>> {
-  const { data } = await api.get<Page<Asset>>("/assets", { params: { limit: 100 } });
+async function fetchAssets(workspaceId?: number | null): Promise<Page<Asset>> {
+  const params: Record<string, number | string> = { limit: 100 };
+  if (workspaceId) params.workspace_id = workspaceId;
+  const { data } = await api.get<Page<Asset>>("/assets", { params });
   return data;
+}
+
+interface WorkspaceLite {
+  id: number;
+  slug: string;
+  name: string;
+  is_default: boolean;
 }
 
 export default function Assets() {
@@ -51,10 +60,21 @@ export default function Assets() {
   const qc = useQueryClient();
   const [open, setOpen] = useState(false);
   const [form] = Form.useForm();
+  const isAdmin = user?.role === "admin";
+
+  // workspace filter (ADMIN만). 0/null = 모두
+  const [workspaceFilter, setWorkspaceFilter] = useState<number | null>(null);
+
+  const { data: workspaces } = useQuery({
+    queryKey: ["workspaces-lite"],
+    queryFn: async () => (await api.get<WorkspaceLite[]>("/admin/workspaces")).data,
+    enabled: isAdmin,
+    retry: false,
+  });
 
   const { data, isLoading } = useQuery({
-    queryKey: ["assets"],
-    queryFn: fetchAssets,
+    queryKey: ["assets", workspaceFilter],
+    queryFn: () => fetchAssets(workspaceFilter),
   });
 
   // AI Insights citation에서 진입 시 ?focus=N → row highlight + scroll
@@ -107,9 +127,26 @@ export default function Assets() {
         <Title level={2} style={{ margin: 0 }}>
           {t.assets.title}
         </Title>
-        <Button type="primary" icon={<PlusOutlined />} onClick={() => setOpen(true)}>
-          {t.assets.add}
-        </Button>
+        <Space>
+          {isAdmin && workspaces && workspaces.length > 1 && (
+            <Select
+              size="middle"
+              style={{ minWidth: 180 }}
+              value={workspaceFilter ?? 0}
+              onChange={(v) => setWorkspaceFilter(v === 0 ? null : Number(v))}
+              options={[
+                { value: 0, label: locale === "ko" ? "모든 워크스페이스" : "All workspaces" },
+                ...workspaces.map((w) => ({
+                  value: w.id,
+                  label: `${w.name}${w.is_default ? " ★" : ""}`,
+                })),
+              ]}
+            />
+          )}
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setOpen(true)}>
+            {t.assets.add}
+          </Button>
+        </Space>
       </div>
 
       <Table

--- a/frontend/src/pages/admin/AdminConnections.tsx
+++ b/frontend/src/pages/admin/AdminConnections.tsx
@@ -20,6 +20,7 @@ import BitbucketWorkspaceSyncCard from "./connections/BitbucketWorkspaceSyncCard
 import DailyDigestCard from "./connections/DailyDigestCard";
 import GitHubOrgSyncCard from "./connections/GitHubOrgSyncCard";
 import GitLabGroupSyncCard from "./connections/GitLabGroupSyncCard";
+import WorkspacesCard from "./connections/WorkspacesCard";
 import IAMSourceCard from "./connections/IAMSourceCard";
 import IAMSourceModal from "./connections/IAMSourceModal";
 import SSOCard from "./connections/SSOCard";
@@ -38,6 +39,7 @@ export default function AdminConnections() {
       </Title>
       <Paragraph type="secondary">{t.adminArea.connectionsDesc}</Paragraph>
 
+      <WorkspacesCard />
       <IAMSourceCard onAdd={() => setModalOpen(true)} />
       <SSOCard />
       <AIProvidersCard />

--- a/frontend/src/pages/admin/connections/WorkspacesCard.tsx
+++ b/frontend/src/pages/admin/connections/WorkspacesCard.tsx
@@ -1,0 +1,224 @@
+/**
+ * Workspace CRUD — 다중 조직/팀이 한 Mond 인스턴스를 공유할 때 자산 scope.
+ *
+ * v0.3 MVP는 Asset만 workspace로 분리한다. Policy/Finding/IAM 등 나머지 자원은
+ * NULL이면 모든 workspace에서 visible — 단일 조직 운영에 영향 0.
+ */
+
+import { DeleteOutlined, PlusOutlined, StarFilled, StarOutlined, TeamOutlined } from "@ant-design/icons";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Alert,
+  Button,
+  Card,
+  Form,
+  Input,
+  Modal,
+  Popconfirm,
+  Space,
+  Table,
+  Tag,
+  Tooltip,
+  Typography,
+  message,
+} from "antd";
+import { useState } from "react";
+
+import { useI18n } from "@/i18n";
+import { api } from "@/lib/api";
+
+const { Paragraph, Text } = Typography;
+
+interface Workspace {
+  id: number;
+  slug: string;
+  name: string;
+  description: string | null;
+  is_default: boolean;
+}
+
+export default function WorkspacesCard() {
+  const { locale } = useI18n();
+  const qc = useQueryClient();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [form] = Form.useForm();
+
+  const { data: rows, isLoading } = useQuery({
+    queryKey: ["admin-workspaces"],
+    queryFn: async () => (await api.get<Workspace[]>("/admin/workspaces")).data,
+  });
+
+  const invalidate = () => qc.invalidateQueries({ queryKey: ["admin-workspaces"] });
+
+  const create = useMutation({
+    mutationFn: async (values: { slug: string; name: string; description?: string }) =>
+      (await api.post<Workspace>("/admin/workspaces", values)).data,
+    onSuccess: () => {
+      message.success(locale === "ko" ? "워크스페이스 추가 완료" : "Workspace created");
+      setModalOpen(false);
+      form.resetFields();
+      invalidate();
+    },
+    onError: (e: Error & { response?: { data?: { detail?: string } } }) =>
+      message.error(e.response?.data?.detail ?? e.message),
+  });
+
+  const setDefault = useMutation({
+    mutationFn: async (id: number) => (await api.post(`/admin/workspaces/${id}/default`)).data,
+    onSuccess: () => {
+      message.success(locale === "ko" ? "기본 워크스페이스 변경됨" : "Default updated");
+      invalidate();
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: async (id: number) => api.delete(`/admin/workspaces/${id}`),
+    onSuccess: () => {
+      message.success(locale === "ko" ? "워크스페이스 삭제됨" : "Workspace deleted");
+      invalidate();
+    },
+    onError: (e: Error & { response?: { data?: { detail?: string } } }) =>
+      message.error(e.response?.data?.detail ?? e.message),
+  });
+
+  return (
+    <Card
+      title={
+        <Space>
+          <TeamOutlined />
+          <span>{locale === "ko" ? "워크스페이스" : "Workspaces"}</span>
+          <Tag>v0.3 MVP — Asset only</Tag>
+        </Space>
+      }
+      extra={
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalOpen(true)}>
+          {locale === "ko" ? "추가" : "Add"}
+        </Button>
+      }
+      style={{ marginBottom: 16 }}
+    >
+      <Paragraph type="secondary" style={{ marginBottom: 12 }}>
+        {locale === "ko"
+          ? "여러 팀/조직이 한 Mond 인스턴스를 공유할 때 자산을 분리합니다. v0.3에서는 Asset만 workspace로 분리되고, workspace_id가 비어 있으면(NULL) 모든 workspace에서 보입니다. Policy/Finding/IAM 등 나머지 자원은 v0.4에서 확장됩니다."
+          : "Scope assets when multiple teams share one Mond instance. v0.3 covers Asset only; null workspace_id means visible across all workspaces. Policies/findings/IAM coverage in v0.4."}
+      </Paragraph>
+
+      <Table
+        size="small"
+        rowKey="id"
+        loading={isLoading}
+        dataSource={rows ?? []}
+        pagination={false}
+        columns={[
+          {
+            title: locale === "ko" ? "기본" : "Default",
+            dataIndex: "is_default",
+            width: 70,
+            render: (v: boolean, r: Workspace) =>
+              v ? (
+                <Tooltip title={locale === "ko" ? "기본 워크스페이스" : "Default"}>
+                  <StarFilled style={{ color: "#faad14" }} />
+                </Tooltip>
+              ) : (
+                <Tooltip title={locale === "ko" ? "기본으로 설정" : "Set as default"}>
+                  <Button
+                    type="text"
+                    size="small"
+                    icon={<StarOutlined />}
+                    onClick={() => setDefault.mutate(r.id)}
+                  />
+                </Tooltip>
+              ),
+          },
+          { title: "Slug", dataIndex: "slug", width: 160, render: (s: string) => <code>{s}</code> },
+          { title: locale === "ko" ? "이름" : "Name", dataIndex: "name" },
+          {
+            title: locale === "ko" ? "설명" : "Description",
+            dataIndex: "description",
+            render: (v: string | null) => v ?? <Text type="secondary">—</Text>,
+          },
+          {
+            title: "",
+            width: 70,
+            render: (_: unknown, r: Workspace) => (
+              <Popconfirm
+                title={
+                  locale === "ko"
+                    ? "이 워크스페이스를 삭제할까요? 자산의 workspace_id는 NULL로 풀립니다."
+                    : "Delete this workspace? Asset.workspace_id will be set to NULL."
+                }
+                onConfirm={() => remove.mutate(r.id)}
+                disabled={r.is_default}
+              >
+                <Tooltip
+                  title={
+                    r.is_default
+                      ? locale === "ko"
+                        ? "기본 워크스페이스는 삭제 불가"
+                        : "Cannot delete default"
+                      : ""
+                  }
+                >
+                  <Button danger type="text" icon={<DeleteOutlined />} disabled={r.is_default} />
+                </Tooltip>
+              </Popconfirm>
+            ),
+          },
+        ]}
+      />
+
+      <Alert
+        type="info"
+        showIcon
+        style={{ marginTop: 12 }}
+        message={
+          locale === "ko"
+            ? "API: GET/POST/PATCH/DELETE /api/v1/admin/workspaces, POST .../{id}/default. Asset 목록 조회 시 ?workspace_id=N을 붙이면 해당 ws + 미배정(NULL) 자산만 반환."
+            : "API: GET/POST/PATCH/DELETE /api/v1/admin/workspaces, POST .../{id}/default. Asset list with ?workspace_id=N returns that ws + unscoped (NULL) assets."
+        }
+      />
+
+      <Modal
+        title={locale === "ko" ? "워크스페이스 추가" : "Add workspace"}
+        open={modalOpen}
+        onCancel={() => setModalOpen(false)}
+        onOk={() => form.submit()}
+        confirmLoading={create.isPending}
+      >
+        <Form form={form} layout="vertical" onFinish={(values) => create.mutate(values)}>
+          <Form.Item
+            name="slug"
+            label="Slug"
+            rules={[
+              { required: true },
+              {
+                pattern: /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/,
+                message:
+                  locale === "ko"
+                    ? "소문자/숫자/하이픈, 시작·끝은 영숫자, 1~64자"
+                    : "lowercase + digits + hyphen, alphanumeric at ends, 1-64",
+              },
+            ]}
+            extra={locale === "ko" ? "URL/헤더 식별자. 예: platform, mobile-team" : "URL/header identifier"}
+          >
+            <Input placeholder="e.g. platform" />
+          </Form.Item>
+          <Form.Item
+            name="name"
+            label={locale === "ko" ? "이름" : "Name"}
+            rules={[{ required: true, max: 128 }]}
+          >
+            <Input placeholder={locale === "ko" ? "예: Platform 팀" : "e.g. Platform Team"} />
+          </Form.Item>
+          <Form.Item
+            name="description"
+            label={locale === "ko" ? "설명 (선택)" : "Description (optional)"}
+            rules={[{ max: 512 }]}
+          >
+            <Input.TextArea rows={2} />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
여러 팀/조직이 한 Mond 인스턴스를 공유할 때 자산을 분리할 수 있도록 Workspace 모델 + Admin CRUD + Asset에 workspace_id 추가. Phase 1은 Asset 한 자원만 다루고(NULL 허용 → 단일 조직 운영 영향 0), Policy/Finding/IAM 등 나머지 자원 분리는 v0.4 Phase 2에서.

## 변경

### Backend
- `models/workspace.py` — Workspace(slug unique + is_default)
- `models/asset.py` — workspace_id Integer FK ON DELETE SET NULL (nullable)
- `db_seed.py` + lifespan — default workspace seed + ALTER TABLE IF NOT EXISTS
- `services/workspace.py` — slug 검증 + CRUD + set_default + delete 보호 (default/마지막 거부)
- `services/asset.py` — list_assets에 workspace_id + include_unscoped (해당 ws OR NULL)
- `endpoints/admin_workspaces.py` — ADMIN 전용 6 endpoint
- `endpoints/assets.py` — `GET /assets?workspace_id=N` 쿼리
- `schemas/asset.py` — Create/Update에 workspace_id

### 16 단위 테스트
slug 검증 유효 7 + 무효 9 (대문자/leading hyphen/65자/한글 등)

### Frontend
- `WorkspacesCard` — 표 + Add modal(slug regex) + Set default 별 토글 + 삭제(default disable + Popconfirm)
- AdminConnections 카드 최상단 마운트
- Assets 페이지(ADMIN, ws ≥ 2건일 때만) 우상단 selector

### 문서
- `docs/SETUP.md` Part 5 · 8-3) sub-section
- README 로드맵 #5 Phase 1 체크박스 (Phase 2 v0.4 명시)

## 검증
- pytest 120/120
- ruff clean · frontend build OK
- 통합: workspace CRUD + slug 400 + Asset filter + default 삭제 400 + 일반 ws 204

## Test plan
- [x] pytest 120/120
- [x] ruff clean · frontend build
- [x] 통합 curl 검증 (CRUD, slug 거부, Asset filter, default 보호)
- [ ] CI 통과