### PR TITLE
docs: helm 예시 버전 핀 0.3.1로 통일

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ OCI 레지스트리에 자동 배포되는 차트로 한 줄 설치:
 
 ```bash
 helm install mond oci://ghcr.io/jland-93/charts/mond \
-  --version 0.1.0 \
+  --version 0.3.1 \
   -n mond --create-namespace \
   -f charts/mond/values-prod.yaml \
   --set ingress.hosts[0].host=mond.your-corp.com \
@@ -313,7 +313,7 @@ kubectl -n mond create secret generic mond-secrets \
 
 # 2) Helm 설치 (OCI 레지스트리)
 helm install mond oci://ghcr.io/jland-93/charts/mond \
-  --version 0.1.0 \
+  --version 0.3.1 \
   -n mond \
   -f charts/mond/values-prod.yaml \
   --set ingress.hosts[0].host=mond.your-corp.com

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -128,7 +128,7 @@ kubectl -n mond create secret generic mond-secrets \
 
 ```bash
 helm install mond oci://ghcr.io/jland-93/charts/mond \
-  --version 0.1.0 \
+  --version 0.3.1 \
   -n mond \
   -f charts/mond/values-prod.yaml \
   --set ingress.hosts[0].host=mond.your-corp.com \
@@ -1055,13 +1055,13 @@ docker compose exec backend alembic upgrade head   # 스키마 마이그레이�
 
 ```bash
 helm upgrade mond oci://ghcr.io/jland-93/charts/mond \
-  --version 0.2.0 \
+  --version 0.3.1 \
   -n mond \
   --reuse-values
 
 # 또는 새 values로 덮어쓰기
 helm upgrade mond oci://ghcr.io/jland-93/charts/mond \
-  --version 0.2.0 \
+  --version 0.3.1 \
   -n mond \
   -f charts/mond/values-prod.yaml
 ```


### PR DESCRIPTION
## 🌙 Description

README·SETUP의 helm install/upgrade 예시가 낡은 차트 버전(0.1.0 / 0.2.0)을 가리키고 있어 현재 릴리스(0.3.1)와 안 맞던 것을 통일.

- README.md: `--version 0.1.0` ×2 → 0.3.1
- docs/SETUP.md: `--version 0.1.0` ×1 + `--version 0.2.0` ×2 → 0.3.1

## 📋 Type of Change
- [x] 📚 Documentation update