### PR TITLE
chore(lint): CI에 lint 연결 + react-hooks 신규 규칙 적용

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,5 +69,8 @@ jobs:
       - name: Install dependencies
         run: npm install --no-audit --no-fund
 
+      - name: Lint (ESLint)
+        run: npm run lint
+
       - name: Type check + build
         run: npm run build

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,9 +19,12 @@ export default tseslint.config(
       "react-refresh": reactRefresh,
     },
     rules: {
-      // 클래식 훅 규칙만 (신버전 plugin의 set-state-in-effect·immutability 등
-      // 공격적 규칙은 기존 동작 코드를 대량으로 잡으므로 켜지 않는다)
-      "react-hooks/rules-of-hooks": "error",
+      ...reactHooks.configs.recommended.rules,
+      // rules-of-hooks 등 핵심은 error 유지. 아래 신규 aggressive 규칙은
+      // URL 동기화·디바운스·비동기 기본값 등 정당한 effect 패턴을 넓게 잡으므로
+      // 강제 차단 대신 advisory(warn) — 신규 코드에 가시화하되 기존 동작은 안 건드림.
+      "react-hooks/set-state-in-effect": "warn",
+      "react-hooks/immutability": "warn",
       "react-hooks/exhaustive-deps": "warn",
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
     },

--- a/frontend/src/components/Moon3D.tsx
+++ b/frontend/src/components/Moon3D.tsx
@@ -20,15 +20,16 @@ function MoonSphere() {
   });
 
   const texture = useLoader(THREE.TextureLoader, "/moon/moon_color.jpg");
-  texture.colorSpace = THREE.SRGBColorSpace;
-  texture.anisotropy = 4;
 
   return (
     // 살짝 기울여 극(pole)이 정면을 향하지 않게 — 자연스러운 시점
     <mesh ref={meshRef} rotation={[0.12, 0, 0.08]}>
       <sphereGeometry args={[1, 128, 128]} />
+      {/* colorSpace/anisotropy는 텍스처 직접 mutation 대신 선언적으로 설정 */}
       <meshStandardMaterial
         map={texture}
+        map-colorSpace={THREE.SRGBColorSpace}
+        map-anisotropy={4}
         bumpMap={texture}
         bumpScale={0.02}
         roughness={1}

--- a/frontend/src/lib/iam-display.test.ts
+++ b/frontend/src/lib/iam-display.test.ts
@@ -11,7 +11,6 @@ import { identityDisplay, permissionDisplay } from "./iam-display";
 import type { IAMIdentity, PermissionRow } from "./iam-api";
 
 const _expect = (label: string, got: unknown, want: unknown) => {
-  // eslint-disable-next-line no-console
   if (JSON.stringify(got) !== JSON.stringify(want)) console.error(`FAIL ${label}: got=${JSON.stringify(got)} want=${JSON.stringify(want)}`);
 };
 

--- a/frontend/src/pages/dashboard/NextSteps.tsx
+++ b/frontend/src/pages/dashboard/NextSteps.tsx
@@ -12,7 +12,7 @@
 import { CheckCircleFilled, CloseOutlined, RightOutlined } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
 import { Button, Card, Progress, Space, Typography } from "antd";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 
 import { useAuth } from "@/auth/AuthContext";
@@ -35,11 +35,9 @@ interface Step {
 export default function NextSteps({ overview }: { overview: DashboardOverview | undefined }) {
   const { locale } = useI18n();
   const { user } = useAuth();
-  const [dismissed, setDismissed] = useState<boolean>(false);
-
-  useEffect(() => {
-    setDismissed(typeof window !== "undefined" && window.localStorage.getItem(DISMISS_KEY) === "1");
-  }, []);
+  const [dismissed, setDismissed] = useState<boolean>(
+    () => typeof window !== "undefined" && window.localStorage.getItem(DISMISS_KEY) === "1",
+  );
 
   const { data: sources } = useQuery({
     queryKey: ["iam-sources"],


### PR DESCRIPTION
## 🌙 Description

lint 게이트를 실제로 작동시키고, react-hooks 신버전 규칙을 적용.

- **CI 연결** — `ci.yml` 프론트 잡에 `npm run lint` 스텝 추가. (그동안 build만 돌아 lint가 CI에서 안 돌던 것)
- **react-hooks recommended 전체 반영** — 단, 신규 aggressive 규칙(`set-state-in-effect`·`immutability`)은 **warn**. URL 파라미터 동기화·디바운스·비동기 데이터 기본값·마운트 fetch 등 정당한 effect 패턴을 넓게 잡아, 강제 차단(+대량 eslint-disable)보다 가시화가 적절하다고 판단. `rules-of-hooks`는 error 유지.
- **실제 개선 리팩터 2건**:
  - `NextSteps` — localStorage 초기화를 lazy initial state로 (effect 제거)
  - `Moon3D` — 텍스처 colorSpace/anisotropy를 mutation 대신 선언적 `map-colorSpace`/`map-anisotropy`로 → immutability 2건 해소, 렌더 동일(캡처 확인)
- 테스트의 stale `eslint-disable` 정리

결과: `npm run lint` **0 errors** (advisory warnings만). 남은 set-state-in-effect 10건은 의도된 effect 패턴이라 warn으로 노출만.

## 📋 Type of Change
- [x] 🧪 Test improvements

## 🧪 Testing
- [x] `npm run lint` exit 0, `tsc -b` 통과, 로그인 3D 달 렌더 캡처로 동일 확인