### PR TITLE
chore(readme): GitHub release 배지 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     Inventory, scan, triage, approve, audit in one flow.
   </p>
 
+  [![Release](https://img.shields.io/github/v/release/jland-93/mond?display_name=tag&color=7c8cff)](https://github.com/jland-93/mond/releases/latest)
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
   [![Python](https://img.shields.io/badge/Python-3.12+-blue.svg)](https://www.python.org/)
   [![React](https://img.shields.io/badge/React-18-61DAFB.svg)](https://reactjs.org/)


### PR DESCRIPTION
## Summary
README 상단 배지 줄 맨 앞에 GitHub release 배지(latest tag)를 추가. 첫 방문자가 현재 안정 버전(v0.3.0)을 즉시 확인할 수 있게. shields.io 동적 배지라 새 release가 나오면 자동 갱신.

기존 5개 배지(License/Python/React/Claude/Helm)는 그대로 유지.

## Test plan
- [ ] CI 통과 (코드 변경 없음 — README만)