### PR TITLE
chore(frontend): tsc noEmit 설정 + tsbuildinfo gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ coverage/
 # ESLint cache
 .eslintcache
 
+# TypeScript 증분 빌드 캐시 (tsc -b 산출물 — 커밋 금지)
+*.tsbuildinfo
+
 # Optional npm cache directory
 .npm
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
+    "noEmit": true,
     "strict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,


### PR DESCRIPTION
## 🌙 Description

`frontend/tsconfig.json`에 `noEmit`이 없어 `npm run build`(`tsc -b`) 실행 시 `.tsx` 소스 옆에 트랜스파일된 `.js` 74개와 `tsconfig.tsbuildinfo`가 워킹트리에 쌓였다. 번들링은 Vite가 담당하므로 `tsc`는 타입체크만 하면 된다.

- `frontend/tsconfig.json`: `"noEmit": true` 추가 → `tsc -b`가 산출물을 뱉지 않음 (TS 5.9.3, `tsc -b` exit 0 검증)
- `.gitignore`: `*.tsbuildinfo` 추가 (증분 빌드 캐시 안전망)

로컬에 이미 쌓여 있던 산출물 74개 + tsbuildinfo는 별도로 삭제 완료.

## 📋 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- [x] Manual testing completed — `npx tsc -b` 실행 시 산출물 미생성 + 타입에러 없음 확인

## 📝 Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Changes generate no new warnings